### PR TITLE
fix: restore template _version.py with fallback value

### DIFF
--- a/src/package_name/_version.py
+++ b/src/package_name/_version.py
@@ -1,0 +1,7 @@
+"""Version information for package_name.
+
+Managed by hatch-vcs during builds; the fallback value is used only when the
+version cannot be derived (e.g., source tree without git metadata).
+"""
+
+__version__ = "0.0.0"


### PR DESCRIPTION
## Problem

PR #20 incorrectly removed the `src/package_name/_version.py` file from the template.

## Why This File Is Needed

The `_version.py` file should be committed in the template with a simple fallback value:
- Provides a fallback version when hatch-vcs cannot derive one (e.g., fresh clone without git metadata)  
- Hatch-vcs overwrites it during builds with the actual version
- The `.gitignore` entry prevents generated versions from being committed

## Changes

- Restored `src/package_name/_version.py` with fallback value "0.0.0"
- Added clear documentation about its purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)