### PR TITLE
feat: add auto-generated documentation TOC from frontmatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,14 @@ repos:
         pass_filenames: false
         always_run: true
 
+      # Generate documentation TOC from frontmatter
+      - id: generate-doc-toc
+        name: Generate documentation TOC
+        entry: doit docs_toc
+        language: system
+        pass_filenames: false
+        files: ^docs/.*\.md$
+
       # Prevent direct commits to main branch
       - id: no-commit-to-main
         name: Prevent commits to main branch

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -1,92 +1,96 @@
-# Python Project Template Documentation
+# All Documents
 
-This index provides a structured overview of the available documentation for the Python project template.
+Complete index of all documentation, organized by audience and as a full alphabetical list.
 
-## Getting Started
-- **[Installation Guide](getting-started/installation.md)**: Step-by-step instructions for installing and setting up your Python project.
+> These lists are auto-generated from document frontmatter.
+> Run `python tools/generate_doc_toc.py` to update.
 
-## Usage
-- **[Basic Usage](usage/basics.md)**: Introduction to using the project template and core features.
+## By Audience
 
-## Reference
-- **[API Reference](reference/api.md)**: Comprehensive API documentation.
-
-## Development
-- **[Extensions & Plugin System](development/extensions.md)**: Guide to extending the template with custom plugins and doit tasks.
-- **[Coding Standards](development/coding-standards.md)**: Style guides and standards for writing consistent, maintainable code.
-- **[CI/CD Testing](development/ci-cd-testing.md)**: Strategies and setup for continuous integration and testing.
-- **[Release Automation & Security](development/release-and-automation.md)**: Automated versioning, release management, governance validation, and security tooling.
-
-## Examples
-- **[Examples & Recipes](examples/README.md)**: Practical examples and common use cases.
-
-## Template
-- **[Template Management](template/manage.md)**: Unified interface for creating projects, checking for updates, and syncing with the template.
-- **[Migration Guide](template/migration.md)**: Guide for migrating from other project structures or updating existing projects.
-
-## Project Information
-- **[Main Documentation](index.md)**: Overview and introduction to the template.
-
----
-
-## Documentation Sections Explained
-
-### Getting Started
-Essential guides for new users to get up and running quickly with the template.
-
-### Usage
-Day-to-day usage documentation covering common tasks and workflows.
-
-### Reference
-Technical reference documentation for APIs, configuration options, and advanced features.
-
-### Development
-Guides for contributors and developers working on extending or maintaining projects built with this template.
-
-### Examples
-Practical code examples, recipes, and patterns for common scenarios.
-
-### Template
-Step-by-step guides for specific tasks like migration, deployment, or integration.
-
-## Quick Links
-
-### For New Users
-1. [Installation Guide](getting-started/installation.md) - Start here
-2. [Basic Usage](usage/basics.md) - Learn the fundamentals
-3. [Examples](examples/README.md) - See it in action
+### For Users
+<!-- BEGIN:audience=users -->
+- [API Reference](reference/api.md) - Complete API documentation for Package Name
+- [Examples](examples/README.md) - Example scripts demonstrating how to use the package
+- [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
+- [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template
+- [New Project Setup](template/new-project.md) - Create a new Python project from this template
+- [Package Name Documentation](index.md) - Welcome and overview of the project
+- [Template Management](template/manage.md) - Unified interface for creating projects, checking updates, and syncing
+- [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
+- [Usage Guide](usage/basics.md) - Package usage and development workflows
+- [Using This Template](template/index.md) - Overview of using pyproject-template for your Python projects
+<!-- END:audience=users -->
 
 ### For Contributors
-1. [Coding Standards](development/coding-standards.md) - Follow these guidelines
-2. [CI/CD Testing](development/ci-cd-testing.md) - Understand the test pipeline
-3. [Release Automation](development/release-and-automation.md) - Learn the release process
+<!-- BEGIN:audience=contributors -->
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
+- [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
+- [API Reference](reference/api.md) - Complete API documentation for Package Name
+- [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
+- [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
+- [Package Name Documentation](index.md) - Welcome and overview of the project
+- [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
+- [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
+- [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
+<!-- END:audience=contributors -->
 
-### For Advanced Users
-1. [Extensions](development/extensions.md) - Extend the template
-2. [API Reference](reference/api.md) - Technical details
-3. [Template Management](template/manage.md) - Manage template sync
-4. [Migration Guide](template/migration.md) - Migrate existing projects
+### For AI Agents
+<!-- BEGIN:audience=ai-agents -->
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
+- [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
+- [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+<!-- END:audience=ai-agents -->
+
+## Complete Index
+<!-- BEGIN:all -->
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
+- [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
+- [API Reference](reference/api.md) - Complete API documentation for Package Name
+- [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
+- [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [Examples](examples/README.md) - Example scripts demonstrating how to use the package
+- [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
+- [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template
+- [New Project Setup](template/new-project.md) - Create a new Python project from this template
+- [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
+- [Package Name Documentation](index.md) - Welcome and overview of the project
+- [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
+- [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
+- [Template Management](template/manage.md) - Unified interface for creating projects, checking updates, and syncing
+- [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
+- [Usage Guide](usage/basics.md) - Package usage and development workflows
+- [Using This Template](template/index.md) - Overview of using pyproject-template for your Python projects
+<!-- END:all -->
 
 ---
 
 ## Contributing to Documentation
 
 When adding new documentation:
-1. Place files in the appropriate category directory
-2. Update this TABLE_OF_CONTENTS.md with a link to your new documentation
-3. Follow the documentation template format
-4. Include practical examples where applicable
-5. Link to related documentation
 
-## Documentation Standards
+1. Add frontmatter with `title`, `description`, `audience`, and `tags`:
+   ```yaml
+   ---
+   title: My New Guide
+   description: Short description for the index
+   audience:
+     - users
+     - contributors
+   tags:
+     - setup
+     - getting-started
+   ---
+   ```
 
-- Use clear, concise language
-- Include code examples
-- Add troubleshooting sections
-- Link to related documentation
-- Keep line length ≤100 characters
-- Use Markdown formatting consistently
+2. Place the file in the appropriate directory
 
----
+3. Run `python tools/generate_doc_toc.py` to update this index
 
-Last updated: 2025-12-29
+4. The pre-commit hook will also run automatically on commit

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -1,3 +1,15 @@
+---
+title: AI Agent Setup Guide
+description: Configure Claude, Gemini, and Codex for this project
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - setup
+  - configuration
+---
+
 # AI Agent Setup Guide
 
 This template includes pre-configured settings for multiple AI coding assistants.

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -1,3 +1,15 @@
+---
+title: AI Command Blocking
+description: Hooks that block dangerous commands from AI agents
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - security
+  - hooks
+---
+
 # AI CLI Hooks
 
 The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI).

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -1,3 +1,15 @@
+---
+title: AI Enforcement Principles
+description: How we enforce AI agent behavior in code and settings
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - enforcement
+  - hooks
+---
+
 # AI Enforcement Principles
 
 ## Core Principle

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -1,3 +1,15 @@
+---
+title: Claude Code Statusline
+description: Custom statusline showing git branch, Python version, and project info
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - claude
+  - configuration
+---
+
 # Claude Code Statusline
 
 The template includes a custom statusline for Claude Code sessions that provides useful context at a glance.

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -1,3 +1,14 @@
+---
+title: CI/CD Testing Guide
+description: GitHub Actions pipelines for testing, linting, and coverage
+audience:
+  - contributors
+tags:
+  - ci-cd
+  - testing
+  - github-actions
+---
+
 # CI/CD Testing Guide
 
 ## Overview

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,3 +1,14 @@
+---
+title: Python Project Coding Standards
+description: Guidelines for exceptions, typing, structure, testing, and documentation
+audience:
+  - contributors
+tags:
+  - coding-standards
+  - python
+  - best-practices
+---
+
 # Python Project Coding Standards
 
 ## Overview

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -1,3 +1,14 @@
+---
+title: Optional Extensions
+description: Additional tools and extensions for testing, security, and more
+audience:
+  - contributors
+tags:
+  - extensions
+  - tooling
+  - configuration
+---
+
 # Optional Extensions
 
 This guide covers optional tools and extensions that you can add to your project based on your specific needs.

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -1,3 +1,15 @@
+---
+title: Release Automation & Security
+description: Automated versioning, release management, and security tooling
+audience:
+  - contributors
+  - maintainers
+tags:
+  - release
+  - security
+  - automation
+---
+
 # Release Automation & Security
 
 This guide covers automated versioning, release management, governance validation, and security tooling available in this Python project template.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,3 +1,13 @@
+---
+title: Examples
+description: Example scripts demonstrating how to use the package
+audience:
+  - users
+tags:
+  - examples
+  - getting-started
+---
+
 # Examples
 
 This directory contains example scripts demonstrating how to use the package.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,3 +1,14 @@
+---
+title: Installation Guide
+description: How to install and set up your project
+audience:
+  - users
+  - contributors
+tags:
+  - getting-started
+  - setup
+---
+
 # Installation Guide
 
 ## For Template Users

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,14 @@
+---
+title: Package Name Documentation
+description: Welcome and overview of the project
+audience:
+  - users
+  - contributors
+tags:
+  - overview
+  - getting-started
+---
+
 # Package Name Documentation
 
 Welcome to the documentation for Package Name!

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,3 +1,14 @@
+---
+title: API Reference
+description: Complete API documentation for Package Name
+audience:
+  - users
+  - contributors
+tags:
+  - reference
+  - api
+---
+
 # API Reference
 
 Complete API documentation for Package Name.

--- a/docs/template/index.md
+++ b/docs/template/index.md
@@ -1,3 +1,13 @@
+---
+title: Using This Template
+description: Overview of using pyproject-template for your Python projects
+audience:
+  - users
+tags:
+  - template
+  - getting-started
+---
+
 # Using This Template
 
 This section covers how to use the pyproject-template for your Python projects.

--- a/docs/template/manage.md
+++ b/docs/template/manage.md
@@ -1,3 +1,13 @@
+---
+title: Template Management
+description: Unified interface for creating projects, checking updates, and syncing
+audience:
+  - users
+tags:
+  - template
+  - tooling
+---
+
 # Template Management
 
 The `manage.py` script provides a unified interface for all template operations. It auto-detects your project context and recommends appropriate actions.

--- a/docs/template/migration.md
+++ b/docs/template/migration.md
@@ -1,3 +1,13 @@
+---
+title: Migration Guide
+description: Migrate existing Python projects to use this template
+audience:
+  - users
+tags:
+  - template
+  - migration
+---
+
 # Migration Guide
 
 Bring your existing Python project into the pyproject-template.

--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -1,3 +1,14 @@
+---
+title: New Project Setup
+description: Create a new Python project from this template
+audience:
+  - users
+tags:
+  - template
+  - getting-started
+  - setup
+---
+
 # New Project Setup
 
 Create a new Python project from this template using either the automated or manual approach.

--- a/docs/template/tools-reference.md
+++ b/docs/template/tools-reference.md
@@ -1,3 +1,15 @@
+---
+title: Template Tools Reference
+description: Complete reference for all template tools in tools/pyproject_template/
+audience:
+  - users
+  - contributors
+tags:
+  - template
+  - reference
+  - tooling
+---
+
 # Template Tools Reference
 
 Complete reference for all template tools in `tools/pyproject_template/`.

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -1,3 +1,13 @@
+---
+title: Keeping Up to Date
+description: Stay in sync with improvements to the pyproject-template
+audience:
+  - users
+tags:
+  - template
+  - updates
+---
+
 # Keeping Up to Date
 
 Stay in sync with improvements to the pyproject-template.

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -1,3 +1,13 @@
+---
+title: Usage Guide
+description: Package usage and development workflows
+audience:
+  - users
+tags:
+  - usage
+  - getting-started
+---
+
 # Usage Guide
 
 This guide covers both package usage and development workflows.

--- a/dodo.py
+++ b/dodo.py
@@ -18,6 +18,7 @@ from tools.tasks.docs import (  # noqa: F401
     task_docs_build,
     task_docs_deploy,
     task_docs_serve,
+    task_docs_toc,
     task_spell_check,
 )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,6 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Documentation Index: TABLE_OF_CONTENTS.md
   - Getting Started:
       - Installation: getting-started/installation.md
   - Usage:
@@ -74,6 +73,7 @@ nav:
   - Reference:
       - API Reference: reference/api.md
   - Examples: examples/README.md
+  - All Documents: TABLE_OF_CONTENTS.md
 
 extra:
   social:

--- a/tools/generate_doc_toc.py
+++ b/tools/generate_doc_toc.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Generate categorized documentation TOC from frontmatter tags.
+
+This script scans markdown files in docs/, extracts frontmatter metadata,
+and generates categorized page lists in TABLE_OF_CONTENTS.md based on
+template markers.
+
+Template markers:
+    <!-- BEGIN:audience=users -->
+    <!-- END:audience=users -->
+
+    <!-- BEGIN:tag=security,ci-cd -->
+    <!-- END:tag=security,ci-cd -->
+
+    <!-- BEGIN:all -->
+    <!-- END:all -->
+
+Usage:
+    python tools/generate_doc_toc.py
+
+For full documentation, see issue #169.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+DOCS_DIR = Path("docs")
+TOC_FILE = DOCS_DIR / "TABLE_OF_CONTENTS.md"
+
+# Files to exclude from the TOC
+EXCLUDE_FILES = {
+    "TABLE_OF_CONTENTS.md",
+}
+
+# Pattern to match template markers
+# Matches: <!-- BEGIN:key=value,value2 --> or <!-- BEGIN:all -->
+MARKER_PATTERN = re.compile(
+    r"(<!-- BEGIN:(\w+)(?:=([^\s>]+))? -->)"  # Opening marker
+    r"(.*?)"  # Content between markers (non-greedy)
+    r"(<!-- END:\2(?:=\3)? -->)",  # Closing marker
+    re.DOTALL,
+)
+
+
+def extract_frontmatter(path: Path) -> dict:
+    """Extract YAML frontmatter from markdown file.
+
+    Args:
+        path: Path to markdown file.
+
+    Returns:
+        Dictionary of frontmatter metadata, empty if none found.
+    """
+    content = path.read_text(encoding="utf-8")
+
+    if not content.startswith("---"):
+        return {}
+
+    try:
+        # Find the closing ---
+        end_idx = content.index("---", 3)
+        frontmatter_str = content[3:end_idx]
+        return yaml.safe_load(frontmatter_str) or {}
+    except (ValueError, yaml.YAMLError):
+        return {}
+
+
+def get_title(path: Path, meta: dict) -> str:
+    """Get document title from frontmatter or first heading.
+
+    Args:
+        path: Path to markdown file.
+        meta: Frontmatter metadata dictionary.
+
+    Returns:
+        Document title string.
+    """
+    if "title" in meta:
+        return str(meta["title"])
+
+    content = path.read_text(encoding="utf-8")
+
+    # Skip frontmatter if present
+    if content.startswith("---"):
+        try:
+            end_idx = content.index("---", 3)
+            content = content[end_idx + 3 :]
+        except ValueError:
+            pass
+
+    # Find first heading
+    match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+    if match:
+        return match.group(1).strip()
+
+    return path.stem.replace("-", " ").replace("_", " ").title()
+
+
+def collect_docs() -> list[tuple[Path, dict]]:
+    """Collect all documentation files with their metadata.
+
+    Returns:
+        List of (path, metadata) tuples.
+    """
+    docs = []
+
+    for path in sorted(DOCS_DIR.rglob("*.md")):
+        if path.name in EXCLUDE_FILES:
+            continue
+
+        meta = extract_frontmatter(path)
+        docs.append((path, meta))
+
+    return docs
+
+
+def matches_filter(meta: dict, filter_key: str, filter_values: list[str]) -> bool:
+    """Check if document metadata matches the filter criteria.
+
+    Args:
+        meta: Document frontmatter metadata.
+        filter_key: Key to filter on ('audience', 'tag', 'tags', 'all').
+        filter_values: Values to match (OR logic).
+
+    Returns:
+        True if document matches filter.
+    """
+    if filter_key == "all":
+        return True
+
+    # Normalize 'tag' to 'tags'
+    key = "tags" if filter_key == "tag" else filter_key
+
+    doc_values = meta.get(key, [])
+
+    # Handle string values (convert to list)
+    if isinstance(doc_values, str):
+        doc_values = [doc_values]
+
+    # OR logic: match if any filter value is in doc values
+    return any(v in doc_values for v in filter_values)
+
+
+def generate_section(
+    docs: list[tuple[Path, dict]], filter_key: str, filter_values: list[str]
+) -> str:
+    """Generate markdown list for documents matching filter.
+
+    Args:
+        docs: List of (path, metadata) tuples.
+        filter_key: Key to filter on.
+        filter_values: Values to match.
+
+    Returns:
+        Markdown formatted list of matching documents.
+    """
+    lines = []
+
+    for path, meta in docs:
+        if not matches_filter(meta, filter_key, filter_values):
+            continue
+
+        rel_path = path.relative_to(DOCS_DIR)
+        title = get_title(path, meta)
+        description = meta.get("description", "")
+
+        line = f"- [{title}]({rel_path})"
+        if description:
+            line += f" - {description}"
+
+        lines.append((title.lower(), line))  # Sort key, line
+
+    # Sort alphabetically by title
+    lines.sort(key=lambda x: x[0])
+
+    if not lines:
+        return "*No documents in this category.*\n"
+
+    return "\n".join(line for _, line in lines) + "\n"
+
+
+def update_toc(docs: list[tuple[Path, dict]]) -> bool:
+    """Update TABLE_OF_CONTENTS.md with generated sections.
+
+    Args:
+        docs: List of (path, metadata) tuples.
+
+    Returns:
+        True if file was modified, False otherwise.
+    """
+    if not TOC_FILE.exists():
+        print(f"Warning: {TOC_FILE} not found, skipping TOC generation")
+        return False
+
+    original_content = TOC_FILE.read_text(encoding="utf-8")
+
+    def replace_marker(match: re.Match) -> str:
+        begin_marker = match.group(1)
+        filter_key = match.group(2)
+        filter_values_str = match.group(3) or ""
+        end_marker = match.group(5)
+
+        filter_values = [v.strip() for v in filter_values_str.split(",") if v.strip()]
+
+        section = generate_section(docs, filter_key, filter_values)
+
+        return f"{begin_marker}\n{section}{end_marker}"
+
+    new_content = MARKER_PATTERN.sub(replace_marker, original_content)
+
+    if new_content != original_content:
+        TOC_FILE.write_text(new_content, encoding="utf-8")
+        return True
+
+    return False
+
+
+def main() -> int:
+    """Main entry point.
+
+    Returns:
+        Exit code (0 for success/no changes, 1 for changes made).
+    """
+    print(f"Scanning {DOCS_DIR} for documentation files...")
+
+    docs = collect_docs()
+    print(f"Found {len(docs)} documentation files")
+
+    # Count docs with frontmatter
+    with_frontmatter = sum(1 for _, meta in docs if meta)
+    print(f"  - {with_frontmatter} with frontmatter")
+    print(f"  - {len(docs) - with_frontmatter} without frontmatter")
+
+    modified = update_toc(docs)
+
+    if modified:
+        print(f"Updated {TOC_FILE}")
+        return 1  # Return 1 to indicate changes (useful for pre-commit)
+    else:
+        print(f"No changes to {TOC_FILE}")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tasks/docs.py
+++ b/tools/tasks/docs.py
@@ -35,3 +35,12 @@ def task_spell_check() -> dict[str, Any]:
         "actions": ["uv run codespell src/ tests/ docs/ README.md"],
         "title": title_with_actions,
     }
+
+
+def task_docs_toc() -> dict[str, Any]:
+    """Generate documentation table of contents from frontmatter."""
+    return {
+        "actions": ["uv run python tools/generate_doc_toc.py"],
+        "title": title_with_actions,
+        "verbosity": 2,
+    }


### PR DESCRIPTION
## Description

Adds automatic generation of documentation table of contents based on frontmatter tags. This eliminates manual maintenance of the docs index - just add frontmatter to new docs and the TOC updates automatically.

## Related Issue

Closes #169

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **New script**: `tools/generate_doc_toc.py` - scans docs/, extracts frontmatter, generates categorized TOC
- **Frontmatter added**: All 19 docs now have `title`, `description`, `audience`, and `tags` metadata
- **Simplified TOC**: `docs/TABLE_OF_CONTENTS.md` reduced from 147 to 76 lines, uses template markers
- **Doit task**: `doit docs_toc` to manually regenerate TOC
- **Pre-commit hook**: Automatically updates TOC when docs change
- **Nav update**: Moved "All Documents" to end of mkdocs nav

### Frontmatter Schema

```yaml
---
title: Document Title
description: Short description for the index
audience:
  - users
  - contributors
  - ai-agents
tags:
  - ai
  - setup
---
```

### Template Markers

```markdown
<!-- BEGIN:audience=users -->
(auto-generated list)
<!-- END:audience=users -->
```

## Testing

- [x] All existing tests pass
- [x] Manually tested `doit docs_toc` task
- [x] Verified TOC generates correctly for all 19 docs
- [x] Tested pre-commit hook triggers on doc changes

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit check`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings