### PR TITLE
feat: add code complexity metrics with radon

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -477,6 +477,95 @@ Vulture may report false positives for code that's used dynamically. Common exam
 - Document why code is kept if it appears unused but is needed
 - Keep the confidence threshold at 80+ to avoid noise
 
+## Code Complexity Metrics
+
+### Overview
+
+This template uses [radon](https://radon.readthedocs.io/) to analyze code complexity. Complex code is harder to understand, test, and maintain.
+
+### Running Complexity Analysis
+
+```bash
+# Analyze cyclomatic complexity (A-F grades)
+doit complexity
+
+# Analyze maintainability index (A-F grades)
+doit maintainability
+```
+
+### Metrics Explained
+
+#### Cyclomatic Complexity (CC)
+
+Measures the number of independent paths through a function. Lower is better.
+
+| Grade | CC Score | Risk Level |
+|-------|----------|------------|
+| A | 1-5 | Low - simple, easy to test |
+| B | 6-10 | Low - slightly complex |
+| C | 11-20 | Moderate - more difficult to test |
+| D | 21-30 | High - difficult to test |
+| E | 31-40 | Very high - untestable |
+| F | 41+ | Extremely high - error-prone |
+
+**Target:** Keep all functions at grade B or better (CC ≤ 10).
+
+#### Maintainability Index (MI)
+
+A composite score based on cyclomatic complexity, lines of code, and Halstead volume. Higher is better.
+
+| Grade | MI Score | Meaning |
+|-------|----------|---------|
+| A | 20-100 | Highly maintainable |
+| B | 10-19 | Moderately maintainable |
+| C | 0-9 | Difficult to maintain |
+
+**Target:** Keep all modules at grade A (MI ≥ 20).
+
+### Reducing Complexity
+
+If a function has high complexity:
+
+1. **Extract helper functions** - Break large functions into smaller, focused ones
+2. **Use early returns** - Reduce nesting with guard clauses
+3. **Simplify conditionals** - Use lookup tables instead of long if-else chains
+4. **Apply design patterns** - Strategy pattern can replace complex switches
+
+**Example - Before (CC=8):**
+```python
+def process(data, mode):
+    if mode == "a":
+        if data.valid:
+            return handle_a(data)
+        else:
+            return error_a()
+    elif mode == "b":
+        if data.valid:
+            return handle_b(data)
+        else:
+            return error_b()
+    # ... more branches
+```
+
+**Example - After (CC=2):**
+```python
+HANDLERS = {"a": handle_a, "b": handle_b}
+ERRORS = {"a": error_a, "b": error_b}
+
+def process(data, mode):
+    handler = HANDLERS.get(mode)
+    if not handler:
+        raise ValueError(f"Unknown mode: {mode}")
+    return handler(data) if data.valid else ERRORS[mode]()
+```
+
+### Best Practices
+
+- Run `doit complexity` before submitting PRs
+- Refactor functions with CC > 10
+- Document exceptions where high complexity is justified
+- Use maintainability index to identify modules needing attention
+
 ## Related Documentation
 
 - [Release Automation](release-and-automation.md)

--- a/dodo.py
+++ b/dodo.py
@@ -55,10 +55,12 @@ from tools.tasks.maintenance import (  # noqa: F401
 # Code quality tasks
 from tools.tasks.quality import (  # noqa: F401
     task_check,
+    task_complexity,
     task_deadcode,
     task_format,
     task_format_check,
     task_lint,
+    task_maintainability,
     task_type_check,
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pyyaml>=6.0",
     "types-pyyaml>=6.0",
     "vulture>=2.11",
+    "radon>=6.0",
 ]
 security = [
     "pip-audit>=2.6",

--- a/tools/tasks/quality.py
+++ b/tools/tasks/quality.py
@@ -51,6 +51,22 @@ def task_deadcode() -> dict[str, Any]:
     }
 
 
+def task_complexity() -> dict[str, Any]:
+    """Analyze cyclomatic complexity with radon (A-F grades, A is best)."""
+    return {
+        "actions": ["uv run radon cc src/ -a -s"],
+        "title": title_with_actions,
+    }
+
+
+def task_maintainability() -> dict[str, Any]:
+    """Analyze maintainability index with radon (A-F grades, A is best)."""
+    return {
+        "actions": ["uv run radon mi src/ -s"],
+        "title": title_with_actions,
+    }
+
+
 def task_check() -> dict[str, Any]:
     """Run all checks (format, lint, type check, security, spelling, test)."""
     return {

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mando"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/24/cd70d5ae6d35962be752feccb7dca80b5e0c2d450e995b16abd6275f3296/mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500", size = 37868, upload-time = "2022-02-24T08:12:27.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/f0/834e479e47e499b6478e807fb57b31cc2db696c4db30557bb6f5aea4a90b/mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a", size = 28149, upload-time = "2022-02-24T08:12:25.24Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -787,6 +799,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
+    { name = "radon" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "vulture" },
@@ -814,6 +827,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
@@ -1190,6 +1204,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
+name = "radon"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "mando" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add radon for code complexity analysis to help identify complex functions that may be hard to maintain and test. Provides visibility into cyclomatic complexity and maintainability index metrics.

## Related Issue

Closes #97

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `radon>=6.0` to dev dependencies in `pyproject.toml`
- Add `doit complexity` task for cyclomatic complexity analysis (A-F grades)
- Add `doit maintainability` task for maintainability index analysis (A-F grades)
- Export new tasks in `dodo.py`
- Add comprehensive documentation in `docs/development/coding-standards.md`:
  - What cyclomatic complexity and maintainability index measure
  - Grade thresholds and recommended targets
  - How to reduce complexity with before/after examples

## Testing

- [x] All existing tests pass
- [x] `doit check` passes (175 tests)
- [x] `doit complexity` runs successfully
- [x] `doit maintainability` runs successfully
- [x] Pre-commit hooks pass

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
