### PR TITLE
chore: add reminder to close issues after PR merge

### DIFF
--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -634,6 +634,21 @@ def task_pr_merge() -> dict[str, Any]:
                     border_style="green",
                 )
             )
+
+            # Reminder to close linked issues
+            if issues["closes"]:
+                close_commands = [
+                    f'gh issue close {issue} --comment "Fixed in PR #{pr_number}"'
+                    for issue in issues["closes"]
+                ]
+                console.print()
+                console.print(
+                    Panel.fit(
+                        "[bold yellow]Reminder: Close linked issues manually[/bold yellow]\n\n"
+                        + "\n".join(close_commands),
+                        border_style="yellow",
+                    )
+                )
         except subprocess.CalledProcessError as e:
             console.print("[red]Failed to merge PR.[/red]")
             if e.stderr:


### PR DESCRIPTION
## Description

Adds a reminder panel after successful `doit pr_merge` that shows the commands needed to close linked issues manually.

## Related Issue

Closes #193

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add yellow reminder panel after successful PR merge
- Shows `gh issue close` commands for each linked issue
- Only displays when there are issues to close (linked with "Closes #XX" syntax)

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This helps AI agents remember to close issues after merging PRs.
