### PR TITLE
fix: resolve YAML syntax error in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,20 @@ repos:
       # Branch naming enforcement
       - id: check-branch-name
         name: Check branch naming convention
-        entry: bash -c 'BRANCH=$(git branch --show-current); if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" && ! "$BRANCH" =~ ^(issue|feat|fix|hotfix)/[0-9]+-[a-z0-9\-]+$ && ! "$BRANCH" =~ ^release/.+ ]]; then echo "❌ Branch name must follow convention:"; echo "   - issue/<num>-<description>"; echo "   - feat/<num>-<description>"; echo "   - fix/<num>-<description>"; echo "   - hotfix/<description>"; echo "   - release/<version>"; echo ""; echo "Current branch: $BRANCH"; exit 1; fi'
+        entry: |
+          bash -c '
+          BRANCH=$(git branch --show-current);
+          if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" && ! "$BRANCH" =~ ^(issue|feat|fix|hotfix)/[0-9]+-[a-z0-9\-]+$ && ! "$BRANCH" =~ ^release/.+ ]]; then
+            echo "❌ Branch name must follow convention:";
+            echo "   - issue/<num>-<description>";
+            echo "   - feat/<num>-<description>";
+            echo "   - fix/<num>-<description>";
+            echo "   - hotfix/<description>";
+            echo "   - release/<version>";
+            echo "";
+            echo "Current branch: $BRANCH";
+            exit 1;
+          fi'
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Summary
- Fixed YAML syntax error in `.pre-commit-config.yaml`
- Converted `check-branch-name` entry field from compact single-line format to multi-line literal block scalar format
- Resolves VS Code diagnostic error: "Nested mappings are not allowed in compact mappings"

## Changes
- Changed the `entry` field from a single-line bash command to a multi-line literal block using `|` scalar

## Test plan
- [x] YAML file validates correctly in VS Code
- [x] Pre-commit hook still functions as expected

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)