### PR TITLE
refactor: consolidate FILES_TO_UPDATE into shared constant

### DIFF
--- a/tests/pyproject_template/test_utils.py
+++ b/tests/pyproject_template/test_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tools.pyproject_template.utils import (
+    FILES_TO_UPDATE,
     Colors,
     GitHubCLI,
     Logger,
@@ -441,3 +442,69 @@ class TestGitHubCLI:
         """Test is_authenticated returns False when gh not installed."""
         with patch("subprocess.run", side_effect=FileNotFoundError):
             assert GitHubCLI.is_authenticated() is False
+
+
+class TestFilesToUpdate:
+    """Tests for FILES_TO_UPDATE constant."""
+
+    def test_is_tuple(self) -> None:
+        """Test that FILES_TO_UPDATE is a tuple (immutable)."""
+        assert isinstance(FILES_TO_UPDATE, tuple)
+
+    def test_contains_core_files(self) -> None:
+        """Test that essential files are included."""
+        core_files = [
+            "pyproject.toml",
+            "README.md",
+            "LICENSE",
+            "dodo.py",
+            "mkdocs.yml",
+            "AGENTS.md",
+        ]
+        for f in core_files:
+            assert f in FILES_TO_UPDATE, f"Missing core file: {f}"
+
+    def test_contains_github_workflows(self) -> None:
+        """Test that GitHub workflow files are included."""
+        workflow_files = [
+            ".github/workflows/ci.yml",
+            ".github/workflows/release.yml",
+            ".github/workflows/testpypi.yml",
+            ".github/workflows/breaking-change-detection.yml",
+        ]
+        for f in workflow_files:
+            assert f in FILES_TO_UPDATE, f"Missing workflow: {f}"
+
+    def test_contains_github_files(self) -> None:
+        """Test that GitHub config files are included."""
+        github_files = [
+            ".github/CONTRIBUTING.md",
+            ".github/SECURITY.md",
+            ".github/CODE_OF_CONDUCT.md",
+            ".github/CODEOWNERS",
+            ".github/pull_request_template.md",
+        ]
+        for f in github_files:
+            assert f in FILES_TO_UPDATE, f"Missing GitHub file: {f}"
+
+    def test_contains_claude_files(self) -> None:
+        """Test that Claude config files are included."""
+        claude_files = [
+            ".claude/CLAUDE.md",
+            ".claude/lsp-setup.md",
+        ]
+        for f in claude_files:
+            assert f in FILES_TO_UPDATE, f"Missing Claude file: {f}"
+
+    def test_contains_config_files(self) -> None:
+        """Test that config files are included."""
+        config_files = [
+            ".envrc",
+            ".pre-commit-config.yaml",
+        ]
+        for f in config_files:
+            assert f in FILES_TO_UPDATE, f"Missing config file: {f}"
+
+    def test_no_duplicates(self) -> None:
+        """Test that there are no duplicate entries."""
+        assert len(FILES_TO_UPDATE) == len(set(FILES_TO_UPDATE))

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -19,6 +19,7 @@ if str(_script_dir) not in sys.path:
 
 # Import shared utilities
 from utils import (  # noqa: E402
+    FILES_TO_UPDATE,
     Logger,
     get_first_author,
     get_git_config,
@@ -300,27 +301,8 @@ def run_configure(
         # variables (e.g. in extensions.md)
     }
 
-    # Update files
-    files_to_update = [
-        "pyproject.toml",
-        "README.md",
-        "LICENSE",
-        "dodo.py",
-        "mkdocs.yml",
-        "AGENTS.md",
-        "CHANGELOG.md",
-        ".github/workflows/ci.yml",
-        ".github/workflows/release.yml",
-        ".github/workflows/testpypi.yml",
-        ".github/CONTRIBUTING.md",
-        ".github/SECURITY.md",
-        ".github/CODE_OF_CONDUCT.md",
-        ".github/CODEOWNERS",
-        ".github/pull_request_template.md",
-        ".envrc",
-    ]
-
-    for file_path in files_to_update:
+    # Update files (using shared constant from utils.py)
+    for file_path in FILES_TO_UPDATE:
         path = Path(file_path)
         if path.exists():
             print(f"  ✓ Updating {file_path}")

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -34,6 +34,7 @@ if str(_script_dir) not in sys.path:
 
 # Import shared utilities
 from utils import (  # noqa: E402
+    FILES_TO_UPDATE,
     TEMPLATE_REPO,
     Colors,
     GitHubCLI,
@@ -320,27 +321,8 @@ class RepositorySetup:
                 "your.email@example.com": self.config["author_email"],
             }
 
-            # Update main configuration files
-            files_to_update = [
-                "pyproject.toml",
-                "README.md",
-                "LICENSE",
-                "dodo.py",
-                "mkdocs.yml",
-                "AGENTS.md",
-                "CHANGELOG.md",
-                ".github/workflows/ci.yml",
-                ".github/workflows/release.yml",
-                ".github/workflows/testpypi.yml",
-                ".github/CONTRIBUTING.md",
-                ".github/SECURITY.md",
-                ".github/CODEOWNERS",
-                ".github/pull_request_template.md",
-                ".envrc",
-                ".pre-commit-config.yaml",
-            ]
-
-            for file_path in files_to_update:
+            # Update main configuration files (using shared constant from utils.py)
+            for file_path in FILES_TO_UPDATE:
                 path = Path(file_path)
                 if path.exists():
                     update_file(path, replacements)

--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -23,6 +23,31 @@ except ModuleNotFoundError:  # pragma: no cover
 TEMPLATE_REPO = "endavis/pyproject-template"
 TEMPLATE_URL = f"https://github.com/{TEMPLATE_REPO}"
 
+# Files to update during placeholder replacement (single source of truth)
+# Used by both configure.py and setup_repo.py
+FILES_TO_UPDATE: tuple[str, ...] = (
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+    "dodo.py",
+    "mkdocs.yml",
+    "AGENTS.md",
+    "CHANGELOG.md",
+    ".github/workflows/ci.yml",
+    ".github/workflows/release.yml",
+    ".github/workflows/testpypi.yml",
+    ".github/workflows/breaking-change-detection.yml",
+    ".github/CONTRIBUTING.md",
+    ".github/SECURITY.md",
+    ".github/CODE_OF_CONDUCT.md",
+    ".github/CODEOWNERS",
+    ".github/pull_request_template.md",
+    ".claude/CLAUDE.md",
+    ".claude/lsp-setup.md",
+    ".envrc",
+    ".pre-commit-config.yaml",
+)
+
 
 # ANSI color codes
 class Colors:


### PR DESCRIPTION
## Description

Consolidates the duplicate `files_to_update` lists from `configure.py` and `setup_repo.py` into a single `FILES_TO_UPDATE` constant in `utils.py`. Also adds previously missed placeholder files.

Closes #130

## Type of Change
- [x] Code refactoring

## Changes Made
- Added `FILES_TO_UPDATE` tuple to `utils.py` as single source of truth
- Updated `configure.py` to import and use the shared constant
- Updated `setup_repo.py` to import and use the shared constant
- Added missed placeholder files:
  - `.github/workflows/breaking-change-detection.yml`
  - `.github/CODE_OF_CONDUCT.md`
  - `.claude/CLAUDE.md`
  - `.claude/lsp-setup.md`
- Added 7 tests verifying the constant contains required files

## Testing
- [x] All 139 tests pass
- [x] `doit check` passes
- [x] Pre-commit hooks pass

## Checklist
- [x] My code follows the code style of this project
- [x] I have run linting checks
- [x] I have run type checking
- [x] All new and existing tests pass
- [x] My changes generate no new warnings