### PR TITLE
fix: ensure tmp/ directory exists in benchmark CI workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,10 +40,11 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run benchmarks
-        run: >
-          uv run pytest tests/benchmarks/
-          --benchmark-enable --benchmark-only
-          --benchmark-json=tmp/benchmark-results.json -v
+        run: |
+          mkdir -p tmp
+          uv run pytest tests/benchmarks/ \
+            --benchmark-enable --benchmark-only \
+            --benchmark-json=tmp/benchmark-results.json -v
 
       - name: Check for benchmark data branch
         id: check-bench-branch


### PR DESCRIPTION
## Description

The benchmark CI workflow fails because it writes results to `tmp/benchmark-results.json`, but the `tmp/` directory does not exist in the CI runner environment.

Adds `mkdir -p tmp` before the pytest benchmark command to ensure the directory exists.

## Related Issue

Addresses #302

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `mkdir -p tmp` step before pytest benchmark execution in `.github/workflows/benchmark.yml`
- Switched from YAML folded scalar (`>`) to literal block scalar (`|`) to support multi-line shell commands

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

This is a CI-only change. No application code, tests, or documentation are affected. The fix ensures the `tmp/` output directory exists before pytest writes benchmark results to it.
