### PR TITLE
docs: add automatic API documentation generation with mkdocstrings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -120,25 +120,41 @@ def process_items(items: List[str]) -> Dict[str, int]:
 
 ### Docstrings
 
-Use Google-style docstrings:
+Use Google-style docstrings. These are automatically extracted into the
+[API Reference](../docs/reference/api.md) documentation using mkdocstrings.
+
 ```python
-def example_function(param1: str, param2: int) -> bool:
+def example_function(param1: str, param2: int = 10) -> bool:
     """Short description of the function.
 
     Longer description if needed, explaining the purpose,
     behavior, and any important details.
 
     Args:
-        param1: Description of param1
-        param2: Description of param2
+        param1: Description of param1.
+        param2: Description of param2. Defaults to 10.
 
     Returns:
-        Description of return value
+        Description of return value.
 
     Raises:
-        ValueError: When param2 is negative
+        ValueError: When param2 is negative.
+
+    Examples:
+        >>> example_function("test", 5)
+        True
+        >>> example_function("", 10)
+        False
     """
 ```
+
+**Key points:**
+
+- Type hints go in signatures, not duplicated in docstrings
+- End descriptions with periods for consistency
+- Include `Examples` section for complex functions (used by doctests)
+- Document all public functions, classes, and methods
+- Module-level docstrings describe the module's purpose
 
 ### Code Organization
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -241,11 +241,18 @@ def test_processor_validation_error(processor: Processor) -> None:
 
 ## Documentation
 
-### Docstrings
+### Docstring Standards
+
+Docstrings are automatically extracted into the [API Reference](../reference/api.md)
+using [mkdocstrings](https://mkdocstrings.github.io/).
+
+**Requirements:**
 
 - Use **Google-style docstrings** for consistency
 - Document all public functions, classes, and modules
-- Include Args, Returns, Raises sections
+- Include Args, Returns, Raises, Examples sections as appropriate
+- Type hints go in signatures, not duplicated in docstrings
+- End descriptions with periods for consistency
 - Keep line length ≤100 characters
 
 **Example:**

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,91 +11,35 @@ tags:
 
 # API Reference
 
-Complete API documentation for Package Name.
+Complete API documentation for Package Name, auto-generated from source code docstrings.
+
+## Package Overview
+
+::: package_name
+    options:
+      show_root_heading: false
+      show_source: false
+      members: false
 
 ## Core Module
 
-### `package_name.core`
+The core module provides the main functionality of the package.
 
-Core functionality for the package.
+::: package_name.core
+    options:
+      show_root_heading: true
+      show_root_full_path: true
 
-#### Functions
+## Logging Module
 
-##### `greet()`
+Centralized logging configuration with console and structured file output.
 
-```python
-def greet(name: str = "World") -> str
-```
+::: package_name.logging
+    options:
+      show_root_heading: true
+      show_root_full_path: true
 
-Return a greeting message.
-
-**Parameters:**
-- `name` (str, optional): The name to greet. Defaults to "World".
-
-**Returns:**
-- `str`: A greeting message string.
-
-**Example:**
-
-```python
-from package_name import greet
-
-# Default greeting
-message = greet()
-print(message)  # Output: "Hello, World!"
-
-# Custom greeting
-message = greet("Python")
-print(message)  # Output: "Hello, Python!"
-```
-
-**Doctests:**
-
-```python
->>> greet()
-'Hello, World!'
->>> greet("Python")
-'Hello, Python!'
-```
-
-## Package Metadata
-
-### `__version__`
-
-```python
-from package_name import __version__
-```
-
-The current version of the package as a string.
-
-**Example:**
-
-```python
-import package_name
-print(package_name.__version__)  # Derived from the git tag by hatch-vcs
-```
-
-## Module Structure
-
-The package is organized as follows:
-
-```
-package_name/
-├── __init__.py      # Package initialization, exports greet and __version__
-├── _version.py      # Version information (generated from git tags at build time)
-└── core.py          # Core functionality (greet function)
-```
-
-## Type Hints
-
-All public APIs include type hints for better IDE support and type checking:
-
-```python
-from package_name import greet
-
-# Type checkers will infer the correct types
-message: str = greet("Python")
-```
+---
 
 ## Extending the Package
 
@@ -109,7 +53,18 @@ This template provides a starting point. To add your own functionality:
    """New module description."""
 
    def new_function(param: str) -> str:
-       """Function documentation."""
+       """Process a parameter.
+
+       Args:
+           param: The input parameter.
+
+       Returns:
+           The processed result.
+
+       Examples:
+           >>> new_function("test")
+           'Processed: test'
+       """
        return f"Processed: {param}"
    ```
 
@@ -120,105 +75,61 @@ This template provides a starting point. To add your own functionality:
    __all__ = ["__version__", "greet", "new_function"]
    ```
 
-3. Add tests in `tests/`:
-   ```python
-   # tests/test_new_module.py
-   from package_name import new_function
+3. Add documentation to this file:
+   ```markdown
+   ## New Module
 
-   def test_new_function() -> None:
-       """Test new_function."""
-       assert new_function("test") == "Processed: test"
+   ::: package_name.new_module
    ```
 
-### Adding Exception Classes
+4. Add tests in `tests/`.
+
+### Docstring Format
+
+This project uses **Google-style docstrings**. See the
+[Docstring Standards](../development/coding-standards.md#docstring-standards) for the full format.
+
+Quick reference:
 
 ```python
-# src/package_name/exceptions.py
-"""Package exceptions."""
+def example_function(param1: str, param2: int = 10) -> dict[str, Any]:
+    """Short description of the function.
 
-class PackageError(Exception):
-    """Base exception for package errors."""
-    pass
+    Longer description if needed, explaining the behavior
+    in more detail.
 
-class ValidationError(PackageError):
-    """Raised when validation fails."""
-    pass
+    Args:
+        param1: Description of param1.
+        param2: Description of param2. Defaults to 10.
+
+    Returns:
+        Description of what is returned.
+
+    Raises:
+        ValueError: When param1 is empty.
+
+    Examples:
+        >>> example_function("test")
+        {'result': 'test', 'count': 10}
+    """
 ```
 
-Export them:
+## Type Hints
+
+All public APIs include type hints for better IDE support and type checking:
 
 ```python
-# src/package_name/__init__.py
-from .exceptions import PackageError, ValidationError
+from package_name import greet
 
-__all__ = [
-    "__version__",
-    "greet",
-    "PackageError",
-    "ValidationError",
-]
+# Type checkers will infer the correct types
+message: str = greet("Python")
 ```
 
-### Adding CLI Support
+Run mypy to verify type hints:
 
-1. Add `click` or `typer` to dependencies in `pyproject.toml`
-
-2. Create CLI module:
-   ```python
-   # src/package_name/cli.py
-   """Command-line interface."""
-   import click
-   from . import greet
-
-   @click.command()
-   @click.argument("name", default="World")
-   def main(name: str) -> None:
-       """Greet someone."""
-       click.echo(greet(name))
-   ```
-
-3. Add entry point in `pyproject.toml`:
-   ```toml
-   [project.scripts]
-   package-cli = "package_name.cli:main"
-   ```
-
-## Documentation Best Practices
-
-When adding new functions or classes:
-
-1. **Always include type hints**:
-   ```python
-   def process(data: str, validate: bool = True) -> dict[str, Any]:
-       """Process data."""
-   ```
-
-2. **Write comprehensive docstrings**:
-   ```python
-   def process(data: str, validate: bool = True) -> dict[str, Any]:
-       """Process input data.
-
-       Args:
-           data: The input data to process.
-           validate: Whether to validate the data. Defaults to True.
-
-       Returns:
-           A dictionary containing the processed results.
-
-       Raises:
-           ValueError: If validation fails and validate is True.
-
-       Example:
-           >>> process("test")
-           {'result': 'test'}
-       """
-   ```
-
-3. **Include examples in docstrings**
-
-4. **Update this API documentation**
-
-5. **Add tests for all new functionality**
+```bash
+uv run mypy src/
+```
 
 ## Testing
 
@@ -226,31 +137,8 @@ All public APIs should have comprehensive tests:
 
 ```bash
 # Run all tests
-uv run pytest -v
+doit test
 
 # Run with coverage
 uv run pytest --cov=package_name --cov-report=term-missing
-
-# Run specific test
-uv run pytest tests/test_example.py::test_version -v
 ```
-
-## Type Checking
-
-Run mypy to verify type hints:
-
-```bash
-# Check entire source
-uv run mypy src/
-
-# Check specific file
-uv run mypy src/package_name/core.py
-```
-
-## Changelog
-
-See [CHANGELOG.md](https://github.com/username/package_name/blob/main/CHANGELOG.md) for version history and changes.
-
-## Contributing
-
-See [CONTRIBUTING.md](https://github.com/username/package_name/blob/main/.github/CONTRIBUTING.md) for information on contributing to the API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,20 @@ theme:
 
 plugins:
   - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_signature_annotations: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            merge_init_into_class: true
+            show_root_heading: true
+            show_root_full_path: false
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "mypy>=1.0",
     "pre-commit>=3.7.0",
     "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.24",
     "codespell>=2.2",
     "pyproject-fmt>=2.0",
     "commitizen>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,18 @@ wheels = [
 ]
 
 [[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -639,6 +651,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -681,6 +707,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/ec/680e3bc7c88704d3fb9c658a517ec10f2f2aed3b9340136978675e581688/mkdocstrings-1.0.1.tar.gz", hash = "sha256:caa7d311c85ac0a0674831725ecfdeee4348e3b8a2c91ab193ee319a41dbeb3d", size = 100794, upload-time = "2026-01-19T11:36:24.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/f9/ecd3e5cf258d63eddc13e354bd090df3aa458b64be50d737d52a8ad9df22/mkdocstrings-1.0.1-py3-none-any.whl", hash = "sha256:10deb908e310e6d427a5b8f69026361dac06b77de860f46043043e26f121db02", size = 35245, upload-time = "2026-01-19T11:36:23.067Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/75/d30af27a2906f00eb90143470272376d728521997800f5dce5b340ba35bc/mkdocstrings_python-2.0.1.tar.gz", hash = "sha256:843a562221e6a471fefdd4b45cc6c22d2607ccbad632879234fa9692e9cf7732", size = 199345, upload-time = "2025-12-03T14:26:11.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/06/c5f8deba7d2cbdfa7967a716ae801aa9ca5f734b8f54fd473ef77a088dbe/mkdocstrings_python-2.0.1-py3-none-any.whl", hash = "sha256:66ecff45c5f8b71bf174e11d49afc845c2dfc7fc0ab17a86b6b337e0f24d8d90", size = 105055, upload-time = "2025-12-03T14:26:10.184Z" },
 ]
 
 [[package]]
@@ -791,6 +853,7 @@ dev = [
     { name = "codespell" },
     { name = "commitizen" },
     { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyproject-fmt" },
@@ -817,6 +880,7 @@ requires-dist = [
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "doit", specifier = ">=0.36.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pip-audit", marker = "extra == 'security'", specifier = ">=2.6" },
     { name = "pip-licenses", marker = "extra == 'security'", specifier = ">=4.0" },


### PR DESCRIPTION
## Description

Integrate mkdocstrings for automatic API documentation generation from source code docstrings.

## Related Issue

Closes #86

## Type of Change

- [x] Documentation update
- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `mkdocstrings[python]>=0.24` to dev dependencies
- Configure mkdocstrings plugin in `mkdocs.yml` with:
  - Google-style docstring parsing
  - Source code links
  - Signature type annotations
  - Symbol type headings
- Update `docs/reference/api.md` to use mkdocstrings `::: module` syntax for auto-generation
- Enhance docstring documentation in `.github/CONTRIBUTING.md` with:
  - Reference to mkdocstrings
  - Examples section in docstrings
  - Key points for documentation
- Update `docs/development/coding-standards.md` with:
  - Renamed to "Docstring Standards" with anchor
  - Link to mkdocstrings
  - Type hints guidance

## Testing

- [x] All existing tests pass
- [x] `mkdocs build` succeeds with new configuration
- [x] Manually reviewed generated documentation

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly

## Additional Notes

API documentation is now auto-generated from:
- `package_name` (package overview)
- `package_name.core` (greet function)
- `package_name.logging` (logging classes and functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
