### PR TITLE
chore: add pre-commit hook to protect dynamic version config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,3 +143,23 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      # Protect dynamic version configuration
+      - id: protect-dynamic-version
+        name: Protect dynamic version configuration
+        entry: |
+          bash -c '
+          if git diff --cached --name-only | grep -q "^pyproject.toml$"; then
+            if git diff --cached pyproject.toml | grep -E "^[-+]dynamic\s*=" | grep -q .; then
+              echo "❌ ERROR: Changes to the dynamic field in pyproject.toml are not allowed!"
+              echo ""
+              echo "Version is managed dynamically via git tags."
+              echo "The dynamic = [\"version\"] setting should not be modified."
+              echo ""
+              echo "See AGENTS.md for details on version management."
+              exit 1
+            fi
+          fi'
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -192,6 +192,7 @@ These patterns are blocked across all AI agents. Claude and Gemini use the share
 | No commits to `main` | `no-commit-to-main` | Blocks commit with guidance message |
 | Branch naming convention | `check-branch-name` | Requires `<type>/<issue#>-<description>` format |
 | No local config files | `no-local-config` | Blocks `*.local` and `*.local.*` files (allows `*.local.example`) |
+| Protect dynamic version | `protect-dynamic-version` | Blocks changes to `dynamic =` in pyproject.toml |
 | Conventional commits | `conventional-pre-commit` | Requires `<type>: <subject>` format |
 | Code formatting | `ruff-format` | Auto-fixes formatting issues |
 | Linting | `ruff` | Auto-fixes linting issues |
@@ -269,12 +270,6 @@ When blocking a command, provide an approved alternative when possible. This pro
 ## TODO: Potential Future Enforcement
 
 The following AGENTS.md rules are currently instruction-only and could benefit from automated enforcement:
-
-### Medium Priority
-
-| Rule | Current State | Potential Enforcement |
-|------|---------------|----------------------|
-| "Never edit `pyproject.toml` version" | Instruction only | Pre-commit hook to block changes to `dynamic =` line (see issue #163). Build process catches invalid static+dynamic via PEP 621. |
 
 ### Low Priority / Difficult to Automate
 


### PR DESCRIPTION
## Description

Add a pre-commit hook to protect the `dynamic =` line in pyproject.toml. Version is managed via git tags, and the `dynamic = ["version"]` setting should not be modified manually.

## Related Issue

Closes #163

## Type of Change

- [x] Configuration changes

## Changes Made

- Add `protect-dynamic-version` hook to `.pre-commit-config.yaml`
- Blocks any changes to the `dynamic =` line in pyproject.toml
- Clear error message explains version is managed via git tags
- Update documentation in `docs/development/ai/enforcement-principles.md`

## Testing

- [x] All existing tests pass
- [x] `pre-commit run protect-dynamic-version --all-files` passes
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
