### PR TITLE
fix: resolve gemini CLI hooks.enabled configuration error

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,6 +1,8 @@
 {
+  "hooksConfig": {
+    "enabled": true
+  },
   "hooks": {
-    "enabled": true,
     "BeforeTool": [
       {
         "matcher": "run_shell_command",


### PR DESCRIPTION
## Description

Fix Gemini CLI configuration error by moving `hooks.enabled` to the `hooksConfig` top-level object per the current schema.

Addresses #253

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Moved `"enabled": true` from inside `hooks` to a new `hooksConfig` top-level key
- `hooks` now only contains event arrays (`BeforeTool`) as the schema expects

## Testing

- [x] All existing tests pass
- [x] `doit check` passes
- [x] JSON structure matches current Gemini CLI schema

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
