### PR TITLE
docs: add pre-commit exclude pattern guidance for large/generated dirs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,16 @@ repos:
         stages: [pre-commit]
       - id: check-added-large-files
         stages: [pre-commit]
+        # Add project-specific exclusions for large data/generated directories:
+        # exclude: ^(vendor/|fixtures/|data/)
       - id: check-toml
         stages: [pre-commit]
       - id: check-merge-conflict
         stages: [pre-commit]
       - id: detect-private-key
         stages: [pre-commit]
+        # Exclude directories with non-secret key-like patterns:
+        # exclude: ^(example-config/|test-fixtures/)
 
   # Conventional commits enforcement
   - repo: https://github.com/compilerla/conventional-pre-commit


### PR DESCRIPTION
## Description

Add commented-out `exclude:` pattern examples to `.pre-commit-config.yaml` for the `check-added-large-files` and `detect-private-key` hooks. This gives contributors ready-made templates they can uncomment and adapt when projects have large data directories or non-secret key-like files that trigger false positives.

## Related Issue

Addresses #294

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added commented-out `exclude:` example after `check-added-large-files` hook for large data/generated directories
- Added commented-out `exclude:` example after `detect-private-key` hook for directories with non-secret key-like patterns

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Comment-only change to `.pre-commit-config.yaml`. No functional behavior is altered. No tests are needed since no code is added or modified.
