### PR TITLE
fix: bootstrap gh-benchmarks branch when it does not exist

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,6 +54,14 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create benchmark data branch
+        if: steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
+        run: |
+          git switch --orphan gh-benchmarks
+          git commit --allow-empty -m "Initialize benchmark data branch"
+          git push origin gh-benchmarks
+          git switch -
+
       - name: Store benchmark results
         if: github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true'
         uses: benchmark-action/github-action-benchmark@v1
@@ -63,7 +71,6 @@ jobs:
           gh-pages-branch: gh-benchmarks
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          skip-fetch-gh-pages: ${{ steps.check-bench-branch.outputs.exists != 'true' }}
           comment-on-alert: true
           comment-always: ${{ github.event_name == 'pull_request' }}
           alert-threshold: '110%'

--- a/tests/test_benchmark_workflow.py
+++ b/tests/test_benchmark_workflow.py
@@ -98,12 +98,22 @@ class TestBenchmarkWorkflowSteps:
         store_idx = step_names.index("Store benchmark results")
         assert check_idx < store_idx, "Check branch step must come before Store step"
 
-    def test_store_step_skips_fetch_when_branch_missing(self) -> None:
-        """Store step should skip gh-pages fetch when the data branch doesn't exist."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        skip_fetch = step["with"]["skip-fetch-gh-pages"]
-        assert "check-bench-branch" in skip_fetch
+    def test_has_create_bench_branch_step(self) -> None:
+        """Workflow should create the gh-benchmarks branch if it doesn't exist."""
+        step = self._find_step("Create benchmark data branch")
+        assert step is not None, "Missing 'Create benchmark data branch' step"
+        condition = step.get("if", "")
+        assert "check-bench-branch" in condition
+        assert "push" in condition
+        assert "gh-benchmarks" in step["run"]
+
+    def test_create_branch_before_store_step(self) -> None:
+        """Create branch step should come before store step."""
+        steps = self._get_steps()
+        step_names = [s.get("name") for s in steps]
+        create_idx = step_names.index("Create benchmark data branch")
+        store_idx = step_names.index("Store benchmark results")
+        assert create_idx < store_idx
 
     def test_has_store_benchmark_results_step(self) -> None:
         """Workflow should have a step to store benchmark results."""


### PR DESCRIPTION
## Description

Fix benchmark CI failure on push to `main` when the `gh-benchmarks` data branch doesn't exist. The previous fix (`skip-fetch-gh-pages`) only skipped the remote fetch — the action still fails on `git switch gh-benchmarks` locally. This adds a bootstrap step that creates an empty orphan `gh-benchmarks` branch and pushes it before the benchmark action runs.

## Related Issue

Addresses #242

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added "Create benchmark data branch" step that creates an orphan `gh-benchmarks` branch on first push to `main`
- Removed `skip-fetch-gh-pages` workaround (no longer needed since the branch will exist)
- Updated tests: replaced `skip-fetch-gh-pages` test with tests for the new bootstrap step

## Testing

- [x] All existing tests pass
- [x] Updated tests for new workflow structure
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
