### PR TITLE
chore: block doit release in AI agent hooks

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -87,6 +87,13 @@ pattern = "uv\\s+add"
 action = "deny"
 reason = "BLOCKED: Adding dependencies requires user approval. Suggest the package and let the user run 'uv add <package>' manually. See AGENTS.md."
 
+# Block doit release - releases must be run manually by the user
+[[approval_policy]]
+type = "command"
+pattern = "doit\\s+release"
+action = "deny"
+reason = "BLOCKED: Releases must be run manually by the user, not by AI agents. See AGENTS.md."
+
 # =============================================================================
 # ALLOWED COMMANDS - Standard development tools
 # =============================================================================

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -183,6 +183,7 @@ These commands should use `doit` wrappers or require user approval:
 | `gh pr create` | `doit pr` | Ensures proper template format |
 | `gh pr merge` | `doit pr_merge` | Enforces merge commit format: `<type>: <subject> (merges PR #XX, closes #YY)` |
 | `uv add` | User runs manually | Dependencies require human approval - suggest package, let user run command |
+| `doit release*` | User runs manually | Releases require human approval - AI can help prepare but not execute |
 
 #### Governance Labels
 

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -181,6 +181,7 @@ These patterns are blocked across all AI agents. Claude and Gemini use the share
 | `gh pr create` | Use `doit pr` instead | Hook | Hook | Config |
 | `gh issue create` | Use `doit issue` instead | Hook | Hook | Config |
 | `uv add` | User runs manually | Hook | Hook | Config |
+| `doit release*` | User runs manually | Hook | Hook | Config |
 
 > **Note**: "Hook" = `block-dangerous-commands.py`, "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
 
@@ -268,12 +269,6 @@ When blocking a command, provide an approved alternative when possible. This pro
 ## TODO: Potential Future Enforcement
 
 The following AGENTS.md rules are currently instruction-only and could benefit from automated enforcement:
-
-### High Priority
-
-| Rule | Current State | Potential Enforcement |
-|------|---------------|----------------------|
-| "Never run `doit release` without explicit command" | Instruction only | Hook to block `doit release` (see issue #164) |
 
 ### Medium Priority
 

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -50,6 +50,13 @@ BLOCKED_WORKFLOW_COMMANDS = {
         "Adding dependencies requires user approval. "
         "Suggest the package and let the user run 'uv add <package>' manually."
     ),
+    ("doit", "release"): (
+        "Releases must be run manually by the user, not by AI agents. "
+        "AI can help prepare (update changelog, verify CI) but not execute releases."
+    ),
+    ("doit", "release_dev"): "Releases must be run manually by the user, not by AI agents.",
+    ("doit", "release_tag"): "Releases must be run manually by the user, not by AI agents.",
+    ("doit", "release_pr"): "Releases must be run manually by the user, not by AI agents.",
 }
 
 # Governance labels that require human approval - AI should never add these

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -101,6 +101,17 @@ EOF
     ("uv run pytest", "ALLOW", "uv run"),
     ("uv pip list", "ALLOW", "uv pip list"),
     ("uv remove requests", "ALLOW", "uv remove"),
+    # === SHOULD BLOCK - doit release (releases require user to run manually) ===
+    ("doit release", "BLOCK", "doit release"),
+    ("doit release --dry-run", "BLOCK", "doit release dry-run"),
+    ("doit release_dev", "BLOCK", "doit release_dev"),
+    ("doit release_tag", "BLOCK", "doit release_tag"),
+    ("doit release_pr", "BLOCK", "doit release_pr"),
+    # === SHOULD ALLOW - Other doit commands ===
+    ("doit check", "ALLOW", "doit check"),
+    ("doit test", "ALLOW", "doit test"),
+    ("doit pr", "ALLOW", "doit pr"),
+    ("doit issue --type=bug", "ALLOW", "doit issue"),
     # === SHOULD BLOCK - Governance labels ===
     ("gh pr edit 123 --add-label ready-to-merge", "BLOCK", "add ready-to-merge"),
     ("gh pr edit --add-label ready-to-merge", "BLOCK", "add ready-to-merge no PR"),


### PR DESCRIPTION
## Description

Block `doit release` and all release variants in AI agent hooks. Releases are high-consequence operations that must be run manually by users. AI agents can help prepare (update changelog, verify CI) but cannot execute releases.

## Related Issue

Closes #164

## Type of Change

- [x] Configuration changes

## Changes Made

- Add `doit release`, `doit release_dev`, `doit release_tag`, `doit release_pr` to `BLOCKED_WORKFLOW_COMMANDS` in `tools/hooks/ai/block-dangerous-commands.py`
- Add `doit release` denial rule to `.codex/config.toml`
- Add 9 new test cases for release command blocking (66 total tests pass)
- Update `docs/development/ai/enforcement-principles.md` - add to blocked patterns table, remove from TODO
- Update `docs/development/ai/command-blocking.md` - add to blocked workflow commands table

## Testing

- [x] All existing tests pass
- [x] `python3 tools/hooks/ai/test_hook.py` passes (66 tests)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
