### PR TITLE
fix: propagate --yes flag to manage.py subcommands

### DIFF
--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -62,7 +62,7 @@ After installation:
 Per [Template Manager](manage.md) "Workflow: Staying Up to Date":
 
 ```bash
-python tools/pyproject_template/manage.py check
+python tools/pyproject_template/manage.py --yes check
 ```
 
 This will (per [Tools Reference](tools-reference.md)):
@@ -222,7 +222,7 @@ AI coding assistants (Claude Code, Gemini CLI, Codex) use hooks to block dangero
 Per [Template Manager](manage.md) step [5]:
 
 ```bash
-python tools/pyproject_template/manage.py sync
+python tools/pyproject_template/manage.py --yes sync
 ```
 
 This:
@@ -255,11 +255,11 @@ This:
 
 Once `tools/pyproject_template/manage.py` is installed and sync state is tracked, future updates follow this simplified workflow:
 
-1. **Check:** `python tools/pyproject_template/manage.py check`
+1. **Check:** `python tools/pyproject_template/manage.py --yes check`
 2. **Review:** Inspect diffs for Modified/Missing files
 3. **Apply:** Manually merge relevant changes
 4. **Validate:** `doit check`
-5. **Mark synced:** `python tools/pyproject_template/manage.py sync`
+5. **Mark synced:** `python tools/pyproject_template/manage.py --yes sync`
 6. **Commit:** Follow issue → branch → PR workflow
 
 ---

--- a/tests/pyproject_template/test_pyproject_template_main.py
+++ b/tests/pyproject_template/test_pyproject_template_main.py
@@ -752,6 +752,182 @@ class TestCheckUpdatesModule:
         assert args.dry_run is True
 
 
+class TestYesFlagBehavior:
+    """Tests for --yes flag threading through subcommands."""
+
+    def test_yes_flag_passed_to_run_action(self) -> None:
+        """Verify main(["--yes", "sync"]) passes yes=True through to run_action."""
+        from tools.pyproject_template.manage import main
+
+        with (
+            patch("tools.pyproject_template.manage.SettingsManager") as mock_manager_cls,
+            patch("tools.pyproject_template.manage.run_action", return_value=0) as mock_run_action,
+        ):
+            mock_manager = MagicMock()
+            mock_manager_cls.return_value = mock_manager
+
+            main(["--yes", "sync"])
+
+            mock_run_action.assert_called_once_with(
+                5, mock_manager, False, yes=True, cleanup_mode=None
+            )
+
+    def test_sync_with_yes_skips_prompt(self, tmp_path: Path) -> None:
+        """Verify action_mark_synced() with yes=True skips the confirmation prompt."""
+        from tools.pyproject_template.manage import action_mark_synced
+
+        # Set up template commit file
+        template_dir = tmp_path / "tmp" / "extracted" / "pyproject-template-main"
+        template_dir.mkdir(parents=True)
+        commit_file = template_dir / ".template_commit"
+        commit_file.write_text("abc123newcommit\n2025-06-15\n")
+
+        mock_manager = MagicMock()
+        mock_manager.template_state.commit = "oldcommit000"
+
+        with (
+            patch("tools.pyproject_template.manage.Path") as mock_path_cls,
+            patch("tools.pyproject_template.manage.prompt") as mock_prompt,
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            # Make Path("tmp/extracted/...") resolve to our tmp_path
+            def path_side_effect(arg: str = "") -> Path:
+                if arg == "tmp/extracted/pyproject-template-main":
+                    return template_dir
+                return Path(arg)
+
+            mock_path_cls.side_effect = path_side_effect
+
+            # subprocess calls succeed
+            mock_subprocess.return_value = MagicMock(returncode=0)
+
+            action_mark_synced(mock_manager, dry_run=False, yes=True)
+
+            # prompt should NOT have been called
+            mock_prompt.assert_not_called()
+            # update_template_state should have been called
+            mock_manager.update_template_state.assert_called_once_with(
+                "abc123newcommit", "2025-06-15"
+            )
+
+    def test_create_with_yes_skips_adr_prompt(self) -> None:
+        """Verify action_create_project() with yes=True skips prompt_confirm for ADRs."""
+        from tools.pyproject_template.manage import action_create_project
+
+        mock_manager = MagicMock()
+        mock_manager.settings.github_user = "testuser"
+        mock_manager.settings.github_repo = "test-repo"
+        mock_manager.settings.description = "desc"
+        mock_manager.settings.package_name = "test_pkg"
+        mock_manager.settings.pypi_name = "test-pkg"
+        mock_manager.settings.author_name = "Author"
+        mock_manager.settings.author_email = "a@b.com"
+
+        with (
+            patch("tools.pyproject_template.manage.prompt_confirm") as mock_confirm,
+            patch.dict("sys.modules", {"setup_repo": MagicMock()}),
+        ):
+            # Import the mocked setup_repo
+            import sys
+
+            mock_setup_module = sys.modules["setup_repo"]
+            mock_setup_cls = MagicMock()
+            mock_setup_module.RepositorySetup.return_value = mock_setup_cls
+            mock_setup_cls.config = {}
+
+            with (
+                patch("tools.pyproject_template.manage.Path") as mock_path_cls,
+                patch(
+                    "tools.pyproject_template.manage.get_template_latest_commit", return_value=None
+                ),
+            ):
+                mock_cwd = MagicMock()
+                mock_path_cls.cwd.return_value = mock_cwd
+                mock_template_dir = MagicMock()
+                mock_project_dir = MagicMock()
+                mock_template_dir.exists.return_value = True
+                mock_project_dir.exists.return_value = True
+                mock_cwd.__truediv__ = lambda self, key: (
+                    mock_template_dir
+                    if "template" in str(key)
+                    else mock_project_dir
+                    if "decisions" in str(key)
+                    else MagicMock()
+                )
+
+                action_create_project(mock_manager, dry_run=False, yes=True)
+
+                # prompt_confirm should NOT have been called (skipped by yes=True)
+                mock_confirm.assert_not_called()
+
+    def test_cleanup_with_yes_skips_prompt(self) -> None:
+        """Verify action_template_cleanup() with yes=True skips prompt_cleanup."""
+        from tools.pyproject_template.manage import action_template_cleanup
+
+        mock_manager = MagicMock()
+
+        with patch("tools.pyproject_template.manage.prompt_cleanup") as mock_prompt_cleanup:
+            result = action_template_cleanup(mock_manager, dry_run=False, yes=True)
+
+            assert result == 0
+            mock_prompt_cleanup.assert_not_called()
+
+    def test_configure_with_yes_uses_auto_mode(self) -> None:
+        """Verify action_configure() with yes=True calls run_configure with auto=True."""
+        from tools.pyproject_template.manage import action_configure
+
+        mock_manager = MagicMock()
+        mock_manager.settings.project_name = "test"
+        mock_manager.settings.package_name = "test"
+        mock_manager.settings.pypi_name = "test"
+        mock_manager.settings.description = "test"
+        mock_manager.settings.author_name = "test"
+        mock_manager.settings.author_email = "test@test.com"
+        mock_manager.settings.github_user = "test"
+
+        with (
+            patch("tools.pyproject_template.manage.run_configure", return_value=0) as mock_run,
+            patch("tools.pyproject_template.manage.load_defaults", return_value={}),
+        ):
+            result = action_configure(mock_manager, dry_run=False, yes=True)
+
+            assert result == 0
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            assert kwargs["auto"] is True
+            assert kwargs["yes"] is True
+
+    def test_cleanup_with_cleanup_mode_setup(self) -> None:
+        """Verify action_template_cleanup() with cleanup_mode='setup' uses that mode."""
+        from tools.pyproject_template.manage import action_template_cleanup
+
+        mock_manager = MagicMock()
+
+        with (
+            patch("tools.pyproject_template.manage.cleanup_template_files") as mock_cleanup,
+            patch("tools.pyproject_template.manage.prompt_cleanup"),
+        ):
+            mock_result = MagicMock()
+            mock_result.failed = []
+            mock_cleanup.return_value = mock_result
+
+            result = action_template_cleanup(mock_manager, dry_run=False, cleanup_mode="setup")
+
+            assert result == 0
+            mock_cleanup.assert_called_once()
+
+    def test_cleanup_with_invalid_mode_fails(self) -> None:
+        """Verify action_template_cleanup() with invalid cleanup_mode returns error."""
+        from tools.pyproject_template.manage import action_template_cleanup
+
+        mock_manager = MagicMock()
+
+        with patch("tools.pyproject_template.manage.prompt_cleanup"):
+            result = action_template_cleanup(mock_manager, dry_run=False, cleanup_mode="invalid")
+
+            assert result == 1
+
+
 class TestMigrateModule:
     """Tests for the migrate_existing_project module refactoring."""
 

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -281,20 +281,27 @@ def edit_settings(manager: SettingsManager) -> None:
     manager.save()
 
 
-def run_action(action: int, manager: SettingsManager, dry_run: bool) -> int:
+def run_action(
+    action: int,
+    manager: SettingsManager,
+    dry_run: bool,
+    *,
+    yes: bool = False,
+    cleanup_mode: str | None = None,
+) -> int:
     """Run the selected action."""
     if action == 1:
-        return action_create_project(manager, dry_run)
+        return action_create_project(manager, dry_run, yes=yes)
     elif action == 2:
-        return action_configure(manager, dry_run)
+        return action_configure(manager, dry_run, yes=yes)
     elif action == 3:
         return action_check_updates(manager, dry_run)
     elif action == 4:
         return action_repo_settings(manager, dry_run)
     elif action == 5:
-        return action_mark_synced(manager, dry_run)
+        return action_mark_synced(manager, dry_run, yes=yes)
     elif action == 6:
-        return action_template_cleanup(manager, dry_run)
+        return action_template_cleanup(manager, dry_run, yes=yes, cleanup_mode=cleanup_mode)
     else:
         Logger.error(f"Unknown action: {action}")
         return 1
@@ -319,7 +326,7 @@ def _copy_template_adrs(template_dir: Path, project_dir: Path) -> int:
     return copied
 
 
-def action_create_project(manager: SettingsManager, dry_run: bool) -> int:
+def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool = False) -> int:
     """Create a new project from the template."""
     Logger.header("Creating New Project from Template")
 
@@ -375,14 +382,17 @@ def action_create_project(manager: SettingsManager, dry_run: bool) -> int:
         # Offer to copy template ADRs into project decisions
         template_adrs_dir = Path.cwd() / "docs" / "template" / "decisions"
         project_adrs_dir = Path.cwd() / "docs" / "decisions"
-        if (
-            template_adrs_dir.exists()
+        # When yes=True, skip prompt and default to False (don't copy ADRs)
+        should_copy_adrs = (
+            not yes
+            and template_adrs_dir.exists()
             and project_adrs_dir.exists()
             and prompt_confirm(
                 "Include template ADRs in project decisions directory?",
                 default=False,
             )
-        ):
+        )
+        if should_copy_adrs:
             count = _copy_template_adrs(template_adrs_dir, project_adrs_dir)
             Logger.info(f"Copied {count} template ADR(s) to docs/decisions/")
 
@@ -473,7 +483,7 @@ def action_check_updates(manager: SettingsManager, dry_run: bool) -> int:
     return int(result)
 
 
-def action_configure(manager: SettingsManager, dry_run: bool) -> int:
+def action_configure(manager: SettingsManager, dry_run: bool, *, yes: bool = False) -> int:
     """Re-run configuration."""
     Logger.header("Running Configuration")
 
@@ -496,8 +506,8 @@ def action_configure(manager: SettingsManager, dry_run: bool) -> int:
 
     return int(
         run_configure(
-            auto=False,
-            yes=False,
+            auto=yes,
+            yes=yes,
             dry_run=dry_run,
             defaults=defaults,
         )
@@ -540,7 +550,7 @@ def action_repo_settings(manager: SettingsManager, dry_run: bool) -> int:
         return 1
 
 
-def action_mark_synced(manager: SettingsManager, dry_run: bool) -> int:
+def action_mark_synced(manager: SettingsManager, dry_run: bool, *, yes: bool = False) -> int:
     """Mark project as synced to reviewed template commit."""
     import shutil
     import subprocess  # nosec B404 - subprocess is required for git operations
@@ -581,11 +591,12 @@ def action_mark_synced(manager: SettingsManager, dry_run: bool) -> int:
         Logger.info(f"Dry run: Would mark as synced to {new_commit}")
         return 0
 
-    # Confirm with user
-    confirm = prompt(f"Mark as synced to {new_commit}?", "Y")
-    if confirm.lower() not in ("y", "yes", ""):
-        Logger.warning("Cancelled")
-        return 0
+    # Confirm with user (skip when yes=True to auto-confirm)
+    if not yes:
+        confirm = prompt(f"Mark as synced to {new_commit}?", "Y")
+        if confirm.lower() not in ("y", "yes", ""):
+            Logger.warning("Cancelled")
+            return 0
 
     # Update template state
     manager.update_template_state(new_commit, new_date)
@@ -645,7 +656,13 @@ def action_mark_synced(manager: SettingsManager, dry_run: bool) -> int:
     return 0
 
 
-def action_template_cleanup(manager: SettingsManager, dry_run: bool) -> int:
+def action_template_cleanup(
+    manager: SettingsManager,
+    dry_run: bool,
+    *,
+    yes: bool = False,
+    cleanup_mode: str | None = None,
+) -> int:
     """Clean up template-specific files."""
     Logger.header("Template File Cleanup")
 
@@ -657,11 +674,27 @@ def action_template_cleanup(manager: SettingsManager, dry_run: bool) -> int:
         Logger.info("Dry run: Would prompt for cleanup mode and show files to delete")
         return 0
 
-    # Prompt user for cleanup mode
-    mode = prompt_cleanup()
-    if mode is None:
-        Logger.info("Keeping all template files")
+    mode = None
+
+    if cleanup_mode:
+        # CLI-specified mode (cleanup module is guaranteed available after guard above)
+        from cleanup import CleanupMode as CleanupModeEnum
+
+        mode_map = {"setup": CleanupModeEnum.SETUP_ONLY, "all": CleanupModeEnum.ALL}
+        mode = mode_map.get(cleanup_mode)
+        if mode is None:
+            Logger.error(f"Invalid cleanup mode: {cleanup_mode}. Use 'setup' or 'all'.")
+            return 1
+    elif yes:
+        # Non-interactive without explicit mode: skip cleanup (safer default)
+        Logger.info("Non-interactive mode: skipping cleanup (use --cleanup-mode to specify)")
         return 0
+    else:
+        # Interactive prompt
+        mode = prompt_cleanup()
+        if mode is None:
+            Logger.info("Keeping all template files")
+            return 0
 
     # Perform cleanup
     result = cleanup_template_files(mode, dry_run=False)
@@ -674,13 +707,16 @@ def action_template_cleanup(manager: SettingsManager, dry_run: bool) -> int:
     return 0
 
 
-def offer_cleanup_prompt() -> None:
+def offer_cleanup_prompt(*, yes: bool = False) -> None:
     """Offer to clean up template files after successful setup.
 
     This is called after "Create new project" or "Configure project" completes.
     """
     if prompt_cleanup is None or cleanup_template_files is None:
         return  # Cleanup module not available
+
+    if yes:
+        return  # Non-interactive mode: skip cleanup
 
     print()
     response = prompt("Would you like to clean up template-specific files? (y/N)", "n")
@@ -737,7 +773,7 @@ def prompt_initial_settings(manager: SettingsManager) -> None:
     print()
 
 
-def interactive_menu(manager: SettingsManager, dry_run: bool = False) -> int:
+def interactive_menu(manager: SettingsManager, dry_run: bool = False, *, yes: bool = False) -> int:
     """Run the interactive menu loop."""
     # Prompt for initial settings if not configured
     prompt_initial_settings(manager)
@@ -782,12 +818,12 @@ def interactive_menu(manager: SettingsManager, dry_run: bool = False) -> int:
             Logger.info(f"Dry run mode: {'enabled' if dry_run else 'disabled'}")
         elif choice in ("1", "2", "3", "4", "5", "6"):
             action = int(choice)
-            result = run_action(action, manager, dry_run)
+            result = run_action(action, manager, dry_run, yes=yes)
             if result == 0:
                 Logger.success("Action completed successfully")
                 # Offer cleanup after successful create/configure (but not for cleanup itself)
                 if action in (1, 2) and not dry_run:
-                    offer_cleanup_prompt()
+                    offer_cleanup_prompt(yes=yes)
             else:
                 Logger.error("Action failed")
             input("\nPress enter to return to menu...")
@@ -812,6 +848,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     subparsers.add_parser("check", help="Check for template updates")
     subparsers.add_parser("repo", help="Update repository settings")
     subparsers.add_parser("sync", help="Mark as synced to latest template")
+    cleanup_parser = subparsers.add_parser("cleanup", help="Clean up template-specific files")
+    cleanup_parser.add_argument(
+        "--cleanup-mode",
+        choices=["setup", "all"],
+        help="Cleanup mode: 'setup' removes setup files only, 'all' removes all template files",
+    )
 
     # Global options
     parser.add_argument(
@@ -849,10 +891,14 @@ def main(argv: list[str] | None = None) -> int:
             "check": 3,
             "repo": 4,
             "sync": 5,
+            "cleanup": 6,
         }
         action = command_map.get(args.command)
         if action:
-            return run_action(action, manager, args.dry_run)
+            cleanup_mode = getattr(args, "cleanup_mode", None)
+            return run_action(
+                action, manager, args.dry_run, yes=args.yes, cleanup_mode=cleanup_mode
+            )
         return 1
 
     # Handle --update-only (CI mode)
@@ -874,7 +920,7 @@ def main(argv: list[str] | None = None) -> int:
             manager.context, manager.settings, manager.template_state, latest_commit
         )
         if recommended:
-            return run_action(recommended, manager, args.dry_run)
+            return run_action(recommended, manager, args.dry_run, yes=True)
         Logger.success("Project is up to date, no action needed.")
         return 0
 


### PR DESCRIPTION
## Description

Fixed `--yes` flag propagation to subcommands (`sync`, `configure`, `create`, `cleanup`) in `manage.py`. Previously, `--yes` was only handled at the top level and ignored when subcommands were invoked. Also added a `cleanup` subcommand with `--cleanup-mode` option and updated the AI sync checklist to use `--yes`.

## Related Issue

Addresses #290

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Fixed `--yes` flag to propagate correctly to all subcommands (`sync`, `configure`, `create`, `cleanup`)
- `configure --yes` now uses auto-detection from `pyproject.toml` instead of prompting
- Added `cleanup` subcommand with `--cleanup-mode` option
- Updated AI sync checklist documentation to use `--yes` flag
- Added 7 tests covering `--yes` flag behavior across subcommands

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
