### PR TITLE
feat: add temporary files policy for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,25 @@ AI agents with native file tools (Read, Grep, Glob, Edit, Write) **must** prefer
 
 Native tools provide better visibility, review capabilities, and error handling for the user.
 
+### Temporary Files
+
+AI agents **must never** write temporary files to generic locations like `/tmp/`. Instead, use the project-scoped directory:
+
+```
+tmp/agents/<agent-type>/
+```
+
+Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the relevant agent name.
+
+**Filenames must include context** (issue number, PR number, or task identifier) to prevent collisions when multiple sub-agents run concurrently.
+
+| | Example |
+| :--- | :--- |
+| **Before (wrong)** | `/tmp/pr-body.md` |
+| **After (correct)** | `tmp/agents/claude/pr-body-issue-307.md` |
+
+**Cleanup rule:** Agents must delete their temporary files when the task is complete. Do not leave stale files in `tmp/agents/`.
+
 ## Token Efficiency
 - **Be Concise:** Minimal text output.
 - **Use Local Tools:** Prefer native file tools over sub-agents (see [AI Agent File Operations](#ai-agent-file-operations)).


### PR DESCRIPTION
## Description

Add a "Temporary Files" policy subsection to the "Tooling & Environment" section of AGENTS.md. This establishes a project-scoped convention (`tmp/agents/<agent-type>/`) for AI agent temporary files, replacing ad-hoc use of `/tmp/` or other generic locations.

## Related Issue

Addresses #317

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added "### Temporary Files" subsection under "## Tooling & Environment" in AGENTS.md
- Defines `tmp/agents/<agent-type>/` as the required location for agent temporary files
- Requires context-aware filenames (issue/PR number) to prevent collisions
- Includes before/after examples and a cleanup rule

## Testing

- [x] All existing tests pass
- [x] `doit check` passes (no code changes, documentation only)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

Documentation-only change. No code, tests, or ADR required.
