### PR TITLE
feat: add pre-commit hook to block commits to main branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,28 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      # Prevent direct commits to main branch
+      - id: no-commit-to-main
+        name: Prevent commits to main branch
+        entry: |
+          bash -c '
+          BRANCH=$(git branch --show-current);
+          if [[ "$BRANCH" == "main" ]]; then
+            echo "❌ ERROR: Direct commits to main branch are not allowed!";
+            echo "";
+            echo "The mandatory workflow is: Issue → Branch → Commit → PR → Merge";
+            echo "";
+            echo "Please follow these steps:";
+            echo "  1. Ensure a GitHub issue exists for your change";
+            echo "  2. Create a feature branch: git checkout -b <type>/<issue#>-<description>";
+            echo "  3. Make your changes and commit on the feature branch";
+            echo "  4. Push and create a Pull Request";
+            echo "  5. Merge the PR after review and CI checks pass";
+            echo "";
+            echo "See AGENTS.md and .github/CONTRIBUTING.md for details.";
+            exit 1;
+          fi'
+        language: system
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary
Adds a pre-commit hook that prevents direct commits to the main branch, enforcing the mandatory workflow: Issue → Branch → Commit → PR → Merge.

## Changes
- Added `no-commit-to-main` hook to `.pre-commit-config.yaml`
- Hook detects when current branch is `main` and blocks the commit
- Provides clear, educational error message with workflow steps
- References AGENTS.md and CONTRIBUTING.md for detailed documentation

## Hook Behavior
When a commit is attempted on the `main` branch, the hook will:
1. Detect the branch name
2. Block the commit with error code 1
3. Display clear instructions:
   - Explain the mandatory workflow
   - List the 5 steps to follow
   - Reference documentation for details

## Error Message Example
```
❌ ERROR: Direct commits to main branch are not allowed!

The mandatory workflow is: Issue → Branch → Commit → PR → Merge

Please follow these steps:
  1. Ensure a GitHub issue exists for your change
  2. Create a feature branch: git checkout -b <type>/<issue#>-<description>
  3. Make your changes and commit on the feature branch
  4. Push and create a Pull Request
  5. Merge the PR after review and CI checks pass

See AGENTS.md and .github/CONTRIBUTING.md for details.
```

## Testing
The hook runs on every commit and is validated by the pre-commit framework. To test after merge:
1. Checkout main branch
2. Attempt to make a commit
3. Verify the hook blocks the commit with the error message above

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)