### PR TITLE
fix: add --all-extras --dev flags to post-merge/checkout uv sync hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,7 +184,7 @@ repos:
       # Auto-sync dependencies when uv.lock changes after git pull
       - id: uv-sync-on-pull
         name: Auto uv sync after pull (lock changed)
-        entry: bash -c 'git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep -q "^uv\.lock$" && echo "uv.lock changed — running uv sync..." && uv sync || true'
+        entry: bash -c 'git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep -q "^uv\.lock$" && echo "uv.lock changed — running uv sync..." && uv sync --all-extras --dev || true'
         language: system
         stages: [post-merge]
         pass_filenames: false
@@ -193,7 +193,7 @@ repos:
       # Auto-sync dependencies when uv.lock changes after branch switch
       - id: uv-sync-on-checkout
         name: Auto uv sync after branch switch (lock changed)
-        entry: bash -c 'if [ "$3" = "1" ]; then git diff --name-only "$1" "$2" | grep -q "^uv\.lock$" && echo "uv.lock changed — running uv sync..." && uv sync || true; fi'
+        entry: bash -c 'if [ "$3" = "1" ]; then git diff --name-only "$1" "$2" | grep -q "^uv\.lock$" && echo "uv.lock changed — running uv sync..." && uv sync --all-extras --dev || true; fi'
         language: system
         stages: [post-checkout]
         pass_filenames: false


### PR DESCRIPTION
## Description

Fix the post-merge and post-checkout pre-commit hooks to run `uv sync --all-extras --dev` instead of bare `uv sync`. Without the flags, dev and security dependencies are not installed after pulls or branch switches that change `uv.lock`.

## Related Issue

Addresses #274

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Fixed `uv-sync-on-pull` hook (post-merge) to include `--all-extras --dev` flags
- Fixed `uv-sync-on-checkout` hook (post-checkout) to include `--all-extras --dev` flags

## Testing

- [x] All existing tests pass (`doit check` passes)
- [x] Config-only change — no new tests required

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
