### PR TITLE
chore: block gh issue/pr create commands for AI agents

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -67,6 +67,19 @@ pattern = "rm\\s+-rf\\s+~"
 action = "deny"
 reason = "BLOCKED: Destructive command - removes home directory. See AGENTS.md."
 
+# Block direct gh issue/pr create - use doit wrappers instead
+[[approval_policy]]
+type = "command"
+pattern = "gh\\s+issue\\s+create"
+action = "deny"
+reason = "BLOCKED: Use 'doit issue --type=<type>' instead of 'gh issue create'. See AGENTS.md."
+
+[[approval_policy]]
+type = "command"
+pattern = "gh\\s+pr\\s+create"
+action = "deny"
+reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
+
 # =============================================================================
 # ALLOWED COMMANDS - Standard development tools
 # =============================================================================

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -83,6 +83,17 @@ EOF
     # branch, these would be BLOCK instead. The hook checks current branch.
     ("git merge some-branch", "ALLOW", "merge on feature branch"),
     ("git merge origin/main", "ALLOW", "merge origin/main on feat"),
+    # === SHOULD BLOCK - Direct gh issue/pr create (use doit wrappers) ===
+    ("gh issue create --title 'test'", "BLOCK", "gh issue create"),
+    ("gh pr create --title 'test'", "BLOCK", "gh pr create"),
+    ('gh issue create --title "test" --body "body"', "BLOCK", "gh issue create full"),
+    ("gh pr create --fill", "BLOCK", "gh pr create fill"),
+    # === SHOULD ALLOW - Other gh commands ===
+    ("gh issue list", "ALLOW", "gh issue list"),
+    ("gh pr list", "ALLOW", "gh pr list"),
+    ("gh issue view 123", "ALLOW", "gh issue view"),
+    ("gh pr view 456", "ALLOW", "gh pr view"),
+    ("gh issue close 123", "ALLOW", "gh issue close"),
 ]
 
 
@@ -107,7 +118,7 @@ def run_test(cmd: str, expected: str, desc: str) -> bool:
     print(f"{color}{mark} {actual:5} (expected {expected:5}) | {desc:25} | {cmd_display}{RESET}")
 
     if not passed:
-        print(f'{RED}  stderr: {result.stderr[:200] if result.stderr else "(none)"}{RESET}')
+        print(f"{RED}  stderr: {result.stderr[:200] if result.stderr else '(none)'}{RESET}")
 
     return passed
 


### PR DESCRIPTION
## Description
Block `gh issue create` and `gh pr create` commands for AI agents. AI agents must use `doit issue` and `doit pr` instead to ensure proper template formatting and workflow compliance.

## Related Issue
Fixes #117

## Type of Change
- [x] Code refactoring

## Changes Made
- Added deny patterns to `.codex/config.toml` for Codex CLI
- Added `check_blocked_workflow_commands()` to hook for Claude/Gemini
- Added 9 test cases for gh issue/pr commands

## Testing
- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist
- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
