### PR TITLE
feat: add --sync mode to bootstrap.py for existing projects

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -26,6 +26,7 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Base URL for raw files
 REPO_OWNER = "endavis"
@@ -104,11 +105,10 @@ def detect_project_settings(project_root: Path) -> dict[str, str]:
                 settings["author_email"] = first["email"]
 
         repo_url = project.get("urls", {}).get("Repository", "")
-        if "github.com" in repo_url:
-            # Parse github.com/user/repo from URL
-            parts = repo_url.rstrip("/").split("github.com/")
-            if len(parts) == 2:
-                segments = parts[1].split("/")
+        if repo_url:
+            parsed = urlparse(repo_url)
+            if parsed.netloc == "github.com" or parsed.netloc.endswith(".github.com"):
+                segments = parsed.path.strip("/").split("/")
                 if len(segments) >= 2:
                     settings["github_user"] = segments[0]
                     settings["github_repo"] = segments[1].removesuffix(".git")

--- a/tests/pyproject_template/test_bootstrap.py
+++ b/tests/pyproject_template/test_bootstrap.py
@@ -172,6 +172,30 @@ class TestDetectProjectSettings:
         result = detect_project_settings(tmp_path)
         assert result == {}
 
+    def test_rejects_non_github_url_with_github_in_path(self, tmp_path: Path) -> None:
+        """Test that URLs with github.com in path (not host) are rejected."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[project.urls]\nRepository = "https://evil.com/github.com/user/repo"\n'
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert "github_user" not in result
+        assert "github_repo" not in result
+
+    def test_accepts_github_subdomain(self, tmp_path: Path) -> None:
+        """Test that GitHub subdomain URLs are accepted."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n'
+            '[project.urls]\nRepository = "https://www.github.com/myuser/myrepo"\n'
+        )
+
+        result = detect_project_settings(tmp_path)
+        assert result["github_user"] == "myuser"
+        assert result["github_repo"] == "myrepo"
+
     def test_underscore_name_converted_to_hyphen_for_pypi(self, tmp_path: Path) -> None:
         """Test that underscores in name become hyphens for pypi_name."""
         pyproject = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Description

Adds a `--sync` flag to `bootstrap.py` that downloads the template management suite permanently to `tools/pyproject_template/` for existing downstream projects. This enables a single-command installation:

```bash
curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3 - --sync
```

## Related Issue

Closes #216

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `argparse` CLI parsing with `--sync` flag
- Defined `SETUP_FILES` and `SYNC_FILES` as constants for maintainability
- New `run_sync()`: downloads management suite, detects settings from `pyproject.toml`, creates `settings.toml`, verifies installation
- New helpers: `detect_project_settings()`, `create_settings_file()`
- Existing default mode unchanged, refactored into `run_setup()`
- Handles existing installations with overwrite prompt

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (32 tests)
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings