### PR TITLE
feat: add Claude statusline configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+
+# Claude Code statusline script
+# Color theme: gray, orange, blue, teal, green, lavender, rose, gold, slate, cyan
+COLOR="blue"
+
+# Color codes
+C_RESET='\033[0m'
+C_GRAY='\033[38;5;245m'  # explicit gray for default text
+C_BAR_EMPTY='\033[38;5;238m'
+case "$COLOR" in
+    orange)   C_ACCENT='\033[38;5;173m' ;;
+    blue)     C_ACCENT='\033[38;5;74m' ;;
+    teal)     C_ACCENT='\033[38;5;66m' ;;
+    green)    C_ACCENT='\033[38;5;71m' ;;
+    lavender) C_ACCENT='\033[38;5;139m' ;;
+    rose)     C_ACCENT='\033[38;5;132m' ;;
+    gold)     C_ACCENT='\033[38;5;136m' ;;
+    slate)    C_ACCENT='\033[38;5;60m' ;;
+    cyan)     C_ACCENT='\033[38;5;37m' ;;
+    *)        C_ACCENT="$C_GRAY" ;;  # gray: all same color
+esac
+
+input=$(cat)
+
+
+# Extract model, directory, and cwd
+model=$(echo "$input" | jq -r '.model.display_name // .model.id // "?"')
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+dir=$(basename "$cwd" 2>/dev/null || echo "?")
+gh_user=$(gh api user --jq ".login" 2>/dev/null || echo "")
+python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" || echo "")
+
+# Extract Python .venv
+venv_name=""
+
+# 1. Check if a custom prompt name is set (this comes from activate script)
+if [ -n "$VIRTUAL_ENV_PROMPT" ]; then
+    venv_name="$VIRTUAL_ENV_PROMPT"
+
+# 2. Fallback: Check if VIRTUAL_ENV path is set and use folder name
+elif [ -n "$VIRTUAL_ENV" ]; then
+    venv_name="$(basename "$VIRTUAL_ENV")"
+fi
+
+# Get git branch, uncommitted file count, and sync status
+branch=""
+git_status=""
+if [[ -n "$cwd" && -d "$cwd" ]]; then
+    branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+    if [[ -n "$branch" ]]; then
+        # Count uncommitted files
+        file_count=$(git -C "$cwd" --no-optional-locks status --porcelain -uall 2>/dev/null | wc -l | tr -d ' ')
+
+        # Check sync status with upstream
+        sync_status=""
+        upstream=$(git -C "$cwd" rev-parse --abbrev-ref @{upstream} 2>/dev/null)
+        if [[ -n "$upstream" ]]; then
+            # Get last fetch time
+            fetch_head="$cwd/.git/FETCH_HEAD"
+            fetch_ago=""
+            if [[ -f "$fetch_head" ]]; then
+                fetch_time=$(stat -f %m "$fetch_head" 2>/dev/null || stat -c %Y "$fetch_head" 2>/dev/null)
+                if [[ -n "$fetch_time" ]]; then
+                    now=$(date +%s)
+                    diff=$((now - fetch_time))
+                    if [[ $diff -lt 60 ]]; then
+                        fetch_ago="<1m ago"
+                    elif [[ $diff -lt 3600 ]]; then
+                        fetch_ago="$((diff / 60))m ago"
+                    elif [[ $diff -lt 86400 ]]; then
+                        fetch_ago="$((diff / 3600))h ago"
+                    else
+                        fetch_ago="$((diff / 86400))d ago"
+                    fi
+                fi
+            fi
+
+            counts=$(git -C "$cwd" rev-list --left-right --count HEAD...@{upstream} 2>/dev/null)
+            ahead=$(echo "$counts" | cut -f1)
+            behind=$(echo "$counts" | cut -f2)
+            if [[ "$ahead" -eq 0 && "$behind" -eq 0 ]]; then
+                if [[ -n "$fetch_ago" ]]; then
+                    sync_status="synced ${fetch_ago}"
+                else
+                    sync_status="synced"
+                fi
+            elif [[ "$ahead" -gt 0 && "$behind" -eq 0 ]]; then
+                sync_status="${ahead} ahead"
+            elif [[ "$ahead" -eq 0 && "$behind" -gt 0 ]]; then
+                sync_status="${behind} behind"
+            else
+                sync_status="${ahead} ahead, ${behind} behind"
+            fi
+        else
+            sync_status="no upstream"
+        fi
+
+        # Build git status string
+        if [[ "$file_count" -eq 0 ]]; then
+            git_status="(0 files uncommitted, ${sync_status})"
+        elif [[ "$file_count" -eq 1 ]]; then
+            # Show the actual filename when only one file is uncommitted
+            single_file=$(git -C "$cwd" --no-optional-locks status --porcelain -uall 2>/dev/null | head -1 | sed 's/^...//')
+            git_status="(${single_file} uncommitted, ${sync_status})"
+        else
+            git_status="(${file_count} files uncommitted, ${sync_status})"
+        fi
+    fi
+fi
+
+# Get transcript path for context calculation and last message feature
+transcript_path=$(echo "$input" | jq -r '.transcript_path // empty')
+
+# Get context window size from JSON (accurate), but calculate tokens from transcript
+# (more accurate than total_input_tokens which excludes system prompt/tools/memory)
+# See: github.com/anthropics/claude-code/issues/13652
+max_context=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+max_k=$((max_context / 1000))
+
+# Calculate context bar from transcript
+if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
+    context_length=$(jq -s '
+        map(select(.message.usage and .isSidechain != true and .isApiErrorMessage != true)) |
+        last |
+        if . then
+            (.message.usage.input_tokens // 0) +
+            (.message.usage.cache_read_input_tokens // 0) +
+            (.message.usage.cache_creation_input_tokens // 0)
+        else 0 end
+    ' < "$transcript_path")
+
+    # 20k baseline: includes system prompt (~3k), tools (~15k), memory (~300),
+    # plus ~2k for git status, env block, XML framing, and other dynamic context
+    baseline=20000
+    bar_width=10
+
+    if [[ "$context_length" -gt 0 ]]; then
+        pct=$((context_length * 100 / max_context))
+        pct_prefix=""
+    else
+        # At conversation start, ~20k baseline is already loaded
+        pct=$((baseline * 100 / max_context))
+        pct_prefix="~"
+    fi
+
+    [[ $pct -gt 100 ]] && pct=100
+
+    bar=""
+    for ((i=0; i<bar_width; i++)); do
+        bar_start=$((i * 10))
+        progress=$((pct - bar_start))
+        if [[ $progress -ge 8 ]]; then
+            bar+="${C_ACCENT}█${C_RESET}"
+        elif [[ $progress -ge 3 ]]; then
+            bar+="${C_ACCENT}▄${C_RESET}"
+        else
+            bar+="${C_BAR_EMPTY}░${C_RESET}"
+        fi
+    done
+
+    ctx="${bar} ${C_GRAY}${pct_prefix}${pct}% of ${max_k}k tokens"
+else
+    # Transcript not available yet - show baseline estimate
+    baseline=20000
+    bar_width=10
+    pct=$((baseline * 100 / max_context))
+    [[ $pct -gt 100 ]] && pct=100
+
+    bar=""
+    for ((i=0; i<bar_width; i++)); do
+        bar_start=$((i * 10))
+        progress=$((pct - bar_start))
+        if [[ $progress -ge 8 ]]; then
+            bar+="${C_ACCENT}█${C_RESET}"
+        elif [[ $progress -ge 3 ]]; then
+            bar+="${C_ACCENT}▄${C_RESET}"
+        else
+            bar+="${C_BAR_EMPTY}░${C_RESET}"
+        fi
+    done
+
+    ctx="${bar} ${C_GRAY}~${pct}% of ${max_k}k tokens"
+fi
+
+# Build output: Model | Dir | Branch (uncommitted) | Context
+output="📁 ${dir}"
+[[ -n "$venv_name" ]] && output+=" | 🐍 ${venv_name}"
+[[ -n "$python_version" ]] && output+=" | Python: ${python_version}"
+[[ -n "$gh_user" ]] && output+="\n@${gh_user}"
+[[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
+output+="\n${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
+
+printf '%b\n' "$output"
+
+# Get user's last message (text only, not tool results, skip unhelpful messages)
+if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
+    max_len=80
+    last_user_msg=$(jq -rs '
+        # Messages to skip (not useful as context)
+        def is_unhelpful:
+            startswith("[Request interrupted") or
+            startswith("[Request cancelled") or
+            . == "";
+
+        [.[] | select(.type == "user") |
+         select(.message.content | type == "string" or
+                (type == "array" and any(.[]; .type == "text")))] |
+        reverse |
+        map(.message.content |
+            if type == "string" then .
+            else [.[] | select(.type == "text") | .text] | join(" ") end |
+            gsub("\n"; " ") | gsub("  +"; " ")) |
+        map(select(is_unhelpful | not)) |
+        first // ""
+    ' < "$transcript_path" 2>/dev/null)
+
+    if [[ -n "$last_user_msg" ]]; then
+        if [[ ${#last_user_msg} -gt $max_len ]]; then
+            echo "💬 ${last_user_msg:0:$((max_len - 3))}..."
+        else
+            echo "💬 ${last_user_msg}"
+        fi
+    fi
+fi

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -1,0 +1,92 @@
+# Claude Code Statusline
+
+The template includes a custom statusline for Claude Code sessions that provides useful context at a glance.
+
+## Example Output
+
+```
+📁 project-name | 🐍 .venv | Python: 3.12.12
+@username | 🔀 main (0 files uncommitted, synced 5m ago)
+Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens
+💬 work on issue #130
+```
+
+## Features
+
+- **Current directory** and Python virtual environment name
+- **Python version** currently active
+- **GitHub username** (from `gh` CLI)
+- **Git branch** with uncommitted file count
+- **Sync status** showing ahead/behind commits and last fetch time
+- **Model name** with context usage bar (visual + percentage)
+- **Last user message** preview for quick context
+
+## Configuration
+
+The statusline is configured in `.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"
+  }
+}
+```
+
+## Customization
+
+### Color Theme
+
+Edit `.claude/statusline-command.sh` and change the `COLOR` variable at the top:
+
+```bash
+# Available themes: gray, orange, blue, teal, green, lavender, rose, gold, slate, cyan
+COLOR="blue"
+```
+
+### Color Reference
+
+| Theme    | ANSI Code | Description |
+|----------|-----------|-------------|
+| gray     | 245       | Monochrome, subtle |
+| orange   | 173       | Warm, energetic |
+| blue     | 74        | Default, calm |
+| teal     | 66        | Cool, professional |
+| green    | 71        | Fresh, nature |
+| lavender | 139       | Soft, creative |
+| rose     | 132       | Warm pink |
+| gold     | 136       | Rich, elegant |
+| slate    | 60        | Dark blue-gray |
+| cyan     | 37        | Bright, tech |
+
+### Removing Features
+
+Comment out or remove lines in the "Build output" section of the script:
+
+```bash
+# Build output: Model | Dir | Branch (uncommitted) | Context
+output="📁 ${dir}"
+[[ -n "$venv_name" ]] && output+=" | 🐍 ${venv_name}"
+[[ -n "$python_version" ]] && output+=" | Python: ${python_version}"
+# [[ -n "$gh_user" ]] && output+="\n@${gh_user}"  # Remove GitHub username
+[[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
+```
+
+## Requirements
+
+- `jq` - JSON processor (used for parsing Claude's input)
+- `gh` - GitHub CLI (optional, for username display)
+- `git` - For branch and status information
+
+## Troubleshooting
+
+### Statusline not appearing
+
+1. Ensure the script is executable: `chmod +x .claude/statusline-command.sh`
+2. Check `jq` is installed: `which jq`
+3. Test manually: `echo '{}' | bash .claude/statusline-command.sh`
+
+### Colors not displaying
+
+Some terminals may not support 256-color mode. Try setting `COLOR="gray"` for basic output.


### PR DESCRIPTION
## Description

Add custom statusline for Claude Code sessions that provides useful context at a glance, including project info, git status, model context usage, and last user message.

## Related Issue

Fixes #133

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Add `statusline-command.sh` script to `.claude/` directory
- Update `.claude/settings.json` with statusline configuration
- Add documentation in `docs/development/ai/statusline.md`

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings