### PR TITLE
chore: restructure plan-issue skill to iterate inside plan mode

### DIFF
--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -43,44 +43,47 @@ This command runs in the main conversation context (NOT in a subagent) so the us
 - Check for related ADRs in `docs/decisions/`
 - If anything is ambiguous or there are multiple valid approaches, **ask the user** before deciding
 
-### Step 6: Draft the implementation plan
+### Step 6: Draft the plan and iterate with the user (inside plan mode)
 
-Present the plan to the user for discussion. The plan MUST include these sections:
+**Stay in plan mode for this entire step.** Draft the plan, present it, and iterate until the user approves — all before leaving plan mode.
 
-```
-## Implementation Plan for #<number>: <title>
+1. Present the plan to the user. The plan MUST include these sections:
 
-### Overview
-Brief description of what will be done.
+   ```
+   ## Implementation Plan for #<number>: <title>
 
-### Files to Create/Modify
-- [ ] `path/to/file.py` — description of changes
-- [ ] `tests/test_file.py` — description of test coverage
+   ### Overview
+   Brief description of what will be done.
 
-### Test Plan
-- [ ] Test case 1: description
-- [ ] Test case 2: description
+   ### Files to Create/Modify
+   - [ ] `path/to/file.py` — description of changes
+   - [ ] `tests/test_file.py` — description of test coverage
 
-### Documentation
-- [ ] Any docs that need updating
-- [ ] ADR needed: yes/no (if yes, brief description)
+   ### Test Plan
+   - [ ] Test case 1: description
+   - [ ] Test case 2: description
 
-### Validation
-- [ ] `doit check` passes
-- [ ] Manual verification steps
-```
+   ### Documentation
+   - [ ] Any docs that need updating
+   - [ ] ADR needed: yes/no (if yes, brief description)
+
+   ### Validation
+   - [ ] `doit check` passes
+   - [ ] Manual verification steps
+   ```
+
+2. Use `AskUserQuestion` to ask for feedback on the plan.
+3. Discuss alternatives, answer questions, and adjust the plan as the user requests.
+4. Keep iterating inside plan mode until the user explicitly says the plan is approved.
+5. Do NOT leave plan mode until the user confirms approval.
 
 ### Step 7: Leave plan mode
 
-### Step 8: Iterate with the user
+Once the user has approved the plan, leave plan mode. The `ExitPlanMode` approval prompt means: **"Post the approved plan to the issue."** The plan has already been reviewed and approved by the user during Step 6.
 
-- Present the plan and ask for feedback
-- Discuss alternatives, answer questions, adjust the plan as needed
-- Do NOT post the plan to the issue until the user approves it
+### Step 8: Post the approved plan to the issue
 
-### Step 9: Post the approved plan to the issue
-
-Only after the user approves the plan:
+Post the approved plan as a comment on the issue:
 
 ```bash
 gh issue comment $ARGUMENTS --body "<approved plan>"


### PR DESCRIPTION
## Description

Restructure the plan-issue skill so that plan drafting and user iteration both happen inside plan mode, rather than splitting them across plan mode exit.

Addresses #281

## Related Issue

Addresses #281

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Combined former Steps 6 (draft plan), 7 (leave plan mode), and 8 (iterate with user) into a single Step 6 that keeps the user inside plan mode for the entire draft-and-iterate loop
- Step 7 now exits plan mode only after the user has explicitly approved the plan
- Step 8 posts the approved plan to the issue (formerly Step 9)
- Reduced total steps from 9 to 8 by eliminating the separate iteration step outside plan mode

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is a chore change to an AI agent skill instruction file (`.claude/commands/plan-issue.md`). No Python code, tests, or user-facing documentation are affected. The change improves the plan-issue workflow by keeping the user in plan mode during the entire review cycle, preventing premature exits.
