### PR TITLE
feat: auto-run uv sync when uv.lock changes after git pull or checkout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,3 +163,21 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      # Auto-sync dependencies when uv.lock changes after git pull
+      - id: uv-sync-on-pull
+        name: Auto uv sync after pull (lock changed)
+        entry: bash -c 'git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep -q "^uv\.lock$" && echo "uv.lock changed — running uv sync..." && uv sync || true'
+        language: system
+        stages: [post-merge]
+        pass_filenames: false
+        always_run: true
+
+      # Auto-sync dependencies when uv.lock changes after branch switch
+      - id: uv-sync-on-checkout
+        name: Auto uv sync after branch switch (lock changed)
+        entry: bash -c 'if [ "$3" = "1" ]; then git diff --name-only "$1" "$2" | grep -q "^uv\.lock$" && echo "uv.lock changed — running uv sync..." && uv sync || true; fi'
+        language: system
+        stages: [post-checkout]
+        pass_filenames: false
+        always_run: true

--- a/docs/deployment/development.md
+++ b/docs/deployment/development.md
@@ -305,15 +305,17 @@ SQLite requires no external services and is suitable for most development work.
 The project uses pre-commit hooks for quality gates:
 
 ```bash
-# Install hooks (done automatically by uv sync)
-uv run pre-commit install
+# Install all hooks (pre-commit, post-merge, post-checkout)
+doit pre_commit_install
 
 # Run manually
-uv run pre-commit run --all-files
+doit pre_commit_run
 
 # Skip hooks (use sparingly)
 git commit --no-verify -m "WIP: work in progress"
 ```
+
+The project also includes **post-merge** and **post-checkout** hooks that automatically run `uv sync` when `uv.lock` changes after a `git pull` or branch switch. This keeps your local environment in sync without manual intervention.
 
 ### Type Checking
 

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -185,7 +185,11 @@ Install hooks after cloning:
 
 ```bash
 uv run pre-commit install
+uv run pre-commit install --hook-type post-merge
+uv run pre-commit install --hook-type post-checkout
 ```
+
+The **post-merge** and **post-checkout** hooks automatically run `uv sync` when `uv.lock` changes after a `git pull` or branch switch, keeping your environment in sync.
 
 ## Creating Custom doit Tasks
 

--- a/tools/doit/git.py
+++ b/tools/doit/git.py
@@ -32,7 +32,11 @@ def task_changelog() -> dict[str, Any]:
 def task_pre_commit_install() -> dict[str, Any]:
     """Install pre-commit hooks."""
     return {
-        "actions": ["uv run pre-commit install"],
+        "actions": [
+            "uv run pre-commit install",
+            "uv run pre-commit install --hook-type post-merge",
+            "uv run pre-commit install --hook-type post-checkout",
+        ],
         "title": title_with_actions,
     }
 

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -373,7 +373,7 @@ def run_configure(
     print("1. Review the changes: git diff")
     print("2. Initialize git repository: git init")
     print("3. Install dependencies: uv sync --all-extras --dev")
-    print("4. Install pre-commit hooks: uv run pre-commit install")
+    print("4. Install pre-commit hooks: uv run doit pre_commit_install")
     print("5. Run tests: uv run pytest")
     print("6. Cut a prerelease (if desired): uv run doit release_dev")
     print("7. Start coding!")

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -442,6 +442,13 @@ chore: configure project from template
             )
             if result.returncode == 0:
                 Logger.success("Pre-commit hooks installed")
+                # Install post-merge and post-checkout hooks for auto uv sync
+                for hook_type in ["post-merge", "post-checkout"]:
+                    subprocess.run(
+                        ["uv", "run", "pre-commit", "install", "--hook-type", hook_type],
+                        capture_output=True,
+                        text=True,
+                    )
             else:
                 Logger.warning("Failed to install pre-commit hooks")
                 Logger.info("You can install manually with: uv run pre-commit install")


### PR DESCRIPTION
## Description

Add post-merge and post-checkout pre-commit hooks that automatically run `uv sync` when `uv.lock` changes after a `git pull` or branch switch.

## Related Issue

Addresses #266

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `uv-sync-on-pull` hook (post-merge stage) to `.pre-commit-config.yaml`
- Added `uv-sync-on-checkout` hook (post-checkout stage) to `.pre-commit-config.yaml`
- Updated `task_pre_commit_install` in `tools/doit/git.py` to install all three hook types
- Updated `tools/pyproject_template/setup_repo.py` to install post-merge/post-checkout hooks during repo setup
- Updated `tools/pyproject_template/configure.py` to point to `doit pre_commit_install`
- Updated `docs/deployment/development.md` and `docs/usage/basics.md` with new hook documentation

## Testing

- [x] All existing tests pass (`doit check` passes)
- [x] Manually verified hook installation with `pre-commit install --hook-type post-merge/post-checkout`
- [x] Hooks gracefully no-op when `uv.lock` hasn't changed

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings