### PR TITLE
chore: add pre-commit hook to block local config files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,3 +120,26 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      # Prevent committing local config files
+      - id: no-local-config
+        name: Prevent committing local config files
+        entry: |
+          bash -c '
+          # Find staged files with .local or .local. in name (as distinct segment, not substring)
+          LOCAL_FILES=$(git diff --cached --name-only | grep -E "\.local$|\.local\." | grep -v "\.local\.example" || true)
+          if [[ -n "$LOCAL_FILES" ]]; then
+            echo "❌ ERROR: Local config files should not be committed!"
+            echo ""
+            echo "The following files appear to be user-specific configs:"
+            echo "$LOCAL_FILES" | sed "s/^/  - /"
+            echo ""
+            echo "These files are gitignored for a reason - they may contain"
+            echo "user-specific settings, paths, or sensitive data."
+            echo ""
+            echo "If this is a template, rename it to include .example (e.g., .envrc.local.example)"
+            exit 1
+          fi'
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -190,6 +190,7 @@ These patterns are blocked across all AI agents. Claude and Gemini use the share
 |------|------|--------|
 | No commits to `main` | `no-commit-to-main` | Blocks commit with guidance message |
 | Branch naming convention | `check-branch-name` | Requires `<type>/<issue#>-<description>` format |
+| No local config files | `no-local-config` | Blocks `*.local` and `*.local.*` files (allows `*.local.example`) |
 | Conventional commits | `conventional-pre-commit` | Requires `<type>: <subject>` format |
 | Code formatting | `ruff-format` | Auto-fixes formatting issues |
 | Linting | `ruff` | Auto-fixes linting issues |
@@ -279,7 +280,6 @@ The following AGENTS.md rules are currently instruction-only and could benefit f
 | Rule | Current State | Potential Enforcement |
 |------|---------------|----------------------|
 | "Never edit `pyproject.toml` version" | Instruction only | Pre-commit hook to block changes to `dynamic =` line (see issue #163). Build process catches invalid static+dynamic via PEP 621. |
-| "Protect user config (`.envrc.local`, `settings.local.json`)" | Instruction only | Pre-commit hook to block commits containing files with `.local` or `.local.` in name (excluding `.local.example`). Matches `*.local`, `*.local.*` as distinct segments, not substrings (see issue #165). |
 
 ### Low Priority / Difficult to Automate
 


### PR DESCRIPTION
## Description

Add a pre-commit hook to block committing user-specific config files that may contain sensitive data or user-specific settings.

## Related Issue

Closes #165

## Type of Change

- [x] Configuration changes

## Changes Made

- Add `no-local-config` hook to `.pre-commit-config.yaml`
- Blocks `*.local` files (e.g., `.envrc.local`)
- Blocks `*.local.*` files (e.g., `settings.local.json`)
- Allows `*.local.example*` files (templates are OK)
- Does not false-positive on `localizations.json` or similar (matches `.local` as distinct segment)
- Clear error message explains why and suggests `.example` suffix for templates
- Update documentation in `docs/development/ai/enforcement-principles.md`

## Testing

- [x] All existing tests pass
- [x] `pre-commit run no-local-config --all-files` passes
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
