### PR TITLE
chore: update GitHub Actions versions and add workflow_dispatch to CI

### DIFF
--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -14,14 +14,14 @@ jobs:
     name: Detect API Breaking Changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history for comparison
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
   workflow_call:
 
 permissions:
@@ -17,7 +18,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: .github/python-versions.json
           sparse-checkout-cone-mode: false
@@ -70,13 +71,13 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v1
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -37,7 +37,7 @@ jobs:
     name: Validate Issue Link
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v1
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -19,15 +19,15 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v1
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 


### PR DESCRIPTION
## Description

Update all GitHub Actions to latest versions and add manual trigger capability to CI workflow, synchronizing with infrafoundry's action versions.

Closes #208

## Type of Change

- [x] Code refactoring

## Changes Made

- `actions/checkout`: v4 → v6 (all workflows)
- `actions/setup-python`: v5 → v6 (ci, release, testpypi, breaking-change-detection)
- `astral-sh/setup-uv`: v1 → v7 (ci, release, testpypi)
- Added `workflow_dispatch` trigger to `ci.yml` for manual CI runs

## Testing

- [x] All existing tests pass
- [x] `doit check` passes
- [x] CI will validate the new action versions work correctly

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings