### PR TITLE
feat: add historical benchmark tracking in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,17 @@ jobs:
           --benchmark-enable --benchmark-only
           --benchmark-json=tmp/benchmark-results.json -v
 
+      - name: Check for benchmark data branch
+        id: check-bench-branch
+        run: |
+          if git ls-remote --exit-code origin gh-benchmarks >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Store benchmark results
+        if: github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -713,14 +713,14 @@ The `benchmark.yml` workflow operates in two modes:
 | Trigger | Behavior |
 |---------|----------|
 | **Push to `main`** | Runs benchmarks and commits results to the `gh-benchmarks` data branch for long-term tracking |
-| **Pull request** | Runs benchmarks and posts a comparison comment on the PR (no commit to data branch) |
+| **Pull request** | Runs benchmarks and posts a comparison comment on the PR if the `gh-benchmarks` branch exists (no commit to data branch) |
 | **Manual dispatch** | Runs benchmarks and uploads artifact only |
 
 Only main branch results are stored to keep the historical data clean and consistent.
 
 ### The `gh-benchmarks` Branch
 
-Benchmark data is stored in a dedicated `gh-benchmarks` branch, separate from the main codebase. This branch is auto-created by the benchmark action on the first push to `main` after the workflow is enabled.
+Benchmark data is stored in a dedicated `gh-benchmarks` branch, separate from the main codebase. This branch is auto-created by the benchmark action on the first push to `main` after the workflow is enabled. Until the branch exists, PR benchmark comparisons are skipped gracefully.
 
 - **Data directory:** `dev/bench/` within the branch
 - **Format:** JSON files with benchmark metrics over time

--- a/tests/test_benchmark_workflow.py
+++ b/tests/test_benchmark_workflow.py
@@ -75,6 +75,29 @@ class TestBenchmarkWorkflowSteps:
                 return step
         return None
 
+    def test_has_check_bench_branch_step(self) -> None:
+        """Workflow should check if the gh-benchmarks branch exists."""
+        step = self._find_step("Check for benchmark data branch")
+        assert step is not None, "Missing 'Check for benchmark data branch' step"
+        assert step.get("id") == "check-bench-branch"
+        assert "gh-benchmarks" in step["run"]
+
+    def test_store_step_conditional_on_branch_existence(self) -> None:
+        """Store step should only run on push or when gh-benchmarks branch exists."""
+        step = self._find_step("Store benchmark results")
+        assert step is not None
+        condition = step.get("if", "")
+        assert "push" in condition
+        assert "check-bench-branch" in condition
+
+    def test_check_bench_branch_before_store_step(self) -> None:
+        """Check branch step should come before store step."""
+        steps = self._get_steps()
+        step_names = [s.get("name") for s in steps]
+        check_idx = step_names.index("Check for benchmark data branch")
+        store_idx = step_names.index("Store benchmark results")
+        assert check_idx < store_idx, "Check branch step must come before Store step"
+
     def test_has_store_benchmark_results_step(self) -> None:
         """Workflow should have a step to store benchmark results."""
         step = self._find_step("Store benchmark results")


### PR DESCRIPTION
## Description

Add historical benchmark tracking to the CI pipeline using `benchmark-action/github-action-benchmark`. Benchmark results from `main` are stored on a dedicated `gh-benchmarks` branch for long-term trend analysis, and PR benchmark comparisons are posted as comments for reviewer visibility.

Addresses #242

## Related Issue

Addresses #242

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Modified `.github/workflows/benchmark.yml` to add a `push` trigger on `main`, upgrade permissions to `contents: write` and `pull-requests: write`, and add a "Store benchmark results" step using `benchmark-action/github-action-benchmark@v1`
- Updated `docs/development/ci-cd-testing.md` with a new "Benchmark Tracking" section documenting how historical tracking works, the `gh-benchmarks` data branch, PR comments, alert thresholds, and optional GitHub Pages setup
- Added `tests/test_benchmark_workflow.py` with comprehensive tests validating the workflow YAML structure, triggers, permissions, step ordering, and benchmark action configuration

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (`tests/test_benchmark_workflow.py` -- 20 tests covering triggers, permissions, step configuration, and ordering)
- [x] `doit check` passes (format, lint, type-check, security, spell-check, tests)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

- The `gh-benchmarks` branch is auto-created by the benchmark action on the first push to `main` after merge. No manual branch creation is needed.
- The alert threshold is set to 110% (10% regression tolerance). This can be adjusted in the workflow file.
- GitHub Pages integration for trend charts is optional and documented but not required.
