### PR TITLE
refactor: make pr_merge reminder unconditional and generic

### DIFF
--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -636,20 +636,17 @@ def task_pr_merge() -> dict[str, Any]:
                 )
             )
 
-            # Reminder to close linked issues
-            if issues["closes"]:
-                close_commands = [
-                    f'gh issue close {issue} --comment "Fixed in PR #{pr_number}"'
-                    for issue in issues["closes"]
-                ]
-                console.print()
-                console.print(
-                    Panel.fit(
-                        "[bold yellow]Reminder: Close linked issues manually[/bold yellow]\n\n"
-                        + "\n".join(close_commands),
-                        border_style="yellow",
-                    )
+            # Reminder to update linked issues
+            console.print()
+            console.print(
+                Panel.fit(
+                    "[bold yellow]Reminder: Update linked issues[/bold yellow]\n\n"
+                    "Examples:\n"
+                    f'  gh issue close <number> --comment "Fixed in PR #{pr_number}"\n'
+                    f'  gh issue comment <number> --body "Addressed in PR #{pr_number}"',
+                    border_style="yellow",
                 )
+            )
         except subprocess.CalledProcessError as e:
             console.print("[red]Failed to merge PR.[/red]")
             if e.stderr:


### PR DESCRIPTION
## Description

Replace the conditional closes-only reminder panel with an unconditional one that always displays after a successful merge, showing example commands for both closing and commenting on issues.

## Related Issue

Closes #213

## Type of Change

- [x] Code refactoring

## Changes Made

- Removed conditional `if issues["closes"]:` block that only showed close commands
- Added unconditional reminder panel with generic header "Reminder: Update linked issues"
- Panel now shows example commands for both `gh issue close` and `gh issue comment` using `<number>` placeholders

## Testing

- [x] All existing tests pass
- [x] `doit check` passes (format, lint, type_check, security, spell_check, test)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings