### PR TITLE
ci: add merge-gate workflow to require ready-to-merge label

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   require-label:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check for ready-to-merge label


### PR DESCRIPTION
## Description

Adds a lightweight GitHub Actions workflow that blocks PR merges unless the `ready-to-merge` label is present.

## Related Issue

Fixes #149

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `.github/workflows/merge-gate.yml` workflow
- Triggers on PR events: opened, labeled, unlabeled, synchronize, reopened
- Fails with clear error message if `ready-to-merge` label is missing

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes (workflow syntax validated)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

After merging, the `main` ruleset needs to be updated to require the `require-label` status check. This can be done via:

```bash
gh api repos/{owner}/{repo}/rulesets/10852193 -X PUT --input <(cat <<JSON
{
  "name": "main",
  "enforcement": "active",
  "rules": [
    {"type": "deletion"},
    {"type": "non_fast_forward"},
    {"type": "pull_request", "parameters": {"required_approving_review_count": 0, "dismiss_stale_reviews_on_push": true, "required_reviewers": [], "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": true, "allowed_merge_methods": ["squash"]}},
    {"type": "creation"},
    {"type": "required_linear_history"},
    {"type": "required_signatures"},
    {"type": "code_scanning", "parameters": {"code_scanning_tools": [{"tool": "CodeQL", "security_alerts_threshold": "high_or_higher", "alerts_threshold": "errors"}]}},
    {"type": "code_quality", "parameters": {"severity": "errors"}},
    {"type": "required_status_checks", "parameters": {"strict_required_status_checks_policy": true, "required_status_checks": [{"context": "require-label"}]}}
  ]
}
JSON
)
```