### PR TITLE
fix: align doit type_check with CI and pyproject.toml config

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -194,11 +194,8 @@ def task_format_check() -> dict[str, Any]:
 
 
 def task_type_check() -> dict[str, Any]:
-    """Run mypy type checking with strict mode (matches pre-commit hooks)."""
-    cmd = (
-        f"UV_CACHE_DIR={UV_CACHE_DIR} uv run mypy --strict "
-        "--ignore-missing-imports src/ tools/pyproject_template/"
-    )
+    """Run mypy type checking (uses pyproject.toml configuration)."""
+    cmd = f"UV_CACHE_DIR={UV_CACHE_DIR} uv run mypy src/"
     return {
         "actions": [cmd],
         "title": title_with_actions,


### PR DESCRIPTION
## Description
The `doit type_check` task was passing `tools/pyproject_template/` to mypy, but this directory is excluded in both `pyproject.toml` and `.pre-commit-config.yaml`. This caused mypy to report "no .py files found" because the exclude config filters them out.

Simplified the command to `mypy src/` to align with CI workflow. The pyproject.toml config handles all settings (excludes, strict options, etc.).

## Related Issue
Fixes #116

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Simplified `task_type_check()` in `dodo.py` to use `mypy src/` instead of passing explicit flags and paths
- Removed redundant `--strict --ignore-missing-imports` flags (already in pyproject.toml)
- Removed `tools/pyproject_template/` path (excluded in pyproject.toml config)

## Testing
- [x] All existing tests pass
- [x] Manually tested the changes

## Checklist
- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
