### PR TITLE
fix: enable strict mypy mode in doit check to match pre-commit hooks

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -194,9 +194,11 @@ def task_format_check() -> dict[str, Any]:
 
 
 def task_type_check() -> dict[str, Any]:
-    """Run mypy type checking."""
+    """Run mypy type checking with strict mode (matches pre-commit hooks)."""
     return {
-        "actions": [f"UV_CACHE_DIR={UV_CACHE_DIR} uv run mypy src/"],
+        "actions": [
+            f"UV_CACHE_DIR={UV_CACHE_DIR} uv run mypy --strict --ignore-missing-imports src/"
+        ],
         "title": title_with_actions,
     }
 


### PR DESCRIPTION
## Problem
Currently there's a discrepancy between `doit check` and pre-commit hooks:
- `doit check` runs mypy with pyproject.toml settings only
- Pre-commit hooks run mypy with `--strict` flag

This creates confusion where code passes `doit check` but fails on commit.

## Solution
Add `--strict --ignore-missing-imports` flags to the `doit type_check` task to match pre-commit configuration.

## Changes
- ✅ Updated `task_type_check()` in dodo.py to use strict mode
- ✅ Added `--ignore-missing-imports` to match pre-commit exactly
- ✅ All existing code still passes with strict mode enabled

## Test Plan
- [x] `doit type_check` passes with strict mode
- [x] `doit check` passes completely
- [x] All 31 tests pass
- [x] Pre-commit hooks pass

## Benefits
- Consistent type checking across all workflows
- Catch strict mode issues earlier (during `doit check`)
- Eliminate surprise failures at commit time
- More confidence that "doit check passing" == "commit will succeed"

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)