### PR TITLE
feat: add VS Code workspace configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ htmlcov/
 dmypy.json
 
 # IDEs
-.vscode/
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "ms-python.python",
+    "ms-python.mypy-type-checker",
+    "ms-python.debugpy",
+    "tamasfe.even-better-toml"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Python: Debug Tests",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["tests", "-v"],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "Python: Module with Args",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "${input:moduleName}",
+      "args": "${input:moduleArgs}",
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "moduleName",
+      "type": "promptString",
+      "description": "Module name to run (e.g., package_name)"
+    },
+    {
+      "id": "moduleArgs",
+      "type": "promptString",
+      "description": "Arguments to pass to the module"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+  "ruff.lint.args": ["--config=pyproject.toml"],
+  "ruff.format.args": ["--config=pyproject.toml"],
+  "mypy-type-checker.args": ["--config-file=pyproject.toml"],
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": ["tests"],
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/*.egg-info": true,
+    ".ruff_cache": true,
+    ".mypy_cache": true,
+    ".pytest_cache": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "doit check",
+      "type": "shell",
+      "command": "doit check",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "doit test",
+      "type": "shell",
+      "command": "doit test",
+      "group": "test",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "doit format",
+      "type": "shell",
+      "command": "doit format",
+      "group": "build",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "doit lint",
+      "type": "shell",
+      "command": "doit lint",
+      "group": "build",
+      "problemMatcher": [
+        "$eslint-compact"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Add VS Code workspace configuration files to provide a pre-configured development environment for this project template. This includes settings for ruff, mypy, pytest integration, recommended extensions, debug configurations, and doit task shortcuts.

## Related Issue

Closes #82

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `.vscode/settings.json` with Python interpreter, ruff format-on-save, mypy, pytest config
- Add `.vscode/extensions.json` with recommended extensions (ruff, python, mypy, debugpy, toml)
- Add `.vscode/launch.json` with debug configs for current file, pytest tests, and module with args
- Add `.vscode/tasks.json` with tasks for doit check, test, format, and lint
- Remove `.vscode/` from `.gitignore` to track these files

## Testing

- [x] All existing tests pass
- [x] `doit check` passes (175 tests)
- [ ] VS Code auto-formats with ruff on save
- [ ] Mypy errors shown in Problems panel
- [ ] Test explorer discovers pytest tests
- [ ] Debug configurations work

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
