### PR TITLE
fix: resolve pip CVE-2026-1703 failing CI pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: uv run codespell src/ tests/ docs/ README.md
 
       - name: Run dependency audit
-        run: uv run pip-audit
+        run: uv run pip-audit --skip-editable
 
       - name: Run tests with coverage
         run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 security = [
     "pip-audit>=2.6",
     "bandit>=1.7",
+    "pip>=26.0",
     "pip-licenses>=4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -869,6 +869,7 @@ dev = [
 ]
 security = [
     { name = "bandit" },
+    { name = "pip" },
     { name = "pip-audit" },
     { name = "pip-licenses" },
 ]
@@ -882,6 +883,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "pip", marker = "extra == 'security'", specifier = ">=26.0" },
     { name = "pip-audit", marker = "extra == 'security'", specifier = ">=2.6" },
     { name = "pip-licenses", marker = "extra == 'security'", specifier = ">=4.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
@@ -937,11 +939,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "25.3"
+version = "26.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/6e/74a3f0179a4a73a53d66ce57fdb4de0080a8baa1de0063de206d6167acc2/pip-25.3.tar.gz", hash = "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343", size = 1803014, upload-time = "2025-10-25T00:55:41.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/3c/d717024885424591d5376220b5e836c2d5293ce2011523c9de23ff7bf068/pip-25.3-py3-none-any.whl", hash = "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd", size = 1778622, upload-time = "2025-10-25T00:55:39.247Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

CI fails on all OS/Python matrix combinations because `pip-audit` detects CVE-2026-1703 in `pip 25.3` (fix version: 26.0).

## Related Issue

Closes #238

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `pip>=26.0` to `security` optional dependencies in `pyproject.toml` to pin pip above the vulnerable version
- Added `--skip-editable` to CI `pip-audit` step to align with `doit audit` behavior and eliminate spurious PyPI warning
- Updated `uv.lock` (pip 25.3 → 26.0.1)

## Testing

- [x] All existing tests pass
- [x] `doit check` passes
- [x] `uv run pip-audit --skip-editable` reports no known vulnerabilities

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings