### PR TITLE
fix: skip fetch of gh-benchmarks branch when it does not exist yet

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,6 +63,7 @@ jobs:
           gh-pages-branch: gh-benchmarks
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          skip-fetch-gh-pages: ${{ steps.check-bench-branch.outputs.exists != 'true' }}
           comment-on-alert: true
           comment-always: ${{ github.event_name == 'pull_request' }}
           alert-threshold: '110%'

--- a/tests/test_benchmark_workflow.py
+++ b/tests/test_benchmark_workflow.py
@@ -98,6 +98,13 @@ class TestBenchmarkWorkflowSteps:
         store_idx = step_names.index("Store benchmark results")
         assert check_idx < store_idx, "Check branch step must come before Store step"
 
+    def test_store_step_skips_fetch_when_branch_missing(self) -> None:
+        """Store step should skip gh-pages fetch when the data branch doesn't exist."""
+        step = self._find_step("Store benchmark results")
+        assert step is not None
+        skip_fetch = step["with"]["skip-fetch-gh-pages"]
+        assert "check-bench-branch" in skip_fetch
+
     def test_has_store_benchmark_results_step(self) -> None:
         """Workflow should have a step to store benchmark results."""
         step = self._find_step("Store benchmark results")


### PR DESCRIPTION
## Description

Fix benchmark CI failure on push to `main` when the `gh-benchmarks` data branch doesn't exist yet. The `benchmark-action/github-action-benchmark` action always attempts to `git fetch` the data branch before storing results, which fails when the branch hasn't been created. This adds `skip-fetch-gh-pages` conditioned on the branch existence check so the action can create the branch fresh on first run.

## Related Issue

Addresses #242

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `skip-fetch-gh-pages` parameter to the "Store benchmark results" step, conditioned on the branch existence check output
- Added test validating the `skip-fetch-gh-pages` conditional references the check step

## Testing

- [x] All existing tests pass
- [x] Added new test for `skip-fetch-gh-pages` conditional
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
