### PR TITLE
docs: add git pull reminder before branching in AGENTS.md Flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **No Speculation:** Don't read files you don't need.
 
 ## Critical Reminders
-- **Flow:** Issue (`doit issue`) -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main.
+- **Flow:** Issue (`doit issue`) -> **`git checkout main && git pull`** -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main. Always pull `main` before branching — local `main` may be behind the remote (e.g., after dependabot PRs merged via the web UI).
 - **Scope:** Never mix refactoring, features, and docs in one PR. Create separate branches.
 - **Verify:** Check file paths (`ls`) and branch (`git status`) before assuming they exist.
 - **Security:** NEVER bypass security checks (e.g., `--no-verify`, ignoring secrets).


### PR DESCRIPTION
## Description

Adds an explicit `git checkout main && git pull` step to the Flow bullet in the Critical Reminders section of `AGENTS.md`, with a brief rationale. This closes a gap where AI agents could branch off a stale local `main` (common after dependabot PRs are merged via the web UI), leading to unnecessary rebases or conflicts.

## Related Issue

Addresses #329

## Type of Change

- [x] Documentation update

## Changes Made

- Updated the Flow bullet under `## Critical Reminders` in `AGENTS.md` to include `git checkout main && git pull` between the issue-creation and branch-creation steps.
- Added a short rationale explaining that local `main` may be behind the remote (e.g., after dependabot PRs merged via the web UI).

## Testing

- [x] All existing tests pass (`doit check`)
- [ ] Added new tests for new functionality (N/A — documentation only)
- [x] Manually reviewed the diff

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (N/A — docs-only change to agent instructions)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: issue does not carry the `needs-adr` label, and this is a process clarification, not an architectural decision. ADR 9008 (PR-based development workflow) describes the conceptual workflow and does not need updating for this operational tip.
- No other docs updated: the other `Issue -> Branch -> Commit -> PR -> Merge` references in `docs/template/` and ADR 9008 are high-level workflow descriptions, not AI-agent operational steps, and intentionally omit the pull step.
