### PR TITLE
fix: restore mutation testing workflow on mutmut 3.x

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -36,16 +36,36 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Run mutation testing
+      - name: Run mutmut
+        timeout-minutes: 120
         run: |
-          uv run mutmut run || true
-          uv run mutmut results
-          uv run mutmut html --html-dir tmp/mutmut
+          mkdir -p tmp
+          uv run mutmut run > tmp/mutmut-run-raw.log 2>&1 || true
+
+      - name: Mutation results
+        if: always()
+        run: |
+          mkdir -p tmp
+          if [ -f tmp/mutmut-run-raw.log ]; then
+            # Strip spinner/carriage-return noise from log.
+            # mutmut renders progress with braille spinners + \r; convert \r to \n,
+            # drop blank lines, and drop the repeating spinner phrases.
+            tr '\r' '\n' < tmp/mutmut-run-raw.log \
+              | grep -v '^[[:space:]]*$' \
+              | grep -avE 'Generating mutants|Running stats|Running clean tests|Running mutation testing|Running forced fail test|^[[:space:]]*[^[:alnum:]]*[[:space:]]*[0-9]+/[0-9]+' \
+              > tmp/mutmut-run.log || true
+            echo "=== Mutation run log ==="
+            cat tmp/mutmut-run.log
+          fi
+          uv run mutmut results 2>/dev/null | tee tmp/mutmut-results.txt || true
+          echo ""
+          echo "=== Summary ==="
+          awk -F': ' '{print $NF}' tmp/mutmut-results.txt 2>/dev/null | sort | uniq -c | sort -rn || true
 
       - name: Upload mutation results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: mutation-results
-          path: tmp/mutmut/
+          path: tmp/mutmut-results.txt
           retention-days: 90

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -687,11 +687,8 @@ This project uses [mutmut](https://mutmut.readthedocs.io/) for mutation testing.
 # Run mutation testing (generates results and prints summary)
 doit mutate
 
-# Generate an HTML report for detailed review
-doit mutate_html
-
-# Open the report in a browser
-xdg-open tmp/mutmut/index.html
+# View text results again without re-running
+uv run mutmut results
 ```
 
 ### Interpreting Results
@@ -709,7 +706,7 @@ The **mutation score** is the percentage of mutants killed out of total mutants 
 
 Mutation testing runs weekly in CI (Sunday midnight UTC) via the `.github/workflows/mutation.yml` workflow. It is informational only and does not block merges or fail the build.
 
-Results are uploaded as artifacts with 90-day retention. You can also trigger the workflow manually from the Actions tab using the `workflow_dispatch` event.
+Results are uploaded as the `mutmut-results.txt` artifact with 90-day retention. You can also trigger the workflow manually from the Actions tab using the `workflow_dispatch` event.
 
 ## Benchmark Tracking
 

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -31,7 +31,7 @@ doit <task_name>
 
 | Category | Tasks | Description |
 |----------|-------|-------------|
-| [Testing](#testing-tasks) | `test`, `coverage`, `mutate`, `mutate_html` | Run tests, coverage, and mutation testing |
+| [Testing](#testing-tasks) | `test`, `coverage`, `mutate` | Run tests, coverage, and mutation testing |
 | [Benchmarking](#benchmarking-tasks) | `benchmark`, `benchmark_save`, `benchmark_compare` | Performance benchmarks |
 | [Code Quality](#code-quality-tasks) | `format`, `lint`, `type_check`, `check` | Code formatting and linting |
 | [Code Analysis](#code-analysis-tasks) | `complexity`, `maintainability`, `deadcode` | Code metrics and analysis |
@@ -102,7 +102,7 @@ doit mutate
 - Reports which mutations were killed (detected) vs survived (missed)
 - Prints a summary with the mutation score
 
-**Output:** Results are stored in `tmp/mutmut/` directory.
+**Output:** Results are stored in the `mutants/` cache directory. Re-run `uv run mutmut results` at any time to re-display the text summary.
 
 **When to use:**
 - To evaluate how effective your test suite is at detecting bugs
@@ -110,25 +110,6 @@ doit mutate
 - Informational only -- no enforced threshold
 
 See [Mutation Testing](ci-cd-testing.md#mutation-testing) for details on interpreting results.
-
-### `mutate_html`
-
-Generate an HTML report from mutation testing results.
-
-```bash
-doit mutate_html
-```
-
-**What it does:**
-- Generates a detailed HTML report from the latest `doit mutate` run
-- Report is saved to `tmp/mutmut/index.html`
-
-**Prerequisite:** Run `doit mutate` first to generate results.
-
-**Viewing the report:**
-```bash
-xdg-open tmp/mutmut/index.html
-```
 
 ---
 

--- a/docs/development/extensions.md
+++ b/docs/development/extensions.md
@@ -126,7 +126,7 @@ Test your tests by introducing bugs and verifying they catch them.
 [project.optional-dependencies]
 dev = [
     # ... existing deps ...
-    "mutmut>=2.4",
+    "mutmut>=3.0",
 ]
 
 # Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,8 +235,8 @@ ignore_decorators = [
 ]
 
 [tool.mutmut]
-paths_to_mutate = "src/"
-tests_dir = "tests/"
+paths_to_mutate = ["src/"]
+tests_dir = ["tests/"]
 runner = "uv run python -m pytest -x --assert=plain"
 
 [tool.commitizen]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,14 @@ settings.register_profile(
     "ci",
     max_examples=50,
     deadline=500,
-    suppress_health_check=[HealthCheck.too_slow],
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.differing_executors],
 )
 
 # Default profile: more thorough exploration for local development
 settings.register_profile(
     "default",
     max_examples=200,
+    suppress_health_check=[HealthCheck.differing_executors],
 )
 
 settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))

--- a/tests/test_doit_install_tools.py
+++ b/tests/test_doit_install_tools.py
@@ -74,13 +74,16 @@ class TestGetLatestGithubRelease:
             "Authorization", "token test-token"
         )
 
-    @patch.dict("os.environ", {}, clear=True)
     @patch("tools.doit.install_tools.urllib.request.urlopen")
     @patch("tools.doit.install_tools.urllib.request.Request")
     def test_no_auth_header_when_no_token(
-        self, mock_request_cls: MagicMock, mock_urlopen: MagicMock
+        self,
+        mock_request_cls: MagicMock,
+        mock_urlopen: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that no Authorization header is added without GITHUB_TOKEN."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         mock_request_instance = MagicMock()
         mock_request_cls.return_value = mock_request_instance
 

--- a/tools/doit/testing.py
+++ b/tools/doit/testing.py
@@ -36,12 +36,3 @@ def task_mutate() -> dict[str, Any]:
         "title": title_with_actions,
         "verbosity": 2,
     }
-
-
-def task_mutate_html() -> dict[str, Any]:
-    """Generate HTML report from mutmut results."""
-    return {
-        "actions": ["uv run mutmut html --html-dir tmp/mutmut"],
-        "title": title_with_actions,
-        "verbosity": 2,
-    }


### PR DESCRIPTION
## Description

Fixes mutation testing workflow incompatibilities with mutmut 3.x. The existing configuration caused mutmut to walk the entire filesystem (treating the string config values as iterable characters), and the CI job used a `mutmut html` subcommand that no longer exists in 3.x. This PR restores a working `doit mutate` task and CI workflow on mutmut 3.x, and fixes two unrelated test-suite issues that surfaced while validating the change.

## Related Issue

Addresses #330

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- **`pyproject.toml`**: Change `[tool.mutmut]` `paths_to_mutate` and `tests_dir` from strings to single-element lists. In mutmut 3.x these options must be lists; passing a string causes mutmut to iterate character-by-character and walk the filesystem, producing a hang/failure.
- **`tools/doit/testing.py`**: Remove `task_mutate_html` — the `mutmut html` subcommand was removed in 3.x. Text results via `uv run mutmut results` are the supported output.
- **`.github/workflows/mutation.yml`**: Rework the job to (1) run `mutmut run` with a 120-minute timeout, redirecting output to a raw log; (2) strip mutmut's carriage-return/braille spinner noise before printing; (3) capture `mutmut results` into `tmp/mutmut-results.txt`; (4) print a summary histogram; (5) upload `tmp/mutmut-results.txt` as the `mutation-results` artifact (replacing the removed HTML directory).
- **`tests/conftest.py`**: Add `HealthCheck.differing_executors` to `suppress_health_check` for both `ci` and `default` Hypothesis profiles. mutmut runs each mutant in a fresh subprocess, which Hypothesis flags as flaky without this suppression.
- **`tests/test_doit_install_tools.py`**: Replace `@patch.dict("os.environ", {}, clear=True)` with `monkeypatch.delenv("GITHUB_TOKEN", raising=False)`. Clearing the entire environment strips `MUTANT_UNDER_TEST`, which mutmut's trampoline requires — without this fix, mutmut's initial test run aborts with `KeyError` and zero mutants are tested.
- **Docs**: Update `docs/development/ci-cd-testing.md`, `docs/development/doit-tasks-reference.md`, and `docs/development/extensions.md` to remove references to `doit mutate_html` / `mutmut html` / `tmp/mutmut/index.html`, document `uv run mutmut results` as the re-display command, describe the new `mutmut-results.txt` artifact, and bump the documented `mutmut` version floor to `>=3.0`.

## Root Cause

`mutmut` 3.x tightened its config schema: `paths_to_mutate` and `tests_dir` must be lists. When given strings, Python iterates them character-by-character, so mutmut tried to mutate paths like `s`, `r`, `c`, `/`, ... and walked the filesystem from the working directory. Combined with the removal of the `mutmut html` subcommand, the existing workflow and `doit mutate_html` task were broken end-to-end.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added/updated tests for changed behavior (Hypothesis profile + env-clearing fix)
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell-check, tests).

The mutmut config and workflow fixes were additionally validated end-to-end in a downstream consumer of this template (endavis/infrafoundry#496), where the full mutation CI run succeeds on mutmut 3.x with the same config/workflow changes applied.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required (issue is not labelled `needs-adr` and this is a bug fix, not an architectural decision).
- The test-suite fixes (`conftest.py`, `test_doit_install_tools.py`) are included here because they are required for mutmut to actually exercise mutants — without them, the workflow would still report zero meaningful results even after the config and CI fixes.
