### PR TITLE
fix: replace Unicode checkmark with ASCII marker in direct-stdout task output

### DIFF
--- a/tests/test_doit_install_tools.py
+++ b/tests/test_doit_install_tools.py
@@ -424,6 +424,51 @@ class TestInstallTool:
             check=True,
         )
 
+    @patch("tools.doit.install_tools.subprocess.run")
+    @patch("tools.doit.install_tools.shutil.which", return_value="/usr/bin/mytool")
+    def test_already_installed_output_is_cp1252_encodable(
+        self, mock_which: MagicMock, mock_run: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Regression test for #328: already-installed output must encode in cp1252 (Windows)."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["mytool", "--version"], returncode=0, stdout="1.0.0\n", stderr=""
+        )
+
+        install_tool(
+            name="mytool",
+            repo="owner/repo",
+            asset_patterns={"linux": "mytool.linux-amd64"},
+        )
+
+        captured = capsys.readouterr()
+        # Must not raise UnicodeEncodeError on Windows cp1252 console
+        captured.out.encode("cp1252")
+        assert "already installed" in captured.out
+
+    @patch("tools.doit.install_tools.download_github_release_binary")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="2.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Linux")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_fresh_install_output_is_cp1252_encodable(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_download: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Regression test for #328: fresh-install output must encode in cp1252 (Windows)."""
+        install_tool(
+            name="mytool",
+            repo="owner/repo",
+            asset_patterns={"linux": "mytool.linux-amd64"},
+        )
+
+        captured = capsys.readouterr()
+        # Must not raise UnicodeEncodeError on Windows cp1252 console
+        captured.out.encode("cp1252")
+        assert "mytool installed" in captured.out
+
 
 class TestCreateInstallTask:
     """Tests for create_install_task function."""

--- a/tools/doit/install_tools.py
+++ b/tools/doit/install_tools.py
@@ -114,7 +114,7 @@ def install_tool(
             check=True,
         )
         version_output = result.stdout.strip() or result.stderr.strip()
-        print(f"\u2713 {name} already installed: {version_output}")
+        print(f"[OK] {name} already installed: {version_output}")
         return
 
     print(f"Installing {name}...")
@@ -135,7 +135,7 @@ def install_tool(
         print(f"Unsupported OS for {name}: {system}")
         sys.exit(1)
 
-    print(f"\u2713 {name} installed.")
+    print(f"[OK] {name} installed.")
     if post_install_message:
         print(post_install_message)
 

--- a/tools/doit/maintenance.py
+++ b/tools/doit/maintenance.py
@@ -145,7 +145,7 @@ def task_update_deps() -> dict[str, Any]:
         print()
         if check_result.returncode == 0:
             print("=" * 70)
-            print(" " * 20 + "✓ All checks passed!")
+            print(" " * 20 + "[OK] All checks passed!")
             print("=" * 70)
             print()
             print("Next steps:")


### PR DESCRIPTION
## Description

Fix `UnicodeEncodeError` in `doit install_tools` and `doit upgrade` maintenance output when run on Windows consoles using the legacy `cp1252` code page. The tasks printed a `\u2713` (U+2713 CHECK MARK) directly to `stdout`, which the Windows default console encoder cannot represent, causing the tasks to crash before completing.

Replaced the raw Unicode checkmark with the ASCII marker `[OK]` in the two code paths that write directly to `stdout`/`stderr` (bypassing Rich). Other `✓` usages in the codebase go through `rich.console.Console`, which handles encoding fallback safely and is therefore left alone.

## Related Issue

Addresses #328

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Root Cause

On Windows, the default console code page is frequently `cp1252` (Western European), which cannot encode `U+2713`. `install_tools.py` and `maintenance.py` each emitted the checkmark via a plain `print(...)` / direct `sys.stdout.write(...)` call — not through Rich — so Python raised `UnicodeEncodeError: 'charmap' codec can't encode character '\u2713'` and the task aborted before reporting success.

## Changes Made

- `tools/doit/install_tools.py` (lines 117, 138): replaced `\u2713` with the ASCII marker `[OK]` in the two success messages written directly to stdout.
- `tools/doit/maintenance.py` (line 148): replaced the literal `✓` with `[OK]` in the direct-stdout success line (same root cause).
- `tests/test_doit_install_tools.py`: added two regression tests that capture the task output and assert it is encodable as `cp1252`, so the Unicode regression cannot return unnoticed.

## Why Not Touch Every `✓` In The Repo

Only the call sites that write directly to `stdout`/`stderr` are affected. All other `✓` usages go through `rich.console.Console`, which detects the terminal encoding and either emits the character safely or degrades gracefully. Changing those would reduce output quality on capable terminals for no benefit.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added new tests for new functionality (cp1252-encodability regression tests)
- [x] Manually tested the changes

### Regression Test Approach

The new tests invoke the affected task actions, capture their stdout, and assert `captured.encode("cp1252")` succeeds. This reproduces the Windows failure mode on any platform and fails loudly if a non-cp1252 character is reintroduced to these code paths.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (N/A — no docs reference this output)
- [ ] I have updated the CHANGELOG.md (handled at release time from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

No ADR is required: this is a bug fix with no architectural decision, and the issue is not labeled `needs-adr`. No existing ADR documents the `install_tools` / `maintenance` output format. A `docs/` sweep found no references to the literal checkmark output or screenshots that would need updating.
