### PR TITLE
chore: suppress doit check subtask output on success

### DIFF
--- a/tools/doit/docs.py
+++ b/tools/doit/docs.py
@@ -34,6 +34,7 @@ def task_spell_check() -> dict[str, Any]:
     return {
         "actions": ["uv run codespell src/ tests/ docs/ README.md"],
         "title": title_with_actions,
+        "verbosity": 0,
     }
 
 

--- a/tools/doit/quality.py
+++ b/tools/doit/quality.py
@@ -12,6 +12,7 @@ def task_lint() -> dict[str, Any]:
     return {
         "actions": ["uv run ruff check src/ tests/"],
         "title": title_with_actions,
+        "verbosity": 0,
     }
 
 
@@ -31,6 +32,7 @@ def task_format_check() -> dict[str, Any]:
     return {
         "actions": ["uv run ruff format --check src/ tests/"],
         "title": title_with_actions,
+        "verbosity": 0,
     }
 
 
@@ -40,6 +42,7 @@ def task_type_check() -> dict[str, Any]:
     return {
         "actions": [cmd],
         "title": title_with_actions,
+        "verbosity": 0,
     }
 
 

--- a/tools/doit/security.py
+++ b/tools/doit/security.py
@@ -24,6 +24,7 @@ def task_security() -> dict[str, Any]:
             "echo 'bandit not installed. Run: uv sync --extra security'"
         ],
         "title": title_with_actions,
+        "verbosity": 0,
     }
 
 

--- a/tools/doit/testing.py
+++ b/tools/doit/testing.py
@@ -10,6 +10,7 @@ def task_test() -> dict[str, Any]:
     return {
         "actions": ["uv run pytest -n auto -v"],
         "title": title_with_actions,
+        "verbosity": 0,
     }
 
 


### PR DESCRIPTION
## Description

Set `verbosity: 0` on `doit check` subtasks so their output is only displayed when a task fails. This reduces noise when all checks pass, making it easier to spot failures.

## Related Issue

Closes #205

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Added `"verbosity": 0` to `task_format_check`, `task_lint`, `task_type_check` in `tools/doit/quality.py`
- Added `"verbosity": 0` to `task_security` in `tools/doit/security.py`
- Added `"verbosity": 0` to `task_spell_check` in `tools/doit/docs.py`
- Added `"verbosity": 0` to `task_test` in `tools/doit/testing.py`

## Testing

- [x] All existing tests pass
- [x] Verified `doit check` output is clean on success
- [x] Subtask output will still be shown on failure (doit framework behavior)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings