### PR TITLE
fix: preserve package_name keyword arguments during configure

### DIFF
--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -109,13 +109,22 @@ def validate_email(email: str) -> bool:
 
 
 def update_file(filepath: Path, replacements: dict[str, str]) -> None:
-    """Update file with string replacements."""
+    """Update file with string replacements.
+
+    Special handling for 'package_name': only replaces when NOT followed by '='
+    to preserve Python keyword argument syntax (e.g., package_name="value").
+    """
     if not filepath.exists():
         return
     try:
         content = filepath.read_text(encoding="utf-8")
         for old, new in replacements.items():
-            content = content.replace(old, new)
+            if old == "package_name":
+                # Use regex to replace 'package_name' only when NOT followed by '='
+                # This preserves keyword argument syntax like package_name="value"
+                content = re.sub(r"package_name(?!=)", new, content)
+            else:
+                content = content.replace(old, new)
         filepath.write_text(content, encoding="utf-8")
     except UnicodeDecodeError:
         pass  # Skip binary files


### PR DESCRIPTION
## Description
Fix configure script breaking test files when the package name matches a Python identifier pattern (like `test`). The script was replacing `package_name=` keyword arguments with the new package name, causing TypeErrors.

## Related Issue
Fixes #121

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Modified `update_file()` in `tools/pyproject_template/utils.py` to use regex with negative lookahead
- `package_name` is now only replaced when NOT followed by `=`
- Preserves Python keyword argument syntax like `package_name="value"`

## Testing
- [x] All existing tests pass
- [x] Manually verified fix prevents the reported bug

## Checklist
- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
