### PR TITLE
fix: add permissions for PR comments in breaking-change-detection workflow

### DIFF
--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, edited]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   detect-breaking-changes:
     name: Detect API Breaking Changes


### PR DESCRIPTION
## Description

Add permissions block to the breaking-change-detection workflow to allow posting comments to PRs when breaking changes are detected.

## Related Issue

Closes #202

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `permissions` block to `.github/workflows/breaking-change-detection.yml`
- Grants `contents: read`, `issues: write`, and `pull-requests: write` permissions

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes (ran `doit check`)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings