### PR TITLE
feat: add dual-agent (Claude + Gemini) planning and PR review commands

### DIFF
--- a/.claude/commands/gemini-review.md
+++ b/.claude/commands/gemini-review.md
@@ -1,0 +1,42 @@
+# Gemini PR Review
+
+Invoke Gemini CLI to review the current branch's pull request and post findings to the PR.
+
+## Instructions
+
+This command runs in the main conversation context. It invokes Gemini CLI
+non-interactively to get a code review, then posts the findings to the PR.
+
+### Step 1: Verify the PR exists
+
+```bash
+gh pr view --json number,title,headRefName
+```
+
+- If no PR exists for the current branch, tell the user and stop.
+- Save the PR number for later use.
+
+### Step 2: Invoke Gemini CLI
+
+Run Gemini in non-interactive mode:
+
+```bash
+gemini -p "/review-pr" --yolo 2>/dev/null
+```
+
+- Capture the stdout output — this is Gemini's review in markdown format.
+- If Gemini fails or produces empty output, report the error and stop.
+
+### Step 3: Post the review to the PR
+
+Post Gemini's review as a PR comment:
+
+```bash
+gh pr comment <PR_NUMBER> --body "<gemini review output>"
+```
+
+### Step 4: Report to user
+
+Tell the user:
+- Gemini's review has been posted to PR #<number>
+- Provide a brief summary of Gemini's findings (verdict, critical issues if any)

--- a/.claude/commands/plan-both.md
+++ b/.claude/commands/plan-both.md
@@ -1,0 +1,107 @@
+# Dual-Agent Plan
+
+Both Claude and Gemini independently create implementation plans for GitHub issue
+#$ARGUMENTS in separate contexts, then the user discusses the synthesized plan
+with Claude in the current conversation.
+
+## Instructions
+
+### Step 1: Validate the issue
+
+```bash
+gh issue view $ARGUMENTS --json number,title,state,labels
+```
+
+- If the issue does not exist, tell the user and stop.
+- If the issue is closed, tell the user and ask if they want to reopen it or stop.
+
+### Step 2: Check for existing plans
+
+```bash
+gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -l "## Implementation Plan for"
+```
+
+- If plan comments already exist, warn the user:
+  > "Issue #$ARGUMENTS already has implementation plan comments. Continuing will post new ones. Proceed?"
+- Wait for user confirmation before continuing.
+
+### Step 3: Generate both plans in parallel (separate contexts)
+
+Both plans MUST be generated in isolated contexts so neither influences the other.
+
+**Claude's plan** — use the Task tool to spawn a subagent:
+
+Prompt the subagent with:
+> Read AGENTS.md and .claude/CLAUDE.md for project standards.
+> Fetch issue #$ARGUMENTS via `gh issue view $ARGUMENTS --json title,body,labels,assignees`.
+> Explore the codebase to understand relevant files, patterns, and tests.
+> Create an implementation plan in this exact format:
+>
+> ## Implementation Plan for #<number>: <title>
+> ### Overview
+> ### Files to Create/Modify
+> ### Test Plan
+> ### Documentation
+> ### Validation
+> ### Risks and Considerations
+>
+> End with: `---` followed by `*Plan by: Claude* | *Date: <today's date>*`
+>
+> Output ONLY the plan markdown.
+
+Save the subagent's output as Claude's plan.
+
+**Gemini's plan** — invoke Gemini CLI non-interactively:
+
+```bash
+gemini -p "/plan-issue $ARGUMENTS" --yolo 2>/dev/null
+```
+
+Capture the stdout output as Gemini's plan.
+
+Run both in parallel if possible. If either fails or produces empty output,
+report the error and ask the user if they want to continue with the other
+agent's plan only or retry.
+
+### Step 4: Post both plans to the issue
+
+Post each plan as a separate comment on the issue:
+
+```bash
+gh issue comment $ARGUMENTS --body "<claude plan>"
+gh issue comment $ARGUMENTS --body "<gemini plan>"
+```
+
+### Step 5: Synthesize the final plan
+
+Read both plans and create a synthesized final plan that:
+- Combines the best elements from both plans
+- Resolves any conflicts or contradictions between them
+- Notes where the plans agreed (higher confidence)
+- Notes where they diverged (needs discussion)
+- Preserves the standard plan format (Overview, Files, Test Plan, Documentation, Validation)
+
+Add the signature:
+```
+---
+*Synthesized Plan by: Claude (from Claude + Gemini input)* | *Date: <today's date>*
+```
+
+### Step 6: Review with user
+
+Present the synthesized plan to the user for discussion:
+- Highlight areas where the two agents disagreed
+- Ask for feedback and iterate as needed
+- Do NOT post the synthesized plan until the user approves it
+
+### Step 7: Post the approved synthesized plan
+
+Only after the user approves:
+
+```bash
+gh issue comment $ARGUMENTS --body "<synthesized plan>"
+```
+
+Tell the user:
+- All three plans (Claude, Gemini, Synthesized) have been posted to issue #$ARGUMENTS
+- When ready, use `/implement $ARGUMENTS` to start implementation

--- a/.claude/commands/review-both.md
+++ b/.claude/commands/review-both.md
@@ -1,0 +1,105 @@
+# Dual-Agent PR Review
+
+Both Claude and Gemini independently review the current branch's pull request
+in separate contexts, then the user discusses the synthesized findings with
+Claude in the current conversation.
+
+## Instructions
+
+### Step 1: Verify the PR exists
+
+```bash
+gh pr view --json number,title,body,headRefName
+```
+
+- If no PR exists for the current branch, tell the user and stop.
+- Save the PR number for later use.
+
+### Step 2: Generate both reviews in parallel (separate contexts)
+
+Both reviews MUST be generated in isolated contexts so neither influences the other.
+
+**Claude's review** — use the Task tool to spawn a subagent:
+
+Prompt the subagent with:
+> Read AGENTS.md and .github/CONTRIBUTING.md for project standards.
+> Get the PR details via `gh pr view --json number,title,body,headRefName`.
+> Get the diff via `gh pr diff`.
+> Review the code for: correctness, code style, testing, security,
+> documentation, architecture, and breaking changes.
+> Create a review in this exact format:
+>
+> ## PR Review: #<number> — <title>
+> ### Summary
+> ### Findings
+> #### Critical
+> #### Suggestions
+> #### Positive
+> ### Verdict
+> Approve, Request Changes, or Comment with justification.
+>
+> End with: `---` followed by `*Review by: Claude* | *Date: <today's date>*`
+>
+> Output ONLY the review markdown.
+
+Save the subagent's output as Claude's review.
+
+**Gemini's review** — invoke Gemini CLI non-interactively:
+
+```bash
+gemini -p "/review-pr" --yolo 2>/dev/null
+```
+
+Capture the stdout output as Gemini's review.
+
+Run both in parallel if possible. If either fails or produces empty output,
+report the error and ask the user if they want to continue with the other
+agent's review only or retry.
+
+### Step 3: Post both reviews to the PR
+
+Post each review as a separate comment on the PR:
+
+```bash
+gh pr comment <PR_NUMBER> --body "<claude review>"
+gh pr comment <PR_NUMBER> --body "<gemini review>"
+```
+
+### Step 4: Synthesize the findings
+
+Read both reviews and create a synthesis that:
+- Lists issues both agents flagged (highest priority — both caught it)
+- Lists issues only one agent flagged (worth investigating)
+- Notes disagreements in verdicts if any
+- Provides a combined verdict with justification
+
+Format:
+
+```
+## Combined Review Summary
+
+### Consensus Findings (both agents flagged)
+- Description of shared finding
+
+### Claude-Only Findings
+- Description of finding only Claude caught
+
+### Gemini-Only Findings
+- Description of finding only Gemini caught
+
+### Combined Verdict
+**Approve / Request Changes / Comment** — justification
+
+---
+*Synthesized Review by: Claude (from Claude + Gemini input)* | *Date: <today's date>*
+```
+
+### Step 5: Post and discuss
+
+Post the synthesis to the PR:
+
+```bash
+gh pr comment <PR_NUMBER> --body "<synthesis>"
+```
+
+Present the synthesis to the user and highlight any areas that need attention.

--- a/.gemini/commands/plan-issue.md
+++ b/.gemini/commands/plan-issue.md
@@ -1,0 +1,69 @@
+# Plan Issue (Gemini)
+
+Create an implementation plan for GitHub issue #$ARGUMENTS.
+
+## Instructions
+
+You are being invoked to provide a planning perspective. Your plan will be posted
+to the GitHub issue by the orchestrating agent (Claude). Output clean markdown to
+stdout — do NOT post to GitHub directly.
+
+### Step 1: Fetch the issue details
+
+```bash
+gh issue view $ARGUMENTS --json title,body,labels,assignees
+```
+
+- Parse the issue body to understand what needs to be done
+- Check if the issue has the `needs-adr` label
+
+### Step 2: Read the project standards
+
+- Read `AGENTS.md` — understand workflow, conventions, and patterns
+- Identify relevant coding standards and testing requirements
+
+### Step 3: Explore the codebase
+
+- Identify which files, modules, and tests are relevant
+- Understand existing patterns and conventions in the affected areas
+- Check for related ADRs in `docs/decisions/`
+
+### Step 4: Output the implementation plan
+
+Output the plan in this exact format:
+
+```
+## Implementation Plan for #<number>: <title>
+
+### Overview
+Brief description of what will be done.
+
+### Files to Create/Modify
+- [ ] `path/to/file.py` — description of changes
+- [ ] `tests/test_file.py` — description of test coverage
+
+### Test Plan
+- [ ] Test case 1: description
+- [ ] Test case 2: description
+
+### Documentation
+- [ ] Any docs that need updating
+- [ ] ADR needed: yes/no (if yes, brief description)
+
+### Validation
+- [ ] `doit check` passes
+- [ ] Manual verification steps
+
+### Risks and Considerations
+- Any potential issues, edge cases, or trade-offs to consider
+
+---
+*Plan by: Gemini* | *Date: <today's date>*
+```
+
+### Important
+
+- Output ONLY the plan markdown — no preamble, no conversational text
+- Be specific about file paths and function names
+- Include concrete test cases, not vague descriptions
+- Note any risks or alternative approaches worth considering

--- a/.gemini/commands/review-pr.md
+++ b/.gemini/commands/review-pr.md
@@ -1,0 +1,79 @@
+# Review PR (Gemini)
+
+Review the pull request for the current branch.
+
+## Instructions
+
+You are being invoked to provide a code review perspective. Your review will be
+posted to the PR by the orchestrating agent (Claude). Output clean markdown to
+stdout — do NOT post to GitHub directly.
+
+### Step 1: Identify the PR
+
+```bash
+gh pr view --json number,title,body,baseRefName,headRefName
+```
+
+If no PR exists for the current branch, output an error message and stop.
+
+### Step 2: Read the project standards
+
+- Read `AGENTS.md` — understand code style, testing requirements, and conventions
+- Read `.github/CONTRIBUTING.md` — understand contribution guidelines
+
+### Step 3: Get the changes
+
+```bash
+gh pr diff
+```
+
+Review the full diff carefully.
+
+### Step 4: Analyze the changes
+
+Review the code for:
+
+1. **Correctness** — Does the logic work? Are there bugs or edge cases?
+2. **Code Style** — Does it follow project conventions from AGENTS.md?
+3. **Testing** — Are tests adequate? Are edge cases covered?
+4. **Security** — Any OWASP top 10 vulnerabilities? Command injection, path traversal, etc.?
+5. **Documentation** — Are docstrings/comments appropriate? Does behavior change need doc updates?
+6. **Architecture** — Does it follow existing patterns? Is there tight coupling?
+7. **Breaking Changes** — Does this change public APIs or default behavior?
+
+### Step 5: Output the review
+
+Output the review in this exact format:
+
+```
+## PR Review: #<number> — <title>
+
+### Summary
+Brief assessment of the changes (1-2 sentences).
+
+### Findings
+
+#### Critical
+- [ ] Description of critical issue (if any)
+
+#### Suggestions
+- [ ] Description of suggested improvement (if any)
+
+#### Positive
+- Notable good practices or well-implemented aspects
+
+### Verdict
+One of: **Approve**, **Request Changes**, or **Comment**
+
+Brief justification for the verdict.
+
+---
+*Review by: Gemini* | *Date: <today's date>*
+```
+
+### Important
+
+- Output ONLY the review markdown — no preamble, no conversational text
+- Be specific: reference file paths and line ranges
+- Distinguish between critical issues (must fix) and suggestions (nice to have)
+- If the code looks good, say so — don't invent issues to fill space

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,32 @@
+# Gemini CLI Instructions
+
+## Context
+
+This project uses both Claude Code and Gemini CLI as AI coding assistants.
+Gemini shares the same project standards defined in AGENTS.md.
+
+## Collaboration Mode
+
+Gemini may be invoked non-interactively by Claude Code via `gemini -p "..." --yolo`.
+When running in this mode:
+
+- **Output to stdout only** — do NOT post directly to GitHub
+- Claude handles all GitHub writes (issue comments, PR comments) to preserve governance hooks
+- Structure output as clean markdown so Claude can post it as-is
+
+## Output Signing
+
+When producing plans or reviews, always include a signature footer:
+
+```
+---
+*{Action} by: Gemini* | *Date: {today's date}*
+```
+
+Where `{Action}` is "Plan" or "Review".
+
+## Tool Usage
+
+- Use `gh` for reading GitHub data (issues, PRs, diffs)
+- Follow the tool hierarchy from AGENTS.md (doit > uv > gh > git > raw commands)
+- Prefer file reading tools for codebase exploration


### PR DESCRIPTION
## Description

Add workflow commands enabling both Claude Code and Gemini CLI to collaborate on issue planning and PR review. Gemini outputs to stdout only; Claude handles all GitHub writes to preserve governance hooks.

Addresses #255

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `GEMINI.md` — project context for Gemini CLI (collaboration mode, output signing, tool usage)
- `.gemini/commands/plan-issue.md` — Gemini planning command (explores codebase, outputs plan to stdout)
- `.gemini/commands/review-pr.md` — Gemini review command (reviews PR diff, outputs findings to stdout)
- `.claude/commands/gemini-review.md` — Claude invokes Gemini to review current PR, posts signed findings
- `.claude/commands/plan-both.md` — both agents plan in isolated contexts, Claude synthesizes for user discussion
- `.claude/commands/review-both.md` — both agents review in isolated contexts, Claude synthesizes findings

## Testing

- [x] All existing tests pass (`doit check` passes)
- [x] No code changes — markdown command files only

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings