### PR TITLE
feat: add property-based testing with Hypothesis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     env:
       UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+      HYPOTHESIS_PROFILE: ci
 
     steps:
       - name: Configure git line endings (Windows)

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -586,6 +586,82 @@ PR opened → CI runs (6 jobs) → Review/Approval → Add ready-to-merge label 
 PR opened → CI runs → Add full-matrix label → Full CI runs (9-15 jobs) → Review → Add ready-to-merge → Merge
 ```
 
+## Property-Based Testing
+
+### What Is Property-Based Testing?
+
+Property-based testing verifies *invariant properties* of your code by feeding it hundreds of randomly generated inputs rather than a handful of hand-picked examples. If a property holds for every input the framework can dream up, you gain much higher confidence than example-based tests alone.
+
+This project uses [Hypothesis](https://hypothesis.readthedocs.io/) for property-based testing.
+
+### When to Use Property-Based Tests
+
+| Good fit | Not a good fit |
+|----------|----------------|
+| Pure functions with clear contracts (validators, formatters, parsers) | Tests that require complex external state (databases, APIs) |
+| Functions whose output must satisfy invariants (e.g., "always lowercase") | Behaviour that depends on side effects or ordering |
+| Edge-case-heavy logic (string processing, numeric conversions) | Simple CRUD with no transformation logic |
+
+### Writing Property Tests
+
+```python
+import pytest
+from hypothesis import given, example
+from hypothesis import strategies as st
+
+@pytest.mark.property
+@given(name=st.text(min_size=1))
+@example("edge-case-value")
+def test_output_is_always_lowercase(name: str) -> None:
+    result = normalize(name)
+    assert result == result.lower()
+```
+
+**Key decorators and strategies:**
+
+| Element | Purpose |
+|---------|---------|
+| `@given(...)` | Declares the randomly generated inputs |
+| `@example(...)` | Pins a specific input that must always be tested |
+| `st.text()` | Generates arbitrary Unicode strings |
+| `st.from_regex(r"...")` | Generates strings matching a regular expression |
+| `st.integers()`, `st.floats()` | Numeric strategies |
+| `@pytest.mark.property` | Custom marker to select/deselect property tests |
+
+### Hypothesis Profiles
+
+Two profiles are configured in `tests/conftest.py`:
+
+| Profile | `max_examples` | `deadline` | Used when |
+|---------|---------------|------------|-----------|
+| `default` | 200 | Hypothesis default | Local development |
+| `ci` | 50 | 500 ms | GitHub Actions CI |
+
+The CI workflow sets `HYPOTHESIS_PROFILE: ci` so property tests run faster in pipelines.
+
+### Running Property Tests
+
+```bash
+# Run only property tests
+uv run pytest -m property -v
+
+# Run with a specific seed for reproducibility
+uv run pytest -m property --hypothesis-seed=12345
+
+# Run with more examples locally
+HYPOTHESIS_PROFILE=default uv run pytest -m property -v
+```
+
+### Debugging Failures
+
+When a property test fails, Hypothesis prints the **minimal failing example**. To reproduce:
+
+1. Copy the seed from the failure output (e.g., `--hypothesis-seed=98765`)
+2. Re-run: `uv run pytest tests/test_properties.py --hypothesis-seed=98765 -v`
+3. Hypothesis will reproduce the exact same sequence of inputs
+
+Hypothesis also stores failing examples in a `.hypothesis/` directory (git-ignored) so they are replayed automatically on the next run.
+
 ## Mutation Testing
 
 ### What Is Mutation Testing?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "radon>=6.0",
     "pytest-benchmark>=4.0",
     "mutmut>=3.0",
+    "hypothesis>=6.0",
 ]
 security = [
     "pip-audit>=2.6",
@@ -147,6 +148,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
     "benchmark: marks tests as performance benchmarks (deselect with '--benchmark-disable')",
+    "property: marks tests as property-based tests (run with Hypothesis)",
 ]
 
 [tool.pytest-benchmark]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest configuration and Hypothesis profiles."""
+
+import os
+
+from hypothesis import HealthCheck, settings
+
+# CI profile: fewer examples, relaxed deadline for slow CI runners
+settings.register_profile(
+    "ci",
+    max_examples=50,
+    deadline=500,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+# Default profile: more thorough exploration for local development
+settings.register_profile(
+    "default",
+    max_examples=200,
+)
+
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,217 @@
+"""Property-based tests using Hypothesis.
+
+Tests invariant properties of utility functions and core module
+using randomly generated inputs rather than hand-picked examples.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from package_name.core import greet
+
+# Add project root to sys.path so tools module can be imported
+_project_root = Path(__file__).resolve().parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from tools.pyproject_template.utils import (  # noqa: E402
+    is_github_url,
+    validate_email,
+    validate_package_name,
+    validate_pypi_name,
+)
+
+# ---------------------------------------------------------------------------
+# validate_package_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestValidatePackageNameProperties:
+    """Property-based tests for validate_package_name."""
+
+    @given(name=st.text(min_size=1))
+    @example("MyPackage")
+    @example("123start")
+    @example("hello-world")
+    @example("__leading__")
+    def test_output_contains_only_valid_chars(self, name: str) -> None:
+        """Output must only contain lowercase letters, digits, and underscores."""
+        result = validate_package_name(name)
+        if result:
+            assert re.fullmatch(r"[a-z0-9_]+", result), f"Invalid chars in output: {result!r}"
+
+    @given(name=st.text(min_size=1))
+    @example("9lives")
+    def test_output_never_starts_with_digit(self, name: str) -> None:
+        """Output must never start with a digit (Python identifier rule)."""
+        result = validate_package_name(name)
+        if result:
+            assert not result[0].isdigit(), f"Output starts with digit: {result!r}"
+
+    @given(name=st.from_regex(r"[a-zA-Z][a-zA-Z0-9_]*", fullmatch=True))
+    @example("valid_name")
+    def test_valid_input_produces_nonempty_output(self, name: str) -> None:
+        """Input with at least one alpha char produces non-empty output."""
+        result = validate_package_name(name)
+        assert result, f"Expected non-empty output for input: {name!r}"
+
+    @given(name=st.text(min_size=1))
+    def test_output_has_no_leading_trailing_underscores(self, name: str) -> None:
+        """Output must not have leading or trailing underscores (after strip).
+
+        Exception: a leading underscore is added when the result starts with a digit.
+        """
+        result = validate_package_name(name)
+        if result:
+            # If it starts with _, the next char must be a digit (the prefix case)
+            if result.startswith("_"):
+                assert len(result) > 1 and result[1].isdigit(), (
+                    f"Unexpected leading underscore: {result!r}"
+                )
+            assert not result.endswith("_"), f"Trailing underscore in output: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# validate_pypi_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestValidatePypiNameProperties:
+    """Property-based tests for validate_pypi_name."""
+
+    @given(name=st.text(min_size=1))
+    @example("My--Package")
+    @example("--leading")
+    @example("trailing--")
+    def test_output_contains_only_valid_chars(self, name: str) -> None:
+        """Output must only contain lowercase letters, digits, and hyphens."""
+        result = validate_pypi_name(name)
+        if result:
+            assert re.fullmatch(r"[a-z0-9-]+", result), f"Invalid chars in output: {result!r}"
+
+    @given(name=st.text(min_size=1))
+    @example("a--b--c")
+    def test_no_consecutive_hyphens(self, name: str) -> None:
+        """Output must not contain consecutive hyphens."""
+        result = validate_pypi_name(name)
+        assert "--" not in result, f"Consecutive hyphens in output: {result!r}"
+
+    @given(name=st.text(min_size=1))
+    @example("-leading")
+    @example("trailing-")
+    def test_no_leading_or_trailing_hyphens(self, name: str) -> None:
+        """Output must not start or end with a hyphen."""
+        result = validate_pypi_name(name)
+        if result:
+            assert not result.startswith("-"), f"Leading hyphen: {result!r}"
+            assert not result.endswith("-"), f"Trailing hyphen: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# greet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestGreetProperties:
+    """Property-based tests for the greet function."""
+
+    @given(name=st.text(min_size=1))
+    @example("World")
+    @example("Alice")
+    def test_output_contains_input_name(self, name: str) -> None:
+        """The greeting must contain the input name verbatim."""
+        result = greet(name)
+        assert name in result, f"Name {name!r} not found in greeting: {result!r}"
+
+    @given(name=st.text(min_size=0))
+    @example("")
+    @example("Test")
+    def test_output_starts_with_hello(self, name: str) -> None:
+        """The greeting must always start with 'Hello, '."""
+        result = greet(name)
+        assert result.startswith("Hello, "), f"Greeting doesn't start with 'Hello, ': {result!r}"
+
+    @given(name=st.text(min_size=0))
+    def test_output_ends_with_exclamation(self, name: str) -> None:
+        """The greeting must always end with '!'."""
+        result = greet(name)
+        assert result.endswith("!"), f"Greeting doesn't end with '!': {result!r}"
+
+    @given(name=st.text(min_size=0))
+    def test_output_format_is_exact(self, name: str) -> None:
+        """The greeting must exactly match 'Hello, {name}!'."""
+        result = greet(name)
+        assert result == f"Hello, {name}!", f"Unexpected format: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# validate_email
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestValidateEmailProperties:
+    """Property-based tests for validate_email."""
+
+    def test_empty_string_returns_false(self) -> None:
+        """Empty string must not be considered a valid email."""
+        assert validate_email("") is False
+
+    @given(text=st.text(alphabet=st.characters(blacklist_characters="@"), min_size=1))
+    def test_string_without_at_returns_false(self, text: str) -> None:
+        """A string without '@' cannot be a valid email."""
+        assert validate_email(text) is False
+
+    @given(
+        local=st.from_regex(r"[a-zA-Z0-9._%+-]+", fullmatch=True),
+        domain=st.from_regex(r"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", fullmatch=True),
+    )
+    @example(local="user", domain="example.com")
+    def test_well_formed_email_returns_true(self, local: str, domain: str) -> None:
+        """Well-formed local@domain emails must validate as true."""
+        email = f"{local}@{domain}"
+        assert validate_email(email) is True, f"Expected valid: {email!r}"
+
+
+# ---------------------------------------------------------------------------
+# is_github_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestIsGithubUrlProperties:
+    """Property-based tests for is_github_url."""
+
+    @given(
+        domain=st.from_regex(r"[a-z]{3,12}\.(com|org|net|io)", fullmatch=True).filter(
+            lambda d: "github" not in d
+        )
+    )
+    def test_non_github_domains_return_false(self, domain: str) -> None:
+        """URLs with non-github domains must return False."""
+        url = f"https://{domain}/owner/repo"
+        assert is_github_url(url) is False, f"Expected False for: {url!r}"
+
+    @given(path=st.from_regex(r"/[a-z]+/[a-z]+", fullmatch=True))
+    @example(path="/owner/repo")
+    def test_github_com_returns_true(self, path: str) -> None:
+        """URLs with github.com domain must return True."""
+        url = f"https://github.com{path}"
+        assert is_github_url(url) is True, f"Expected True for: {url!r}"
+
+    @given(text=st.text(min_size=0, max_size=50))
+    def test_never_raises(self, text: str) -> None:
+        """is_github_url must never raise an exception for any input."""
+        # Should return a bool without raising
+        result = is_github_url(text)
+        assert isinstance(result, bool)

--- a/uv.lock
+++ b/uv.lock
@@ -390,6 +390,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.151.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -930,6 +942,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "commitizen" },
+    { name = "hypothesis" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mutmut" },
@@ -960,6 +973,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.2" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "doit", specifier = ">=0.36.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.0" },


### PR DESCRIPTION
## Description

Add property-based testing support using Hypothesis. This integrates Hypothesis into the project's test infrastructure with CI-aware profiles and provides 17 property-based tests covering the core validators and parsers.

## Related Issue

Addresses #88

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvement

## Changes Made

- Added `hypothesis` as a dev dependency in `pyproject.toml`
- Added `property` pytest marker for property-based tests in `pyproject.toml`
- Created `tests/conftest.py` with Hypothesis profile configuration (CI profile with reduced examples/relaxed deadlines, default profile for thorough local exploration)
- Created `tests/test_properties.py` with 17 property-based tests covering:
  - `validate_package_name` (character validity, no leading digits, non-empty output, underscore handling)
  - `validate_pypi_name` (character validity, no consecutive hyphens, no leading/trailing hyphens)
  - `greet` (output contains name, starts with "Hello, ", ends with "!", exact format)
  - `validate_email` (empty string, missing @, well-formed emails)
  - `is_github_url` (non-github domains, github.com URLs, no exceptions on arbitrary input)
- Added `HYPOTHESIS_PROFILE: ci` environment variable to CI workflow
- Updated `docs/development/ci-cd-testing.md` with property-based testing documentation

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

- The CI profile uses `max_examples=50` and `deadline=500ms` to avoid flaky tests on slow CI runners
- The default (local) profile uses `max_examples=200` for more thorough exploration
- Profile selection is controlled by the `HYPOTHESIS_PROFILE` environment variable
