### PR TITLE
chore: use project's tool versions in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,34 +1,7 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
-    hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
-    hooks:
-      - id: mypy
-        additional_dependencies: [types-PyYAML]
-        args: [--ignore-missing-imports]
-        exclude: ^(\.claude/|\.gemini/|\.codex/|tools/pyproject_template/)
-
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
-    hooks:
-      - id: bandit
-        args: [-c, pyproject.toml]
-        additional_dependencies: ["bandit[toml]"]
-
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
-    hooks:
-      - id: codespell
-        additional_dependencies: [tomli]
-
+  # Generic file checks (not Python-specific, keep external)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -46,9 +19,48 @@ repos:
         stages: [commit-msg]
         args: [--strict]
 
-  # Local hooks for project-specific checks
+  # Local hooks using project's installed tools via uv
+  # This ensures version consistency with pyproject.toml
   - repo: local
     hooks:
+      # Python linting and formatting (uses project's ruff version)
+      - id: ruff
+        name: ruff
+        entry: uv run ruff check --fix
+        language: system
+        types: [python]
+
+      - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
+        types: [python]
+
+      # Type checking (uses project's mypy version)
+      # Only checks src/ to match doit type_check behavior
+      - id: mypy
+        name: mypy
+        entry: uv run mypy src/
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      # Security scanning (uses project's bandit version)
+      # Skips if bandit not installed (optional security extra)
+      - id: bandit
+        name: bandit
+        entry: bash -c 'command -v bandit &>/dev/null || uv run python -c "import bandit" 2>/dev/null || exit 0; uv run bandit -c pyproject.toml "$@"' --
+        language: system
+        types: [python]
+
+      # Spell checking (uses project's codespell version)
+      - id: codespell
+        name: codespell
+        entry: uv run codespell
+        language: system
+        types: [text]
+        exclude: ^(\.git/|\.venv/|uv\.lock)
+
       # Branch naming enforcement
       - id: check-branch-name
         name: Check branch naming convention

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ ignore = [
 "tools/pyproject_template/*.py" = [
     "E501",    # Line too long
     "RUF001",  # Ambiguous unicode
+    "RUF005",  # Tuple concatenation (stylistic preference)
+    "RUF022",  # __all__ not sorted (intentionally grouped by category)
     "SIM102",  # Nested if
 ]
 


### PR DESCRIPTION
## Description

Replace external pre-commit repos with local hooks using `uv run`. This ensures pre-commit uses the same tool versions installed via `pyproject.toml`, eliminating version drift and formatting inconsistencies between pre-commit and `doit` commands.

## Related Issue

Closes #184

## Type of Change

- [x] Configuration changes

## Changes Made

- Replace external ruff-pre-commit, mirrors-mypy, bandit, codespell repos with local hooks using `uv run`
- Update pre-commit-hooks to v5.0.0
- mypy now only checks `src/` (matches `doit type_check` behavior)
- bandit skips gracefully if not installed (optional security extra)
- Added RUF005/RUF022 to per-file-ignores for `tools/pyproject_template/` (new rules from updated ruff)

## Testing

- [x] All existing tests pass
- [x] `pre-commit run --all-files` passes
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
