### PR TITLE
feat: block AI from adding ready-to-merge label

### DIFF
--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -183,6 +183,14 @@ These commands should use `doit` wrappers instead to ensure proper formatting an
 | `gh pr create` | `doit pr` | Ensures proper template format |
 | `gh pr merge` | `doit pr_merge` | Enforces merge commit format: `<type>: <subject> (merges PR #XX, closes #YY)` |
 
+#### Governance Labels
+
+Some labels are governance controls that require human approval. AI agents are blocked from adding these labels:
+
+| Label | Reason |
+|-------|--------|
+| `ready-to-merge` | Signals human approval that PR is ready for merge. Add manually via `gh pr edit --add-label ready-to-merge` or GitHub web UI. |
+
 ### Adding New Patterns
 
 Edit `tools/hooks/ai/block-dangerous-commands.py`:

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -91,6 +91,13 @@ EOF
     ("gh pr merge 123", "BLOCK", "gh pr merge"),
     ("gh pr merge --squash", "BLOCK", "gh pr merge squash"),
     ("gh pr merge 123 --squash --delete-branch", "BLOCK", "gh pr merge full"),
+    # === SHOULD BLOCK - Governance labels ===
+    ("gh pr edit 123 --add-label ready-to-merge", "BLOCK", "add ready-to-merge"),
+    ("gh pr edit --add-label ready-to-merge", "BLOCK", "add ready-to-merge no PR"),
+    ("gh issue edit 45 --add-label ready-to-merge", "BLOCK", "issue ready-to-merge"),
+    # === SHOULD ALLOW - Other labels ===
+    ("gh pr edit 123 --add-label bug", "ALLOW", "add bug label"),
+    ("gh pr edit 123 --add-label enhancement", "ALLOW", "add enhancement label"),
     # === SHOULD ALLOW - Other gh commands ===
     ("gh issue list", "ALLOW", "gh issue list"),
     ("gh pr list", "ALLOW", "gh pr list"),


### PR DESCRIPTION
## Description

Block AI agents from adding the `ready-to-merge` label. This label is a governance control that signals human approval - only maintainers should add it.

Closes #179

## Changes

- Add `GOVERNANCE_LABELS` constant with `ready-to-merge` and explanation
- Add `check_governance_labels()` function to detect when AI tries to add governance labels
- Block `gh pr edit --add-label ready-to-merge` and `gh issue edit --add-label ready-to-merge`
- Add 5 test cases (3 blocked, 2 allowed for other labels)
- Update `docs/development/ai/command-blocking.md` with governance labels section

## Test Plan

- [x] All 49 hook tests pass (including 5 new governance label tests)
- [x] All 191 unit tests pass
- [x] `doit check` passes