### PR TITLE
feat: add workflow commands for issue lifecycle

### DIFF
--- a/.claude/commands/close-issue.md
+++ b/.claude/commands/close-issue.md
@@ -1,0 +1,86 @@
+# Close Issue
+
+Close GitHub issue #$ARGUMENTS after verifying its PR has been merged, and handle related issues.
+
+## Instructions
+
+### Step 1: Verify the PR is merged
+
+1. **Find PRs that reference this issue:**
+   ```bash
+   gh pr list --state merged --search "$ARGUMENTS" --json number,title,body,mergedAt
+   ```
+   Also check:
+   ```bash
+   gh pr list --state merged --search "Addresses #$ARGUMENTS" --json number,title,body,mergedAt
+   ```
+
+2. **If no merged PR is found:**
+   - Tell the user no merged PR was found for issue #$ARGUMENTS
+   - Ask if they want to proceed anyway or check the PR status
+   - Do NOT close the issue without a merged PR unless the user explicitly confirms
+
+### Step 2: Update issue task checkboxes
+
+1. **Fetch the current issue body:**
+   ```bash
+   gh issue view $ARGUMENTS --json body
+   ```
+
+2. **Check for task checkboxes** (`- [ ]` items) in the issue body.
+
+3. **If task checkboxes exist:**
+   - Review each task against the merged PR changes
+   - Mark completed tasks as `- [x]`
+   - Update the issue body with checked-off tasks:
+     ```bash
+     gh issue edit $ARGUMENTS --body "<updated body>"
+     ```
+   - Tell the user which tasks were marked complete and which remain unchecked (if any)
+
+4. **If unchecked tasks remain**, ask the user:
+   > "Some tasks in issue #$ARGUMENTS are not yet complete: <list>. Close anyway?"
+   - Wait for user confirmation before proceeding
+
+### Step 3: Close the primary issue
+
+1. **Add a closing comment:**
+   ```bash
+   gh issue comment $ARGUMENTS --body "Addressed in PR #<pr-number>"
+   ```
+
+2. **Close the issue:**
+   ```bash
+   gh issue close $ARGUMENTS
+   ```
+
+3. **Confirm** to the user that issue #$ARGUMENTS has been closed.
+
+### Step 4: Find and handle related issues
+
+1. **Scan all merged PRs** for this issue to find referenced issues:
+   ```bash
+   gh pr view <pr-number> --json body,comments
+   ```
+   Search the PR body and comments for patterns like:
+   - `Addresses #N`
+   - `Part of #N`
+   - `Related to #N`
+   - `Closes #N`
+   - `Fixes #N`
+   - `References #N`
+   - `#N` (bare issue references)
+
+   Exclude the primary issue (#$ARGUMENTS) from this list.
+
+2. **For each related issue found:**
+   - Fetch its current state: `gh issue view <N> --json state,title`
+   - Skip issues that are already closed
+   - For each **open** related issue, ask the user:
+     > "Issue #N: <title> is still open and was referenced in PR #<pr>. Would you like to close it?"
+   - If the user says yes, close it with comment "Addressed in PR #<pr-number>"
+   - If the user says no, move to the next one
+
+3. **Summary:** After processing all related issues, show the user a summary:
+   - Issues closed in this session
+   - Issues left open

--- a/.claude/commands/finalize.md
+++ b/.claude/commands/finalize.md
@@ -1,0 +1,84 @@
+# Finalize
+
+Finalize the current branch: update documentation, commit changes, and create a PR.
+
+## Instructions
+
+This command operates on the current branch. It assumes implementation and review are complete.
+
+### Step 1: Gather context
+
+In the main context (lightweight reads):
+
+1. **Detect the current branch and linked issue:**
+   ```bash
+   git branch --show-current
+   ```
+   Extract the issue number from the branch name (e.g., `feat/245-description` → `#245`).
+   - If on `main`, tell the user they need to be on a feature branch and stop.
+
+2. **Get the issue details:**
+   ```bash
+   gh issue view <number> --json title,labels
+   ```
+
+3. **Check for uncommitted changes:**
+   ```bash
+   git status --short
+   ```
+   - If there are unstaged or uncommitted changes (e.g., from the review/fix cycle), list them for the user
+   - These will be included in the commit — confirm with the user that all changes should be included
+
+4. **Check what changed vs main:**
+   ```bash
+   git diff main --stat
+   ```
+
+### Step 2: Spawn a finalization agent
+
+Use the Task tool with `subagent_type: "general-purpose"` and provide it with the branch name, issue number, issue title, labels, and the list of changed files. The agent should:
+
+1. **Read the project rules:**
+   - Read `AGENTS.md` — understand commit guidelines, PR checklist, ADR requirements
+   - Read `.github/CONTRIBUTING.md` — understand commit format
+   - Read `.github/pull_request_template.md` — understand PR structure
+
+2. **Check documentation needs:**
+   - Review the changed files — do any user-facing behaviors change?
+   - If yes, identify which docs in `docs/` need updating and update them
+   - Check `docs/decisions/` for related ADRs that need updating
+
+3. **Check ADR needs:**
+   - If the issue has the `needs-adr` label, create an ADR using `doit adr`
+   - If the changes relate to an existing ADR, update it with the issue link
+   - Every ADR must link to documentation in `docs/`
+
+4. **Run final validation:**
+   - Run: `doit check`
+   - ALL checks must pass before proceeding
+
+5. **Draft the PR description** and write it to a temp file:
+   - Read `.github/pull_request_template.md` for structure
+   - Write the PR body to `/tmp/pr-body.md`
+   - The body MUST include `Addresses #<issue-number>`
+
+6. **Return** a summary of:
+   - Documentation changes made (if any)
+   - ADR changes made (if any)
+   - Suggested commit message following conventional format: `<type>: <subject>`
+   - Suggested PR title following conventional format: `<type>: <subject>`
+   - Path to the PR body file (`/tmp/pr-body.md`)
+
+### Step 3: Commit and create PR
+
+After the agent returns, in the main context:
+
+1. **Show the user** the suggested commit message and PR description
+2. **Ask the user** for approval to commit and create the PR
+3. **Only after user confirms:**
+   - Stage files: `git add <specific files>` (include all changed files from implementation and review/fix cycle)
+   - Commit with the approved message
+   - Create PR: `doit pr --title="<type>: <subject>" --body-file=/tmp/pr-body.md`
+4. **Report** the PR URL to the user
+
+**IMPORTANT:** Do NOT commit or create the PR without explicit user confirmation.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,101 @@
+# Implement Issue
+
+Implement the plan for GitHub issue #$ARGUMENTS.
+
+## Instructions
+
+You MUST delegate the implementation to an agent (Task tool) to keep the main conversation context clean. The agent does all the coding. You receive the summary for user review.
+
+### Step 1: Validate preconditions
+
+1. **Verify the issue exists and is open:**
+   ```bash
+   gh issue view $ARGUMENTS --json number,title,state,labels
+   ```
+   - If the issue does not exist or is closed, tell the user and stop.
+
+2. **Verify a plan comment exists:**
+   Fetch all comments and search for the plan header:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep "## Implementation Plan for"
+   ```
+   - If no plan comment is found, tell the user:
+     > "No implementation plan found for issue #$ARGUMENTS. Run `/plan-issue $ARGUMENTS` first."
+   - Stop and wait for the user.
+
+3. **Check current branch state:**
+   ```bash
+   git branch --show-current
+   git status --short
+   ```
+   - If already on a branch matching `*/$ARGUMENTS-*` (e.g., `feat/$ARGUMENTS-description`):
+     - Tell the user you're resuming work on the existing branch
+     - Skip branch creation (Step 2)
+     - If there are uncommitted changes, warn the user and ask how to proceed
+   - If on `main` or a different branch: proceed to Step 2
+
+### Step 2: Create the branch
+
+Only if not already on the correct branch:
+
+1. Fetch the issue to determine the branch type:
+   ```bash
+   gh issue view $ARGUMENTS --json title,labels
+   ```
+2. Determine branch type from labels:
+   - `enhancement` → `feat`
+   - `bug` → `fix`
+   - `refactor` → `refactor`
+   - `documentation` → `docs`
+   - `chore` → `chore`
+   - Default → `issue`
+3. Create and switch to branch:
+   ```bash
+   git checkout main && git pull
+   git checkout -b <type>/$ARGUMENTS-<short-description>
+   ```
+
+### Step 3: Spawn an implementation agent
+
+Use the Task tool with `subagent_type: "general-purpose"` and provide it with the issue number and branch name. The agent should:
+
+1. **Read the project rules:**
+   - Read `AGENTS.md` — understand workflow, conventions, code style, testing guidelines
+   - Read `.claude/CLAUDE.md` — understand TodoWrite requirements
+
+2. **Fetch the implementation plan:**
+   Retrieve all comments and find the one containing `## Implementation Plan for`:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[] | select(.body | contains("## Implementation Plan for")) | .body'
+   ```
+   - If multiple plan comments exist, use the most recent one
+   - Parse the plan to extract the file list and test plan
+
+3. **Implement the plan:**
+   - Follow the plan step by step
+   - Create implementation files
+   - Create test files — this is MANDATORY, never skip tests
+   - Follow existing code patterns and conventions
+
+4. **Run validation:**
+   - Run: `doit check`
+   - If checks fail, fix the issues and re-run
+   - Do NOT give up after first failure — investigate and fix
+
+5. **Return a summary** of all changes made:
+   - Files created/modified with brief descriptions
+   - Test results (pass/fail counts)
+   - Any deviations from the plan and why
+
+### Step 4: Present changes to user
+
+After the agent returns, show the user:
+- Summary of what was implemented
+- Files changed
+- Test results
+- Any issues or deviations from the plan
+
+Tell the user:
+- Review the changes and test as needed
+- Discuss any fixes directly in conversation (no command needed)
+- When satisfied, use `/finalize` to commit and create a PR

--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -1,0 +1,87 @@
+# Plan Issue
+
+Plan the implementation for GitHub issue #$ARGUMENTS.
+
+## Instructions
+
+This command runs in the main conversation context (NOT in a subagent) so the user can ask questions, discuss tradeoffs, and refine the plan interactively.
+
+### Step 1: Validate the issue
+
+1. **Verify the issue exists and is open:**
+   ```bash
+   gh issue view $ARGUMENTS --json number,title,state,labels
+   ```
+   - If the issue does not exist, tell the user and stop.
+   - If the issue is closed, tell the user and ask if they want to reopen it or stop.
+
+2. **Check for an existing plan comment:**
+   ```bash
+   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -l "## Implementation Plan for"
+   ```
+   - If a plan comment already exists, warn the user:
+     > "Issue #$ARGUMENTS already has an implementation plan comment. Continuing will post a new one. Proceed?"
+   - Wait for user confirmation before continuing.
+
+### Step 2: Read the project rules
+
+- Read `AGENTS.md` — understand workflow, conventions, and commit guidelines
+- Read `.claude/CLAUDE.md` — understand TodoWrite requirements
+
+### Step 3: Fetch the issue details
+
+- Run: `gh issue view $ARGUMENTS --json title,body,labels,assignees`
+- Parse the issue body to understand what needs to be done
+- Check if the issue has the `needs-adr` label
+
+### Step 4: Explore the codebase
+
+- Identify which files, modules, and tests are relevant
+- Understand existing patterns and conventions in the affected areas
+- Check for related ADRs in `docs/decisions/`
+- If anything is ambiguous or there are multiple valid approaches, **ask the user** before deciding
+
+### Step 5: Draft the implementation plan
+
+Present the plan to the user for discussion. The plan MUST include these sections:
+
+```
+## Implementation Plan for #<number>: <title>
+
+### Overview
+Brief description of what will be done.
+
+### Files to Create/Modify
+- [ ] `path/to/file.py` — description of changes
+- [ ] `tests/test_file.py` — description of test coverage
+
+### Test Plan
+- [ ] Test case 1: description
+- [ ] Test case 2: description
+
+### Documentation
+- [ ] Any docs that need updating
+- [ ] ADR needed: yes/no (if yes, brief description)
+
+### Validation
+- [ ] `doit check` passes
+- [ ] Manual verification steps
+```
+
+### Step 6: Iterate with the user
+
+- Present the plan and ask for feedback
+- Discuss alternatives, answer questions, adjust the plan as needed
+- Do NOT post the plan to the issue until the user approves it
+
+### Step 7: Post the approved plan to the issue
+
+Only after the user approves the plan:
+
+```bash
+gh issue comment $ARGUMENTS --body "<approved plan>"
+```
+
+Tell the user:
+- The plan has been posted as a comment on issue #$ARGUMENTS
+- When ready, use `/implement $ARGUMENTS` to start implementation

--- a/.claude/commands/where-am-i.md
+++ b/.claude/commands/where-am-i.md
@@ -1,0 +1,75 @@
+# Where Am I
+
+Assess the current workflow state and suggest the next step.
+
+## Instructions
+
+Gather information about the current state and determine where the user is in the issue lifecycle. This command takes no arguments — it inspects the environment.
+
+### Step 1: Check git state
+
+```bash
+git branch --show-current
+git status --short
+git log --oneline -5
+```
+
+### Step 2: Determine context
+
+Based on the branch name, determine the workflow state:
+
+**If on `main`:**
+- No active work in progress
+- Suggest: "Start with `/plan-issue <N>` to plan an issue, or create one with `doit issue`"
+
+**If on a feature branch (e.g., `feat/245-description`):**
+1. Extract the issue number from the branch name
+2. Fetch issue state:
+   ```bash
+   gh issue view <number> --json number,title,state,labels
+   ```
+3. Check for a plan comment:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[].body' | grep "## Implementation Plan for"
+   ```
+4. Check for uncommitted changes:
+   ```bash
+   git status --short
+   ```
+5. Check for unpushed commits:
+   ```bash
+   git log origin/main..HEAD --oneline 2>/dev/null || git log main..HEAD --oneline
+   ```
+6. Check for an existing PR:
+   ```bash
+   gh pr list --head "$(git branch --show-current)" --json number,title,state,url
+   ```
+
+### Step 3: Report state and suggest next step
+
+Present a status summary and suggest what to do next:
+
+| State | Suggestion |
+| :--- | :--- |
+| On feature branch, no plan comment | Run `/plan-issue <N>` to create a plan |
+| On feature branch, plan exists, no code changes | Run `/implement <N>` to start implementation |
+| On feature branch, code changes, not committed | Review changes, then run `/finalize` to commit and create PR |
+| On feature branch, committed, no PR | Run `/finalize` to create the PR |
+| On feature branch, PR exists (open) | PR is open — waiting for review/merge |
+| On feature branch, PR exists (merged) | Run `/close-issue <N>` to close the issue |
+| Issue is already closed | Work complete — switch back to `main` |
+
+### Output format
+
+```
+## Workflow Status
+
+- **Branch:** feat/245-workflow-commands
+- **Issue:** #245 — feat: add workflow commands (OPEN)
+- **Plan:** Posted as comment ✓
+- **Changes:** 4 files modified, 2 uncommitted
+- **PR:** None
+
+## Suggested next step
+Run `/finalize` to commit your changes and create a PR.
+```


### PR DESCRIPTION
## Description

Add five Claude Code custom commands in `.claude/commands/` that orchestrate the full issue lifecycle. Each command aligns with a natural workflow breakpoint where user interaction is needed.

Addresses #245

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `/plan-issue <N>` — runs in main context for interactive planning: validates issue, explores code, drafts plan, iterates with user, posts approved plan as issue comment
- `/implement <N>` — delegates to subagent: verifies plan exists, creates branch, implements from plan comment, runs `doit check`
- `/finalize` — delegates docs/ADR to subagent, commits and creates PR in main context with user confirmation
- `/close-issue <N>` — verifies PR merged, updates issue task checkboxes, closes issue, scans PRs for related issues and asks about each
- `/where-am-i` — inspects branch/issue/plan/PR state and suggests next workflow command

### Design decisions

- **Context isolation**: `/implement` and `/finalize` delegate heavy work to subagents so the main conversation stays clean for review/fix loops
- **Interactive planning**: `/plan-issue` stays in main context so the user can discuss tradeoffs and refine the plan
- **Issue as persistent state**: plan lives as an issue comment, branch name encodes the issue number — no context sharing needed between phases
- **Guards and validation**: each command validates preconditions (issue exists, plan exists, branch state) before acting

## Testing

- [x] All existing tests pass
- [x] `doit check` passes
- [x] Commands are recognized by Claude Code (visible in skill list)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
