### PR TITLE
docs: clarify PR/issue workflow and Merge Gate in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,9 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 - **Tests:** Creating code = Creating tests. No exceptions.
 - **Commits:** One logical change per commit. Use conventional commits.
 - **Releases:** Never run `doit release` without explicit command.
-- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format.
-- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Fixed in PR #XXX".
+- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed.
+- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation.
+- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Fixed in PR #XXX". Issues are not closed automatically when PRs are merged.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 
 ## Workflow Commands (for AI agents)


### PR DESCRIPTION
## Description

Clarifies AI agent workflow rules in AGENTS.md Critical Reminders section to prevent common mistakes.

## Related Issue

Closes #229

## Type of Change

- [x] Documentation update

## Changes Made

- Clarify that issues are not automatically closed when PRs merge; AI agents should ask the user if they want the issue closed
- Add reminder that Merge Gate action is manual and requires `ready-to-merge` label (should never be added by automation)
- Reinforce that issues must be manually closed after PR merge

## Testing

- [x] All existing tests pass
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings