### PR TITLE
debug: add logging to breaking changes workflow

### DIFF
--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -116,14 +116,19 @@ jobs:
                 // For function signature patterns, check if it's only type annotations
                 if (checkTypeAnnotations) {
                   let isBreaking = false;
+                  console.log(`\n=== Checking ${description} in ${file.filename} ===`);
 
                   // Find all removed function signatures
                   for (let i = 0; i < patchLines.length; i++) {
                     const line = patchLines[i];
                     if (!pattern.test(line)) continue;
 
+                    console.log(`Found removed line: ${line}`);
                     const funcName = extractFunctionName(line);
+                    console.log(`Extracted function name: ${funcName}`);
+
                     if (!funcName) {
+                      console.log('Failed to extract function name, marking as breaking');
                       isBreaking = true;
                       break;
                     }
@@ -136,21 +141,36 @@ jobs:
 
                       const addedFuncName = extractFunctionName(addedLine);
                       if (addedFuncName === funcName) {
+                        console.log(`Found potential match: ${addedLine}`);
+
+                        const normRemoved = normalizeSignature(line);
+                        const normAdded = normalizeSignature(addedLine);
+                        console.log(`Normalized removed: ${normRemoved}`);
+                        console.log(`Normalized added: ${normAdded}`);
+                        console.log(`Are they equal? ${normRemoved === normAdded}`);
+
                         // Check if only type annotations changed
                         if (isOnlyTypeAnnotationChange(line, addedLine)) {
+                          console.log(`Type annotation only change - NOT breaking`);
                           foundMatch = true;
                           break;
+                        } else {
+                          console.log(`Signatures differ beyond type annotations`);
                         }
                       }
                     }
 
                     // If no matching added line, or signatures differ beyond type hints, it's breaking
                     if (!foundMatch) {
+                      console.log(`No match found for ${funcName}, marking as breaking`);
                       isBreaking = true;
                       break;
+                    } else {
+                      console.log(`Match found for ${funcName}, continuing`);
                     }
                   }
 
+                  console.log(`Final decision: isBreaking = ${isBreaking}`);
                   if (isBreaking) {
                     matches.push({description, severity});
                   }


### PR DESCRIPTION
## Purpose

Adds comprehensive debug logging to the breaking changes detection workflow to diagnose why type annotation changes are still being flagged as breaking despite the fix in PR #23.

## Changes

- Add console.log statements to trace execution
- Log which lines are being processed
- Log function name extraction results
- Log normalized signatures and comparison results
- Log final decisions

## Why Merge This

We need this in main temporarily so that PR #20 will use the debug workflow and we can see what's actually happening. Once we identify and fix the issue, we'll remove the debug logging.

## Related

- Issue #24 - The ongoing problem with breaking changes detection
- PR #20 - Blocked by false positive breaking changes detection

This is a temporary debugging PR that will be followed by the actual fix.