### PR TITLE
fix: improve breaking changes detection to ignore type annotations

### DIFF
--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -27,42 +27,73 @@ jobs:
               pull_number: pr.number
             });
 
+            // Helper function to normalize function signature (remove type annotations)
+            function normalizeSignature(line) {
+              // Remove leading +/- from diff
+              let sig = line.replace(/^[+-]\s*/, '');
+              // Remove return type annotations (-> Type:)
+              sig = sig.replace(/\s*->\s*[^:]+:/, ':');
+              // Remove parameter type annotations (param: Type -> param)
+              sig = sig.replace(/(\w+)\s*:\s*[^,)=]+/g, '$1');
+              return sig.trim();
+            }
+
+            // Helper function to extract function name from signature
+            function extractFunctionName(line) {
+              const match = line.match(/def\s+(\w+)\s*\(/);
+              return match ? match[1] : null;
+            }
+
+            // Helper function to check if signature change is only type annotations
+            function isOnlyTypeAnnotationChange(removedLine, addedLine) {
+              const normalizedRemoved = normalizeSignature(removedLine);
+              const normalizedAdded = normalizeSignature(addedLine);
+              return normalizedRemoved === normalizedAdded;
+            }
+
             // Patterns that may indicate breaking changes
             const breakingPatterns = [
               {
                 pattern: /^-\s*def\s+\w+\(/m,
                 description: 'Function signature removed or modified',
-                severity: 'high'
+                severity: 'high',
+                checkTypeAnnotations: true
               },
               {
                 pattern: /^-\s*class\s+\w+/m,
                 description: 'Class definition removed or modified',
-                severity: 'high'
+                severity: 'high',
+                checkTypeAnnotations: false
               },
               {
                 pattern: /^-\s*async\s+def\s+\w+\(/m,
                 description: 'Async function removed or modified',
-                severity: 'high'
+                severity: 'high',
+                checkTypeAnnotations: true
               },
               {
                 pattern: /^-.*__init__\s*\(/m,
                 description: 'Constructor signature changed',
-                severity: 'high'
+                severity: 'high',
+                checkTypeAnnotations: true
               },
               {
                 pattern: /^-.*raise\s+\w+Error/m,
                 description: 'Exception type changed',
-                severity: 'medium'
+                severity: 'medium',
+                checkTypeAnnotations: false
               },
               {
                 pattern: /__all__.*=/,
                 description: 'Public API exports modified',
-                severity: 'high'
+                severity: 'high',
+                checkTypeAnnotations: false
               },
               {
                 pattern: /^-.*@property/m,
                 description: 'Property removed or modified',
-                severity: 'medium'
+                severity: 'medium',
+                checkTypeAnnotations: false
               }
             ];
 
@@ -77,8 +108,54 @@ jobs:
               if (!file.patch) continue;
 
               const matches = [];
-              for (const {pattern, description, severity} of breakingPatterns) {
-                if (pattern.test(file.patch)) {
+              const patchLines = file.patch.split('\n');
+
+              for (const {pattern, description, severity, checkTypeAnnotations} of breakingPatterns) {
+                if (!pattern.test(file.patch)) continue;
+
+                // For function signature patterns, check if it's only type annotations
+                if (checkTypeAnnotations) {
+                  let isBreaking = false;
+
+                  // Find all removed function signatures
+                  for (let i = 0; i < patchLines.length; i++) {
+                    const line = patchLines[i];
+                    if (!pattern.test(line)) continue;
+
+                    const funcName = extractFunctionName(line);
+                    if (!funcName) {
+                      isBreaking = true;
+                      break;
+                    }
+
+                    // Look for corresponding added line with same function name
+                    let foundMatch = false;
+                    for (let j = 0; j < patchLines.length; j++) {
+                      const addedLine = patchLines[j];
+                      if (!addedLine.startsWith('+')) continue;
+
+                      const addedFuncName = extractFunctionName(addedLine);
+                      if (addedFuncName === funcName) {
+                        // Check if only type annotations changed
+                        if (isOnlyTypeAnnotationChange(line, addedLine)) {
+                          foundMatch = true;
+                          break;
+                        }
+                      }
+                    }
+
+                    // If no matching added line, or signatures differ beyond type hints, it's breaking
+                    if (!foundMatch) {
+                      isBreaking = true;
+                      break;
+                    }
+                  }
+
+                  if (isBreaking) {
+                    matches.push({description, severity});
+                  }
+                } else {
+                  // For non-function patterns, use simple pattern matching
                   matches.push({description, severity});
                 }
               }


### PR DESCRIPTION
## Summary

Fixes the breaking-change-detection workflow to properly distinguish between actual breaking changes and type annotation additions.

## Problem

The workflow was incorrectly flagging PRs that added type annotations as having "breaking changes". For example, when PR #20 changed:

```python
# Before
def task_install():

# After  
def task_install() -> dict[str, Any]:
```

The workflow detected this as "Function signature removed or modified" because it only looked for removed function definitions, without checking if they were immediately replaced with the same function plus type annotations.

## Solution

Enhanced the breaking changes detection logic with three helper functions:

1. **`normalizeSignature(line)`** - Strips type annotations from function signatures for comparison
   - Removes return type hints (`-> Type`)
   - Removes parameter type hints (`param: Type`)
   - Normalizes the signature for comparison

2. **`extractFunctionName(line)`** - Extracts the function name from a diff line

3. **`isOnlyTypeAnnotationChange(removedLine, addedLine)`** - Compares normalized signatures to detect type-only changes

The workflow now:
- Finds all removed function definitions
- For each removed function, looks for a corresponding added function with the same name
- Compares the normalized signatures (without type annotations)
- Only flags as breaking if the base signatures actually differ

## Test Plan

- [x] Commit passes pre-commit hooks
- [ ] Verify workflow correctly ignores type annotation additions
- [ ] Verify workflow still detects actual breaking changes (parameter changes, function removals)

## Related

- Closes #21
- Will allow PR #20 to pass the breaking changes check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>