### PR TITLE
chore: block uv add in AI agent hooks

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -80,6 +80,13 @@ pattern = "gh\\s+pr\\s+create"
 action = "deny"
 reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
 
+# Block uv add - dependencies require user approval
+[[approval_policy]]
+type = "command"
+pattern = "uv\\s+add"
+action = "deny"
+reason = "BLOCKED: Adding dependencies requires user approval. Suggest the package and let the user run 'uv add <package>' manually. See AGENTS.md."
+
 # =============================================================================
 # ALLOWED COMMANDS - Standard development tools
 # =============================================================================

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -175,13 +175,14 @@ Force push, delete, and merge operations are only blocked when targeting protect
 
 #### Blocked Workflow Commands
 
-These commands should use `doit` wrappers instead to ensure proper formatting and validation:
+These commands should use `doit` wrappers or require user approval:
 
 | Command | Use Instead | Reason |
 |---------|-------------|--------|
 | `gh issue create` | `doit issue --type=<type>` | Ensures proper template and labels |
 | `gh pr create` | `doit pr` | Ensures proper template format |
 | `gh pr merge` | `doit pr_merge` | Enforces merge commit format: `<type>: <subject> (merges PR #XX, closes #YY)` |
+| `uv add` | User runs manually | Dependencies require human approval - suggest package, let user run command |
 
 #### Governance Labels
 

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -180,6 +180,7 @@ These patterns are blocked across all AI agents. Claude and Gemini use the share
 | Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | — |
 | `gh pr create` | Use `doit pr` instead | Hook | Hook | Config |
 | `gh issue create` | Use `doit issue` instead | Hook | Hook | Config |
+| `uv add` | User runs manually | Hook | Hook | Config |
 
 > **Note**: "Hook" = `block-dangerous-commands.py`, "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
 
@@ -278,7 +279,6 @@ The following AGENTS.md rules are currently instruction-only and could benefit f
 | Rule | Current State | Potential Enforcement |
 |------|---------------|----------------------|
 | "Never edit `pyproject.toml` version" | Instruction only | Pre-commit hook to block changes to `dynamic =` line (see issue #163). Build process catches invalid static+dynamic via PEP 621. |
-| "Ask before adding new dependencies" | Instruction only | Block `uv add` in AI hooks - agent suggests, user runs manually (see issue #166) |
 | "Protect user config (`.envrc.local`, `settings.local.json`)" | Instruction only | Pre-commit hook to block commits containing files with `.local` or `.local.` in name (excluding `.local.example`). Matches `*.local`, `*.local.*` as distinct segments, not substrings (see issue #165). |
 
 ### Low Priority / Difficult to Automate

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -41,11 +41,15 @@ DANGEROUS_SEQUENCES = [
 # Force push flags
 FORCE_PUSH_FLAGS = {"--force", "-f", "--force-with-lease"}
 
-# Blocked workflow commands - use doit wrappers instead
+# Blocked workflow commands - use doit wrappers or require user approval
 BLOCKED_WORKFLOW_COMMANDS = {
     ("gh", "issue", "create"): "Use 'doit issue --type=<type>' instead of 'gh issue create'",
     ("gh", "pr", "create"): "Use 'doit pr' instead of 'gh pr create'",
     ("gh", "pr", "merge"): "Use 'doit pr_merge' instead of 'gh pr merge'",
+    ("uv", "add"): (
+        "Adding dependencies requires user approval. "
+        "Suggest the package and let the user run 'uv add <package>' manually."
+    ),
 }
 
 # Governance labels that require human approval - AI should never add these

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -91,6 +91,16 @@ EOF
     ("gh pr merge 123", "BLOCK", "gh pr merge"),
     ("gh pr merge --squash", "BLOCK", "gh pr merge squash"),
     ("gh pr merge 123 --squash --delete-branch", "BLOCK", "gh pr merge full"),
+    # === SHOULD BLOCK - uv add (dependencies require user approval) ===
+    ("uv add requests", "BLOCK", "uv add single package"),
+    ("uv add requests httpx", "BLOCK", "uv add multiple packages"),
+    ("uv add 'requests>=2.0'", "BLOCK", "uv add with version"),
+    ("uv add --dev pytest", "BLOCK", "uv add dev dependency"),
+    # === SHOULD ALLOW - Other uv commands ===
+    ("uv sync", "ALLOW", "uv sync"),
+    ("uv run pytest", "ALLOW", "uv run"),
+    ("uv pip list", "ALLOW", "uv pip list"),
+    ("uv remove requests", "ALLOW", "uv remove"),
     # === SHOULD BLOCK - Governance labels ===
     ("gh pr edit 123 --add-label ready-to-merge", "BLOCK", "add ready-to-merge"),
     ("gh pr edit --add-label ready-to-merge", "BLOCK", "add ready-to-merge no PR"),


### PR DESCRIPTION
## Description

Block `uv add` command in AI agent hooks to enforce the "Ask First" policy for new dependencies. AI agents can research and suggest packages, but users must run the command manually.

## Related Issue

Closes #166

## Type of Change

- [x] Configuration changes

## Changes Made

- Add `uv add` to `BLOCKED_WORKFLOW_COMMANDS` in `tools/hooks/ai/block-dangerous-commands.py`
- Add `uv add` denial rule to `.codex/config.toml`
- Add tests for `uv add` blocking and other `uv` commands (8 new test cases)
- Update `docs/development/ai/enforcement-principles.md` - add to blocked patterns table, remove from TODO
- Update `docs/development/ai/command-blocking.md` - add to blocked workflow commands table

## Testing

- [x] All existing tests pass
- [x] `python3 tools/hooks/ai/test_hook.py` passes (57 tests)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
