### PR TITLE
chore: improve GitHub issue workflow and documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -228,11 +228,13 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `feat`: New feature
 - `fix`: Bug fix
 - `docs`: Documentation changes
+- `style`: Formatting, whitespace (no code change)
 - `test`: Adding or updating tests
 - `refactor`: Code refactoring
 - `perf`: Performance improvements
 - `chore`: Maintenance tasks (deps, tooling)
 - `ci`: CI/CD changes
+- `revert`: Reverting previous commits
 
 ### Examples
 
@@ -354,21 +356,25 @@ Every code change must be linked to a GitHub Issue. This ensures:
 doit issue --type=feature    # For new features
 doit issue --type=bug        # For bugs and defects
 doit issue --type=refactor   # For code refactoring
+doit issue --type=doc        # For documentation
+doit issue --type=chore      # For maintenance tasks
 
 # Non-interactive: For AI agents or scripts
 doit issue --type=feature --title="Add export" --body-file=issue.md
-doit issue --type=feature --title="Add export" --body="## Problem\n..."
+doit issue --type=doc --title="Add guide" --body="## Description\n..."
 ```
 
 **Or use gh CLI directly:**
 ```bash
-gh issue create --title "<type>: <description>" --body "..."
+gh issue create --title "<description>" --label "enhancement" --body "..."
 ```
 
-**Issue types map to title prefixes:**
-- `feature` → `feat: <title>`
-- `bug` → `fix: <title>`
-- `refactor` → `refactor: <title>`
+**Issue types auto-apply labels:**
+- `feature` → `enhancement, needs-triage`
+- `bug` → `bug, needs-triage`
+- `refactor` → `refactor, needs-triage`
+- `doc` → `documentation, needs-triage`
+- `chore` → `chore, needs-triage`
 
 **Required fields ensure complete information** - Fill all fields to provide context.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: 🐛 Bug Report
 description: Report a bug or unexpected behavior
-title: "bug: "
 labels: ["bug", "needs-triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,72 @@
+name: 🔨 Chore / Maintenance
+description: Maintenance tasks, tooling, CI/CD, or dependency updates
+labels: ["chore", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Chore / Maintenance Task
+
+        Describe the maintenance or tooling task that needs to be done.
+
+  - type: dropdown
+    id: chore-type
+    attributes:
+      label: Chore Type
+      description: What kind of maintenance task is this?
+      options:
+        - CI/CD configuration
+        - Dependency updates
+        - Tooling improvements
+        - Code cleanup
+        - Configuration changes
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the maintenance task
+      placeholder: |
+        What needs to be done and why?
+        Example: "Update GitHub Actions to use Node 20 before Node 16 EOL..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-changes
+    attributes:
+      label: Proposed Changes
+      description: What specific changes need to be made?
+      placeholder: |
+        - Update file X
+        - Modify configuration Y
+        - Add/remove dependency Z
+    validations:
+      required: false
+
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: Success Criteria
+      description: How will we know this task is complete?
+      placeholder: |
+        - [ ] CI passes
+        - [ ] No breaking changes
+        - [ ] Documentation updated if needed
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information
+      placeholder: |
+        - Related issues
+        - Urgency/timeline
+        - Dependencies on other tasks
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,74 @@
+name: 📚 Documentation Request
+description: Request new documentation or improvements to existing docs
+labels: ["documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation Request
+
+        Help us improve our documentation by describing what's needed.
+
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: Documentation Type
+      description: What kind of documentation change is needed?
+      options:
+        - New guide or tutorial
+        - Update existing documentation
+        - Fix incorrect information
+        - Add code examples
+        - API documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the documentation that is needed
+      placeholder: |
+        What documentation is missing or needs improvement?
+        Example: "There's no guide explaining how to configure logging..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Suggested Location
+      description: Where should this documentation live?
+      placeholder: |
+        - docs/getting-started/
+        - docs/examples/
+        - README.md
+        - Inline code comments
+    validations:
+      required: false
+
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: Success Criteria
+      description: How will we know the documentation is complete?
+      placeholder: |
+        - [ ] Topic is fully explained
+        - [ ] Code examples included
+        - [ ] Added to navigation/index
+        - [ ] Reviewed for accuracy
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information
+      placeholder: |
+        - Links to related documentation
+        - Examples from other projects
+        - Target audience
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: ✨ Feature Request
 description: Propose a new feature or enhancement
-title: "feat: "
 labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,6 +1,5 @@
 name: 🔧 Refactor Request
 description: Propose code refactoring or improvement
-title: "refactor: "
 labels: ["refactor", "needs-triage"]
 body:
   - type: markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   workflow_call:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,13 +115,15 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 - **Commits:** One logical change per commit. Use conventional commits.
 - **Releases:** Never run `doit release` without explicit command.
 - **PRs:** Use `doit pr` to create PRs with proper template format.
-- **Issues:** Use `doit issue --type=<type>` to create issues. Manually close after PR merge.
+- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge.
 
 ## Workflow Commands (for AI agents)
 ```bash
-# Create issue (non-interactive)
+# Create issue (non-interactive) - types: feature, bug, refactor, doc, chore
 doit issue --type=feature --title="Add feature" --body="## Problem\n..."
 doit issue --type=bug --title="Fix bug" --body-file=issue.md
+doit issue --type=doc --title="Add guide" --body="## Description\n..."
+doit issue --type=chore --title="Update CI" --body="## Description\n..."
 
 # Create PR (non-interactive)
 doit pr --title="feat: add feature" --body="## Description\n..."


### PR DESCRIPTION
## Description

Improve GitHub issue workflow by removing title prefixes from templates (prefixes belong on commits/PRs, not issues), adding new issue types, and updating documentation.

### Changes

- Remove title prefixes from issue templates
- Add `documentation` and `chore` issue templates
- Update `dodo.py` to support `doc` and `chore` types with auto-applied labels
- Add `style:` and `revert:` commit types to CONTRIBUTING.md
- Remove unused `develop` branch from CI workflow
- Update AGENTS.md and CONTRIBUTING.md with new issue types

## Related Issue

Closes #105

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Breaking change

## Testing

- [x] `doit check` passes
- [x] `doit help issue` shows all 5 types
- [x] Pre-commit hooks pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings