### PR TITLE
fix: configure git identity for benchmark data branch bootstrap

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Create benchmark data branch
         if: steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git switch --orphan gh-benchmarks
           git commit --allow-empty -m "Initialize benchmark data branch"
           git push origin gh-benchmarks

--- a/tests/test_benchmark_workflow.py
+++ b/tests/test_benchmark_workflow.py
@@ -106,6 +106,8 @@ class TestBenchmarkWorkflowSteps:
         assert "check-bench-branch" in condition
         assert "push" in condition
         assert "gh-benchmarks" in step["run"]
+        assert "git config user.name" in step["run"]
+        assert "git config user.email" in step["run"]
 
     def test_create_branch_before_store_step(self) -> None:
         """Create branch step should come before store step."""


### PR DESCRIPTION
## Description

Fix benchmark CI failure when bootstrapping the `gh-benchmarks` data branch. The `git commit --allow-empty` command fails because the GitHub Actions runner has no git identity configured. This adds `git config user.name/email` using the `github-actions[bot]` identity before the commit.

## Related Issue

Addresses #242

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `git config user.name` and `git config user.email` before the empty commit in the "Create benchmark data branch" step
- Updated test to verify git config commands are present

## Testing

- [x] All existing tests pass
- [x] Updated test for git identity configuration
- [x] `doit check` passes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings
