### PR TITLE
fix: add explicit stages to pre-commit hooks to prevent post-merge conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,19 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
+        stages: [pre-commit]
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: check-added-large-files
+        stages: [pre-commit]
       - id: check-toml
+        stages: [pre-commit]
       - id: check-merge-conflict
+        stages: [pre-commit]
       - id: detect-private-key
+        stages: [pre-commit]
 
   # Conventional commits enforcement
   - repo: https://github.com/compilerla/conventional-pre-commit
@@ -29,12 +36,14 @@ repos:
         entry: uv run ruff check --fix
         language: system
         types: [python]
+        stages: [pre-commit]
 
       - id: ruff-format
         name: ruff-format
         entry: uv run ruff format
         language: system
         types: [python]
+        stages: [pre-commit]
 
       # Type checking (uses project's mypy version)
       # Only checks src/ to match doit type_check behavior
@@ -44,6 +53,7 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+        stages: [pre-commit]
 
       # Security scanning (uses project's bandit version)
       # Skips if bandit not installed (optional security extra)
@@ -52,6 +62,7 @@ repos:
         entry: bash -c 'command -v bandit &>/dev/null || uv run python -c "import bandit" 2>/dev/null || exit 0; uv run bandit -c pyproject.toml "$@"' --
         language: system
         types: [python]
+        stages: [pre-commit]
 
       # Spell checking (uses project's codespell version)
       - id: codespell
@@ -60,6 +71,7 @@ repos:
         language: system
         types: [text]
         exclude: ^(\.git/|\.venv/|uv\.lock)
+        stages: [pre-commit]
 
       # Branch naming enforcement
       - id: check-branch-name
@@ -87,6 +99,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-commit]
 
       # Generate documentation TOC from frontmatter
       - id: generate-doc-toc
@@ -95,6 +108,7 @@ repos:
         language: system
         pass_filenames: false
         files: ^docs/.*\.md$
+        stages: [pre-commit]
 
       # Prevent direct commits to main branch
       - id: no-commit-to-main
@@ -120,6 +134,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-commit]
 
       # Prevent committing local config files
       - id: no-local-config
@@ -143,6 +158,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-commit]
 
       # Protect dynamic version configuration
       - id: protect-dynamic-version
@@ -163,6 +179,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-commit]
 
       # Auto-sync dependencies when uv.lock changes after git pull
       - id: uv-sync-on-pull


### PR DESCRIPTION
## Description

Installing `post-merge` and `post-checkout` hook types (from PR #268) caused all hooks without explicit `stages` to run during `git pull` and branch switches. This meant `no-commit-to-main` blocked pulls to main, and linting/type-checking hooks ran unnecessarily on every pull/checkout.

Adds `stages: [pre-commit]` to all commit-only hooks so they only fire during the pre-commit stage.

## Related Issue

Addresses #266

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `stages: [pre-commit]` to all external hooks (trailing-whitespace, end-of-file-fixer, check-yaml, etc.)
- Added `stages: [pre-commit]` to all local hooks (ruff, mypy, bandit, codespell, check-branch-name, no-commit-to-main, no-local-config, protect-dynamic-version, generate-doc-toc)

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Pre-commit hooks still run on commit
- [x] Post-merge/post-checkout hooks only run uv-sync hooks

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings