### PR TITLE
feat: add automated release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# GitHub auto-generated release notes configuration
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - needs-triage
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: New Features
+      labels:
+        - enhancement
+        - feat
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Performance
+      labels:
+        - performance
+        - perf
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,23 @@ jobs:
           packages-dir: dist
           skip-existing: true
 
-  upload-sbom:
-    name: Upload SBOM to GitHub Release
+  github-release:
+    name: Create GitHub Release
     needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Create GitHub release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          gh release create "$tag" --generate-notes --title "$tag"
+
       - uses: actions/download-artifact@v7
         with:
           name: dist

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -17,6 +17,7 @@ This guide covers automated versioning, release management, governance validatio
 ## Table of Contents
 - [Automated Versioning](#automated-versioning)
 - [Release Management](#release-management)
+- [Release Notes](#release-notes)
 - [PR Merging](#pr-merging)
 - [Security & Quality Tasks](#security-quality-tasks)
 - [SBOM Generation](#sbom-generation)
@@ -169,6 +170,63 @@ uv run doit release_dev --type=beta
 uv run doit release
 # --> Creates v0.2.0, updates CHANGELOG, publishes to PyPI
 ```
+
+## Release Notes
+
+Release notes are automatically generated from merged pull requests when a GitHub release is created. The release workflow creates a GitHub release with auto-generated notes after publishing to PyPI.
+
+### How It Works
+
+1. When a version tag (e.g., `v1.0.0`) is pushed, the release workflow runs
+2. After the package is published to PyPI, the `github-release` job creates a GitHub release
+3. GitHub generates release notes by categorizing merged PRs since the last release
+4. SBOM files are attached to the release as downloadable assets
+
+### Category Configuration
+
+PR labels and conventional commit prefixes are mapped to release note sections in `.github/release.yml`:
+
+| Section | Labels |
+|---------|--------|
+| **Breaking Changes** | `breaking` |
+| **New Features** | `enhancement`, `feat` |
+| **Bug Fixes** | `bug`, `fix` |
+| **Documentation** | `documentation`, `docs` |
+| **Performance** | `performance`, `perf` |
+| **Other Changes** | Everything else |
+
+PRs with the `dependencies` or `needs-triage` labels are excluded from release notes.
+
+### Customizing Categories
+
+To add or modify categories, edit `.github/release.yml`:
+
+```yaml
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - needs-triage
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: New Features
+      labels:
+        - enhancement
+        - feat
+    # Add more categories here
+    - title: Other Changes
+      labels:
+        - "*"
+```
+
+Categories are evaluated in order. A PR is placed in the first matching category. The `"*"` wildcard matches any label and serves as a catch-all.
+
+### Further Reading
+
+- [GitHub Docs: Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+- [GitHub Docs: Configuring automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)
 
 ## PR Merging
 
@@ -394,7 +452,7 @@ SBOMs are automatically generated and attached to every GitHub release:
 
 1. During the **build** job, `cyclonedx-py` generates both JSON and XML SBOMs
 2. The SBOM files are included in the `dist/` artifact alongside wheel and sdist packages
-3. After publishing to PyPI, a dedicated **upload-sbom** job attaches the SBOMs as GitHub release assets
+3. After publishing to PyPI, the **github-release** job creates a GitHub release with auto-generated notes and attaches the SBOMs as release assets
 
 Users can download the SBOM from the GitHub release page for any version.
 


### PR DESCRIPTION
## Description

Add automated release notes generation to the release workflow. When a production release tag is pushed, the workflow now creates a GitHub release with auto-generated notes categorized by PR labels, and attaches SBOM files as release assets.

Addresses #92

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `.github/release.yml` with release notes category configuration (Breaking Changes, New Features, Bug Fixes, Documentation, Performance, Other Changes)
- Modified `.github/workflows/release.yml` to replace the standalone `upload-sbom` job with a `github-release` job that creates a GitHub release with `--generate-notes`, then attaches SBOM artifacts
- Updated `docs/development/release-and-automation.md` with a new Release Notes section documenting category mapping, customization, and references to GitHub docs

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

No new Python code was added; changes are limited to GitHub Actions workflow YAML and documentation. `doit check` passes.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No Python source changes, so no new tests are required. The release notes configuration and workflow changes can only be fully validated when a release tag is pushed to GitHub.
