### PR TITLE
fix: skip benchmark workflow gracefully when tests/benchmarks/ is missing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,15 +20,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for benchmark tests
+        id: check-benchmarks
+        run: |
+          if [ -d "tests/benchmarks" ] && find tests/benchmarks -name 'test_*.py' -print -quit | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No benchmark tests found at tests/benchmarks/; skipping benchmark workflow."
+          fi
+
       - uses: actions/setup-python@v6
+        if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           python-version: "3.14"
 
       - uses: astral-sh/setup-uv@v7
+        if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           version: "latest"
 
       - name: Cache uv dependencies
+        if: steps.check-benchmarks.outputs.exists == 'true'
         uses: actions/cache@v5
         with:
           path: ${{ env.UV_CACHE_DIR }}
@@ -37,9 +50,11 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Install dependencies
+        if: steps.check-benchmarks.outputs.exists == 'true'
         run: uv sync --all-extras --dev
 
       - name: Run benchmarks
+        if: steps.check-benchmarks.outputs.exists == 'true'
         run: |
           mkdir -p tmp
           uv run pytest tests/benchmarks/ \
@@ -47,6 +62,7 @@ jobs:
             --benchmark-json=tmp/benchmark-results.json -v
 
       - name: Check for benchmark data branch
+        if: steps.check-benchmarks.outputs.exists == 'true'
         id: check-bench-branch
         run: |
           if git ls-remote --exit-code origin gh-benchmarks >/dev/null 2>&1; then
@@ -56,7 +72,7 @@ jobs:
           fi
 
       - name: Create benchmark data branch
-        if: steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
+        if: steps.check-benchmarks.outputs.exists == 'true' && steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -66,7 +82,7 @@ jobs:
           git checkout ${{ github.sha }}
 
       - name: Store benchmark results
-        if: github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true'
+        if: steps.check-benchmarks.outputs.exists == 'true' && (github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true')
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'
@@ -80,7 +96,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload benchmark results
-        if: always()
+        if: always() && steps.check-benchmarks.outputs.exists == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -726,6 +726,8 @@ The `benchmark.yml` workflow operates in two modes:
 
 Only main branch results are stored to keep the historical data clean and consistent.
 
+If `tests/benchmarks/` does not exist or contains no `test_*.py` files, the workflow skips all benchmark steps and finishes successfully. This allows downstream projects generated from this template to enable the workflow incrementally without CI failures before any benchmark tests are written.
+
 ### The `gh-benchmarks` Branch
 
 Benchmark data is stored in a dedicated `gh-benchmarks` branch, separate from the main codebase. This branch is auto-created by the benchmark action on the first push to `main` after the workflow is enabled. Until the branch exists, PR benchmark comparisons are skipped gracefully.


### PR DESCRIPTION
## Description

The `benchmark.yml` workflow hardcoded `tests/benchmarks/` as its test target and unconditionally ran setup, install, and pytest against that path. In downstream projects generated from this template that have not yet added benchmark tests, the directory does not exist and the workflow failed on every push and PR, blocking branch protection.

This PR makes the workflow detect the presence of `tests/benchmarks/` (and at least one `test_*.py` file inside it) immediately after checkout and skip the remaining steps gracefully when absent. The job still reports SUCCESS so required-check branch protection is satisfied in downstream consumers that have not yet written benchmarks.

## Related Issue

Addresses #327

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- Added a `Check for benchmark tests` step after `actions/checkout` that sets `steps.check-benchmarks.outputs.exists` to `true`/`false` based on whether `tests/benchmarks/` exists and contains at least one `test_*.py` file. Emits a `::notice::` when skipping so the reason is visible in the Actions log.
- Gated every subsequent step (`setup-python`, `setup-uv`, cache, install, run benchmarks, data-branch check, data-branch create, store results, upload artifact) with `if: steps.check-benchmarks.outputs.exists == 'true'`, AND-combined with any pre-existing conditions (e.g. `if: always()` on the upload step, the `github.event_name == 'push'` guards on the data-branch steps).
- Updated `docs/development/ci-cd-testing.md` under "Benchmark Tracking > How It Works" to document that the workflow skips gracefully when `tests/benchmarks/` is missing or empty.

### Why step-level gating instead of a job-level `if:`

A job-level `if:` would cause the job to report `SKIPPED` in the GitHub UI. That state does not satisfy required status checks in branch protection, which would re-break the same downstream scenario from a different angle. Step-level gating lets the job complete with `SUCCESS` while doing no work, which keeps branch protection happy in downstream consumers that have the workflow listed as a required check.

### Root cause

The workflow assumed `tests/benchmarks/` always exists (true for this repo, not true for fresh template clones). The `Run benchmarks` step executed `uv run pytest tests/benchmarks/ ...` unconditionally; pytest exits non-zero when the path is missing, failing the workflow.

## Testing

- [x] `doit check` passes locally (format, lint, type_check, security, spell_check, test).
- [x] Scratch shell exercise of the detection snippet against four cases:
  1. Directory missing -> `exists=false`
  2. Directory present but empty -> `exists=false`
  3. Directory present with only non-test files (`conftest.py`, `helpers.py`) -> `exists=false`
  4. Directory present with a `test_*.py` file -> `exists=true`
- [x] This repository has real benchmark tests under `tests/benchmarks/`, so this PR's own benchmark workflow run will exercise the `exists == 'true'` path end-to-end and confirm no regression for the happy path.
- [ ] `actionlint` is not available in the local toolchain; YAML syntax / expression validity will be confirmed by CI on this PR.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (`docs/development/ci-cd-testing.md`)
- [ ] I have updated the CHANGELOG.md (changelog is generated from conventional commits at release time)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: this is a mechanical bug fix to CI glue, not an architectural decision. Issue #327 does not carry the `needs-adr` label.
- No new tests added under `tests/`: the change is entirely in a GitHub Actions workflow file, which is not executable from pytest. Verification is via the scratch shell exercise above and the live CI run on this PR.
