### PR TITLE
docs: update placeholder GitHub URLs in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Package Name is a modern Python project template with comprehensive tooling for 
 - [Installation Guide](getting-started/installation.md)
 - [User Guide](usage/basics.md)
 - [API Reference](reference/api.md)
-- [Contributing](https://github.com/username/package_name/blob/main/.github/CONTRIBUTING.md)
+- [Contributing](https://github.com/endavis/pyproject-template/blob/main/.github/CONTRIBUTING.md)
 
 ## Features
 
@@ -46,16 +46,16 @@ print(message)  # Output: Hello, Python!
 
 ### For Contributors
 
-- **[Contributing Guide](https://github.com/username/package_name/blob/main/.github/CONTRIBUTING.md)** - Development workflow, coding standards, and best practices (**source of truth**)
-- **[Code of Conduct](https://github.com/username/package_name/blob/main/.github/CODE_OF_CONDUCT.md)** - Community guidelines
-- **[AI Agent Guide](https://github.com/username/package_name/blob/main/AGENTS.md)** - Quick reference for AI coding assistants
+- **[Contributing Guide](https://github.com/endavis/pyproject-template/blob/main/.github/CONTRIBUTING.md)** - Development workflow, coding standards, and best practices (**source of truth**)
+- **[Code of Conduct](https://github.com/endavis/pyproject-template/blob/main/.github/CODE_OF_CONDUCT.md)** - Community guidelines
+- **[AI Agent Setup](development/AI_SETUP.md)** - Setup guide for AI coding assistants
 
 ## Support
 
-- **Issues:** [GitHub Issues](https://github.com/username/package_name/issues)
-- **Discussions:** [GitHub Discussions](https://github.com/username/package_name/discussions)
-- **Security:** See [SECURITY.md](https://github.com/username/package_name/blob/main/.github/SECURITY.md)
+- **Issues:** [GitHub Issues](https://github.com/endavis/pyproject-template/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/endavis/pyproject-template/discussions)
+- **Security:** See [SECURITY.md](https://github.com/endavis/pyproject-template/blob/main/.github/SECURITY.md)
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/username/package_name/blob/main/LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/endavis/pyproject-template/blob/main/LICENSE) file for details.


### PR DESCRIPTION
## Description

Update placeholder `username/package_name` URLs to `endavis/pyproject-template` in docs/index.md.

## Related Issue

Closes #78

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Updated GitHub URLs from `username/package_name` to `endavis/pyproject-template`

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes (`doit docs_build` passes)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

This is a template placeholder fix.