### PR TITLE
docs: add prohibition on bypass flags without user consent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,7 @@ Use `doit release` or `doit release_dev` (recommended).
 **🚫 NEVER (Absolute Prohibitions)**
 - Commit directly to `main` branch
 - Skip pre-commit hooks (--no-verify, --no-gpg-sign)
+- Use bypass flags without explicit user request (--admin, --force, --no-verify, etc.)
 - Run `doit release` or `doit release_dev` without explicit user request
 - Merge PRs without user consent
 - Commit secrets, credentials, or sensitive data


### PR DESCRIPTION
## Summary
Documents that AI agents must not use security bypass flags without explicit user permission.

## Changes
Added to the "🚫 NEVER (Absolute Prohibitions)" section in AGENTS.md:
- Use bypass flags without explicit user request (--admin, --force, --no-verify, etc.)

## Context
This clarifies that AI agents should always ask before using flags like:
- `gh pr merge --admin` (bypass branch protection)
- `git push --force` (force push)  
- `git commit --no-verify` (skip pre-commit hooks)
- Any similar bypass/force flags

## Benefit
Clear, documented guidance for AI agents to respect repository security measures.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)