### PR TITLE
docs: replace raw commands with doit equivalents in documentation

### DIFF
--- a/docs/deployment/development.md
+++ b/docs/deployment/development.md
@@ -186,7 +186,7 @@ python -m package_name
 doit test
 
 # Run with coverage
-uv run pytest --cov
+doit coverage
 
 # Run specific test file
 uv run pytest tests/test_specific.py
@@ -344,7 +344,7 @@ uv run ruff check --fix src/
 doit fmt
 
 # Check format without changing
-uv run ruff format --check src/
+doit format_check
 ```
 
 ## Troubleshooting

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -31,7 +31,7 @@ CI runs lint/format, tests, coverage, and quality checks to guard against regres
 Local commands:
 ```bash
 doit format && doit lint
-uv run pytest
+doit test
 doit coverage
 ```
 
@@ -249,7 +249,7 @@ Add coverage comments to PRs using GitHub Actions:
 
 ```bash
 # Run all tests
-uv run pytest
+doit test
 
 # Run specific test file
 uv run pytest tests/test_config.py
@@ -261,7 +261,7 @@ uv run pytest tests/test_config.py::test_load_config
 uv run pytest -v
 
 # Run with coverage
-uv run pytest --cov=src
+doit coverage
 
 # Generate HTML coverage report
 uv run pytest --cov=src --cov-report=html
@@ -308,10 +308,10 @@ The template includes pre-commit hooks that run automatically:
 
 ```bash
 # Install hooks
-uv run pre-commit install
+doit pre_commit_install
 
 # Run manually on all files
-uv run pre-commit run --all-files
+doit pre_commit_run
 
 # Update hook versions
 uv run pre-commit autoupdate
@@ -349,7 +349,7 @@ Before pushing to CI:
 - [ ] Run `doit format` to format code
 - [ ] Run `doit lint` to check for issues
 - [ ] Run `doit type_check` to verify types
-- [ ] Run `uv run pytest` to ensure tests pass
+- [ ] Run `doit test` to ensure tests pass
 - [ ] Run `doit coverage` to check coverage threshold
 - [ ] Review changes and commit messages
 

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -608,10 +608,10 @@ uv sync --dev --all-extras
 
 ```bash
 # Install hooks
-uv run pre-commit install
+doit pre_commit_install
 
 # Run manually on all files
-uv run pre-commit run --all-files
+doit pre_commit_run
 
 # Skip hooks (emergency only)
 git commit --no-verify

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -128,7 +128,7 @@ message: str = greet("Python")
 Run mypy to verify type hints:
 
 ```bash
-uv run mypy src/
+doit type_check
 ```
 
 ## Testing
@@ -140,7 +140,7 @@ All public APIs should have comprehensive tests:
 doit test
 
 # Run with coverage
-uv run pytest --cov=package_name --cov-report=term-missing
+doit coverage
 ```
 
 ---

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -209,8 +209,8 @@ AI coding assistants (Claude Code, Gemini CLI, Codex) use hooks to block dangero
 ## Phase 9: Validation
 
 - [ ] Run `doit check` - all checks must pass
-- [ ] Run `uv run pytest` - all tests must pass
-- [ ] Run `uv run pre-commit run --all-files` - all hooks must pass
+- [ ] Run `doit test` - all tests must pass
+- [ ] Run `doit pre_commit_run` - all hooks must pass
 - [ ] Run `doit lint` - no new linting issues
 - [ ] Run `doit type_check` - no new type errors
 - [ ] If new quality tasks added: run them and verify output is reasonable

--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -154,7 +154,7 @@ direnv allow
 
 # Or manually set up
 uv sync --all-extras --dev
-uv run pre-commit install
+doit pre_commit_install
 ```
 
 #### Enable Shell Completions (Optional)

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -42,7 +42,7 @@ This section is for developers working on the project.
 
 ```bash
 # Run tests (parallel)
-uv run pytest -n auto -v
+doit test
 
 # Run all quality checks
 uv run doit check
@@ -184,9 +184,7 @@ The project includes pre-commit hooks that run automatically before each commit:
 Install hooks after cloning:
 
 ```bash
-uv run pre-commit install
-uv run pre-commit install --hook-type post-merge
-uv run pre-commit install --hook-type post-checkout
+doit pre_commit_install
 ```
 
 The **post-merge** and **post-checkout** hooks automatically run `uv sync` when `uv.lock` changes after a `git pull` or branch switch, keeping your environment in sync.
@@ -597,16 +595,16 @@ To run the same checks that CI runs:
 
 ```bash
 # Format check (what CI runs)
-uv run ruff format --check src/ tests/
+doit format_check
 
 # Linting
-uv run ruff check src/ tests/
+doit lint
 
 # Type checking
-uv run mypy src/
+doit type_check
 
 # Tests with coverage
-uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v
+doit coverage
 ```
 
 ### Updating Dependencies
@@ -630,10 +628,7 @@ uv run doit check
 
 ```bash
 # Serve with live reload
-uv run mkdocs serve
-
-# Or using doit
-uv run doit docs_serve
+doit docs_serve
 ```
 
 Open http://127.0.0.1:8000 in your browser.


### PR DESCRIPTION
## Description

Replace raw tool commands (`pytest`, `ruff`, `mypy`, `mkdocs`, etc.) with their `doit` task equivalents across seven documentation files, aligning docs with the project's "use the highest-level tool available" principle from AGENTS.md.

Addresses #267

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/deployment/development.md` - replaced raw commands with `doit` equivalents
- `docs/development/ci-cd-testing.md` - replaced raw commands with `doit` equivalents
- `docs/development/release-and-automation.md` - replaced raw commands with `doit` equivalents
- `docs/reference/api.md` - replaced raw commands with `doit` equivalents
- `docs/template/ai-sync-checklist.md` - replaced raw commands with `doit` equivalents
- `docs/template/new-project.md` - replaced raw commands with `doit` equivalents
- `docs/usage/basics.md` - replaced raw commands with `doit` equivalents and simplified redundant examples

## Testing

- [x] All existing tests pass (`doit check` passes: format, lint, type-check, security, spell-check, tests)
- [x] Documentation-only change; no code or test changes required

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
