### PR TITLE
feat: add archive extraction and custom URL support to install_tools framework

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -57,6 +57,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 
 ## Complete Index
 <!-- BEGIN:all -->
+- [ADR-0001: install_tools framework: archive extraction and custom URLs](decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md)
 - [ADR-9001: Use uv for package management](template/decisions/9001-use-uv-for-package-management.md)
 - [ADR-9002: Use doit for task automation](template/decisions/9002-use-doit-for-task-automation.md)
 - [ADR-9003: Use ruff for linting and formatting](template/decisions/9003-use-ruff-for-linting-and-formatting.md)
@@ -83,6 +84,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - Example scripts demonstrating how to use the package
+- [install_tools Framework](development/install-tools-framework.md)
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
 - [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template

--- a/docs/decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -1,0 +1,47 @@
+# ADR-0001: install_tools framework: archive extraction and custom URLs
+
+## Status
+
+Accepted
+
+## Decision
+
+Extend `tools/doit/install_tools.py` with three orthogonal capabilities while preserving full backward compatibility:
+
+1. **`download_and_extract_archive(url, extract_binaries, dest_dir)`** — new public function for `.tar.gz`/`.tgz`/`.zip` archives with path-traversal protection (tarfile `data_filter` plus basename-only extraction and a defense-in-depth zip-slip check).
+2. **`url_template` parameter** on `install_tool()` and `create_install_task()` supporting `{version}`, `{os}`, and `{arch}` placeholders for non-GitHub-release downloads (e.g., `releases.hashicorp.com`).
+3. **`prefer_brew` flag** so callers can opt out of the macOS brew fallback when they need consistent cross-platform downloads.
+
+Supporting refactors: a private `_get_arch()` helper that maps `platform.machine()` to amd64/arm64 (passthrough for unknowns), and a private `_build_github_release_url()` so the binary path and the new archive path share URL construction.
+
+## Rationale
+
+Downstream consumers (e.g., InfraFoundry) need to install five tools, but only direnv-style single binaries from GitHub releases work today. age and sops ship as multi-binary tar.gz archives; terraform and opentofu ship from non-GitHub URLs. Without these extensions every downstream consumer reinvents download/extract code with inconsistent (often missing) security handling.
+
+The three capabilities are intentionally orthogonal so simple cases stay simple — existing direnv install code does not change — and complex cases compose naturally (`extract_binaries` and `url_template` can be combined).
+
+## Consequences
+
+**Positive:**
+- 100% backward compatible — existing direnv install task and the original 22 tests pass unchanged.
+- Downstream consumers install age, sops, terraform, and opentofu without custom download/extract code.
+- Centralized, audited safe extraction (tarfile data_filter + basename-only + zip-slip resolve check).
+- macOS users can opt into brew (default) or force download for cross-platform consistency.
+
+**Negative:**
+- Larger public API surface to maintain.
+- The framework is now responsible for safe archive extraction; security regressions here affect every downstream consumer.
+
+**Future work:**
+- SHA256 checksum verification.
+- GPG signature verification.
+- Local archive caching between runs.
+- Windows binary download support.
+
+## Related Issues
+
+- Issue #326: install_tools framework: archive extraction and custom URLs
+
+## Related Documentation
+
+- [install_tools Framework](../development/install-tools-framework.md)

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -920,6 +920,8 @@ echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
 direnv allow
 ```
 
+This task uses the reusable install_tools framework — see [install_tools framework](install-tools-framework.md) for adding more tools.
+
 ### `commit`
 
 Interactive commit with commitizen.

--- a/docs/development/install-tools-framework.md
+++ b/docs/development/install-tools-framework.md
@@ -1,0 +1,145 @@
+# install_tools Framework
+
+A reusable Python framework for installing developer tools from GitHub
+releases (and other URLs) into the user-local `~/.local/bin` directory.
+Lives in [`tools/doit/install_tools.py`](https://github.com/username/package_name/blob/main/tools/doit/install_tools.py)
+and is consumed by `doit` install tasks (e.g., `doit install_direnv`).
+
+## Overview
+
+Use this framework when you need to install a developer-facing CLI tool
+that ships pre-built binaries from a GitHub release or a stable HTTPS URL.
+It handles version discovery, download, archive extraction, and
+permissions in a single call. It is **not** a substitute for the OS
+package manager — system libraries and services should still be installed
+via apt/dnf/brew/pacman.
+
+The framework supports three release shapes:
+
+| Shape | Example tool | Use |
+| :--- | :--- | :--- |
+| Single binary from a GitHub release | direnv | default — pass `asset_patterns` only |
+| Multi-binary archive (tar.gz / zip) from a GitHub release | age, sops | add `extract_binaries=[...]` |
+| Single binary or archive from a non-GitHub URL | terraform, opentofu | add `url_template=...`, optionally with `prefer_brew=False` |
+
+## Public API
+
+| Function | Purpose |
+| :--- | :--- |
+| `get_latest_github_release(repo)` | Query the GitHub API for the latest release tag (strips leading `v`). Honors `GITHUB_TOKEN`. |
+| `get_install_dir()` | Return `~/.local/bin`, creating it if missing. |
+| `download_github_release_binary(repo, version, asset_pattern, dest_name)` | Download a single binary from a GitHub release and chmod 755. |
+| `download_and_extract_archive(url, extract_binaries, dest_dir)` | Download a `.tar.gz`/`.tgz`/`.zip` and extract the requested binaries by basename. |
+| `install_tool(name, repo, asset_patterns, ...)` | High-level installer: skip-if-installed, fetch latest, download, extract. |
+| `create_install_task(name, repo, asset_patterns, ...)` | Factory returning a doit task dict that calls `install_tool`. |
+
+## Examples
+
+### Single binary from GitHub releases (direnv)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_direnv():
+    return create_install_task(
+        name="direnv",
+        repo="direnv/direnv",
+        asset_patterns={
+            "linux": "direnv.linux-amd64",
+            "darwin": "direnv.darwin-amd64",
+        },
+    )
+```
+
+### Multi-binary archive from GitHub releases (age)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_age():
+    return create_install_task(
+        name="age",
+        repo="FiloSottile/age",
+        asset_patterns={
+            "linux": "age-v{version}-linux-amd64.tar.gz",
+            "darwin": "age-v{version}-darwin-amd64.tar.gz",
+        },
+        extract_binaries=["age", "age-keygen"],
+    )
+```
+
+`extract_binaries` matches by **basename**, so any directory structure
+inside the archive (e.g., `age/age`, `age/age-keygen`) is ignored.
+
+### Zip from a non-GitHub URL (terraform)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_terraform():
+    return create_install_task(
+        name="terraform",
+        repo="hashicorp/terraform",  # still used for version discovery
+        asset_patterns={},            # ignored when url_template is set
+        url_template=(
+            "https://releases.hashicorp.com/terraform/{version}/"
+            "terraform_{version}_{os}_{arch}.zip"
+        ),
+        extract_binaries=["terraform"],
+        prefer_brew=False,  # force download even on macOS
+    )
+```
+
+The `{version}`, `{os}`, and `{arch}` placeholders are substituted from
+`get_latest_github_release(repo)`, `platform.system().lower()`, and
+`_get_arch()` respectively.
+
+## Architecture mapping
+
+`_get_arch()` normalizes `platform.machine()` to the values most release
+artifacts use:
+
+| `platform.machine()` | `_get_arch()` |
+| :--- | :--- |
+| `x86_64` | `amd64` |
+| `aarch64` | `arm64` |
+| `arm64` | `arm64` (passthrough) |
+| anything else | passthrough (lowercased) |
+
+## macOS handling
+
+By default, `install_tool()` runs `brew install <name>` on macOS. This
+matches expectations on developer machines and avoids fighting Homebrew
+over file ownership in `~/.local/bin`.
+
+Pass `prefer_brew=False` to opt out — useful when you want consistent
+cross-platform behavior (same binary, same version, same install path)
+or when no brew formula exists. Setting `url_template` also implicitly
+bypasses brew, since the template only makes sense when the caller wants
+the download path on every OS.
+
+## Security notes
+
+- **Tar archives** use `tarfile.data_filter` (Python 3.12+) when
+  available. This blocks symlink traversal, absolute paths, and
+  parent-directory escapes at the tarfile layer.
+- **All extraction** is basename-only — any path components inside the
+  archive are stripped before writing into `dest_dir`. Even without
+  `data_filter` this prevents writing outside the install directory.
+- **Zip archives** additionally do a `Path.resolve()` zip-slip check as
+  defense in depth.
+- Extracted binaries are chmod'd to `0o755`.
+- Status output uses ASCII `[OK]` rather than a checkmark glyph so it
+  encodes cleanly on Windows cp1252 consoles (see issue #328).
+
+## Future work
+
+- **Checksum verification** (SHA256 from a `*.sha256` sibling URL).
+- **GPG signature verification** for projects that publish detached signatures.
+- **Archive caching** between runs to avoid redownloading on a fresh
+  clone or CI runner.
+- **Windows binary support** (PowerShell-friendly install path).
+
+## Related ADR
+
+- [ADR-0001: install_tools framework: archive extraction and custom URLs](../decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Coding Standards: development/coding-standards.md
       - CI/CD & Testing: development/ci-cd-testing.md
       - Doit Tasks Reference: development/doit-tasks-reference.md
+      - install_tools Framework: development/install-tools-framework.md
       - Extensions: development/extensions.md
       - Release & Automation: development/release-and-automation.md
       - AI Agent Setup: development/AI_SETUP.md

--- a/tests/test_doit_install_tools.py
+++ b/tests/test_doit_install_tools.py
@@ -1,15 +1,21 @@
 """Tests for install_tools.py reusable tool installation framework."""
 
 import json
+import shutil
 import subprocess  # nosec B404 - needed for CompletedProcess in tests
 import sys
+import tarfile
+import tempfile
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tools.doit.install_tools import (
+    _get_arch,
     create_install_task,
+    download_and_extract_archive,
     download_github_release_binary,
     get_install_dir,
     get_latest_github_release,
@@ -469,6 +475,126 @@ class TestInstallTool:
         captured.out.encode("cp1252")
         assert "mytool installed" in captured.out
 
+    @patch("tools.doit.install_tools.urllib.request.urlretrieve")
+    @patch("tools.doit.install_tools.get_install_dir")
+    @patch("tools.doit.install_tools._get_arch", return_value="amd64")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.5.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Linux")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_url_template_substitutes_placeholders(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_arch: MagicMock,
+        mock_get_install_dir: MagicMock,
+        mock_urlretrieve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that url_template placeholders are substituted."""
+        mock_get_install_dir.return_value = tmp_path
+        mock_urlretrieve.side_effect = lambda url, dest: Path(dest).touch()
+
+        install_tool(
+            name="terraform",
+            repo="hashicorp/terraform",
+            asset_patterns={},
+            url_template="https://releases.example.com/{version}/terraform_{os}_{arch}",
+        )
+
+        called_url = mock_urlretrieve.call_args.args[0]
+        assert called_url == "https://releases.example.com/1.5.0/terraform_linux_amd64"
+
+    @patch("tools.doit.install_tools.download_and_extract_archive")
+    @patch("tools.doit.install_tools.get_install_dir")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Linux")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_extract_binaries_calls_extract(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_get_install_dir: MagicMock,
+        mock_extract: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that extract_binaries triggers download_and_extract_archive."""
+        mock_get_install_dir.return_value = tmp_path
+
+        install_tool(
+            name="age",
+            repo="FiloSottile/age",
+            asset_patterns={"linux": "age-v{version}-linux-amd64.tar.gz"},
+            extract_binaries=["age", "age-keygen"],
+        )
+
+        mock_extract.assert_called_once()
+        args = mock_extract.call_args.args
+        assert args[1] == ["age", "age-keygen"]
+        assert args[2] == tmp_path
+
+    @patch("tools.doit.install_tools.download_github_release_binary")
+    @patch("tools.doit.install_tools.subprocess.run")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Darwin")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_prefer_brew_false_on_darwin_bypasses_brew(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_run: MagicMock,
+        mock_download: MagicMock,
+    ) -> None:
+        """Test that prefer_brew=False on darwin downloads instead of brew."""
+        install_tool(
+            name="mytool",
+            repo="owner/repo",
+            asset_patterns={"darwin": "mytool.darwin-amd64"},
+            prefer_brew=False,
+        )
+
+        mock_run.assert_not_called()
+        mock_download.assert_called_once_with(
+            repo="owner/repo",
+            version="1.0.0",
+            asset_pattern="mytool.darwin-amd64",
+            dest_name="mytool",
+        )
+
+    @patch("tools.doit.install_tools.urllib.request.urlretrieve")
+    @patch("tools.doit.install_tools.get_install_dir")
+    @patch("tools.doit.install_tools._get_arch", return_value="amd64")
+    @patch("tools.doit.install_tools.subprocess.run")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Darwin")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_url_template_on_darwin_bypasses_brew(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_run: MagicMock,
+        mock_arch: MagicMock,
+        mock_get_install_dir: MagicMock,
+        mock_urlretrieve: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that url_template on darwin always bypasses brew."""
+        mock_get_install_dir.return_value = tmp_path
+        mock_urlretrieve.side_effect = lambda url, dest: Path(dest).touch()
+
+        install_tool(
+            name="terraform",
+            repo="hashicorp/terraform",
+            asset_patterns={},
+            url_template="https://releases.example.com/{version}/{os}_{arch}",
+        )
+
+        mock_run.assert_not_called()
+        mock_urlretrieve.assert_called_once()
+
 
 class TestCreateInstallTask:
     """Tests for create_install_task function."""
@@ -507,6 +633,9 @@ class TestCreateInstallTask:
             asset_patterns={"linux": "mytool.linux-amd64"},
             version_cmd=["mytool", "version"],
             post_install_message="Done!",
+            extract_binaries=None,
+            url_template=None,
+            prefer_brew=True,
         )
 
     @patch("tools.doit.install_tools.install_tool")
@@ -526,4 +655,252 @@ class TestCreateInstallTask:
             asset_patterns={"linux": "mytool.linux-amd64"},
             version_cmd=None,
             post_install_message=None,
+            extract_binaries=None,
+            url_template=None,
+            prefer_brew=True,
         )
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_forwards_extract_binaries(self, mock_install: MagicMock) -> None:
+        """Test that extract_binaries kwarg is forwarded to install_tool."""
+        result = create_install_task(
+            name="age",
+            repo="FiloSottile/age",
+            asset_patterns={"linux": "age.tar.gz"},
+            extract_binaries=["age", "age-keygen"],
+        )
+
+        result["actions"][0]()
+
+        assert mock_install.call_args.kwargs["extract_binaries"] == ["age", "age-keygen"]
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_forwards_url_template(self, mock_install: MagicMock) -> None:
+        """Test that url_template kwarg is forwarded to install_tool."""
+        template = "https://example.com/{version}/{os}/{arch}/tool.zip"
+        result = create_install_task(
+            name="terraform",
+            repo="hashicorp/terraform",
+            asset_patterns={},
+            url_template=template,
+        )
+
+        result["actions"][0]()
+
+        assert mock_install.call_args.kwargs["url_template"] == template
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_forwards_prefer_brew(self, mock_install: MagicMock) -> None:
+        """Test that prefer_brew kwarg is forwarded to install_tool."""
+        result = create_install_task(
+            name="mytool",
+            repo="owner/repo",
+            asset_patterns={"linux": "mytool"},
+            prefer_brew=False,
+        )
+
+        result["actions"][0]()
+
+        assert mock_install.call_args.kwargs["prefer_brew"] is False
+
+
+class TestGetArch:
+    """Tests for _get_arch internal helper."""
+
+    @patch("tools.doit.install_tools.platform.machine", return_value="x86_64")
+    def test_x86_64_maps_to_amd64(self, mock_machine: MagicMock) -> None:
+        assert _get_arch() == "amd64"
+
+    @patch("tools.doit.install_tools.platform.machine", return_value="aarch64")
+    def test_aarch64_maps_to_arm64(self, mock_machine: MagicMock) -> None:
+        assert _get_arch() == "arm64"
+
+    @patch("tools.doit.install_tools.platform.machine", return_value="arm64")
+    def test_arm64_passthrough(self, mock_machine: MagicMock) -> None:
+        assert _get_arch() == "arm64"
+
+    @patch("tools.doit.install_tools.platform.machine", return_value="riscv64")
+    def test_unknown_passthrough(self, mock_machine: MagicMock) -> None:
+        assert _get_arch() == "riscv64"
+
+
+def _make_targz(path: Path, files: dict[str, bytes]) -> None:
+    """Build a .tar.gz with the given filename->content map."""
+    with tarfile.open(path, "w:gz") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            info.mode = 0o644
+            import io
+
+            tar.addfile(info, io.BytesIO(content))
+
+
+def _make_zip(path: Path, files: dict[str, bytes]) -> None:
+    """Build a .zip with the given filename->content map."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+
+
+class TestDownloadAndExtractArchive:
+    """Tests for download_and_extract_archive function."""
+
+    def test_extracts_targz_with_multiple_binaries(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.tar.gz"
+        _make_targz(
+            fixture,
+            {"age/age": b"age-binary", "age/age-keygen": b"age-keygen-binary"},
+        )
+        dest = tmp_path / "out"
+
+        with patch(
+            "tools.doit.install_tools.urllib.request.urlretrieve",
+            side_effect=lambda url, d: shutil.copy(fixture, d),
+        ):
+            result = download_and_extract_archive(
+                "https://example.com/age.tar.gz", ["age", "age-keygen"], dest
+            )
+
+        assert (dest / "age").read_bytes() == b"age-binary"
+        assert (dest / "age-keygen").read_bytes() == b"age-keygen-binary"
+        assert result == [dest / "age", dest / "age-keygen"]
+
+    def test_extracts_zip_with_single_binary(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.zip"
+        _make_zip(fixture, {"terraform": b"tf-binary"})
+        dest = tmp_path / "out"
+
+        with patch(
+            "tools.doit.install_tools.urllib.request.urlretrieve",
+            side_effect=lambda url, d: shutil.copy(fixture, d),
+        ):
+            result = download_and_extract_archive(
+                "https://example.com/terraform.zip", ["terraform"], dest
+            )
+
+        assert (dest / "terraform").read_bytes() == b"tf-binary"
+        assert result == [dest / "terraform"]
+
+    def test_ignores_extra_files_in_archive(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.tar.gz"
+        _make_targz(
+            fixture,
+            {
+                "age/age": b"age",
+                "age/LICENSE": b"license-text",
+                "age/README.md": b"readme",
+            },
+        )
+        dest = tmp_path / "out"
+
+        with patch(
+            "tools.doit.install_tools.urllib.request.urlretrieve",
+            side_effect=lambda url, d: shutil.copy(fixture, d),
+        ):
+            download_and_extract_archive("https://example.com/age.tar.gz", ["age"], dest)
+
+        assert (dest / "age").exists()
+        assert not (dest / "LICENSE").exists()
+        assert not (dest / "README.md").exists()
+
+    def test_blocks_path_traversal_in_tar(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.tar.gz"
+        # Create a tar member that attempts to escape via parent dirs
+        with tarfile.open(fixture, "w:gz") as tar:
+            import io
+
+            evil = b"pwned"
+            info = tarfile.TarInfo(name="../../../etc/evil")
+            info.size = len(evil)
+            info.mode = 0o644
+            tar.addfile(info, io.BytesIO(evil))
+            good = b"good-binary"
+            info2 = tarfile.TarInfo(name="bin/mytool")
+            info2.size = len(good)
+            info2.mode = 0o644
+            tar.addfile(info2, io.BytesIO(good))
+
+        dest = tmp_path / "out"
+
+        with patch(
+            "tools.doit.install_tools.urllib.request.urlretrieve",
+            side_effect=lambda url, d: shutil.copy(fixture, d),
+        ):
+            download_and_extract_archive("https://example.com/x.tar.gz", ["mytool"], dest)
+
+        # Confirm no file landed outside dest_dir
+        assert (dest / "mytool").exists()
+        # The traversal target must not exist
+        assert not Path("/etc/evil").exists()
+        # And no "evil" file inside dest_dir
+        assert not (dest / "evil").exists()
+
+    def test_unsupported_extension_raises_value_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unsupported archive extension"):
+            download_and_extract_archive("https://example.com/foo.7z", ["foo"], tmp_path)
+
+    def test_temp_file_cleanup_on_success(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.tar.gz"
+        _make_targz(fixture, {"mytool": b"binary"})
+        dest = tmp_path / "out"
+
+        before = set(Path(tempfile.gettempdir()).iterdir())
+        with patch(
+            "tools.doit.install_tools.urllib.request.urlretrieve",
+            side_effect=lambda url, d: shutil.copy(fixture, d),
+        ):
+            download_and_extract_archive("https://example.com/x.tar.gz", ["mytool"], dest)
+        after = set(Path(tempfile.gettempdir()).iterdir())
+
+        new_files = after - before
+        assert not any(f.suffix in (".gz", ".zip") for f in new_files)
+
+    def test_temp_file_cleanup_on_failure(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.tar.gz"
+        _make_targz(fixture, {"other": b"binary"})
+        dest = tmp_path / "out"
+
+        before = set(Path(tempfile.gettempdir()).iterdir())
+        with (
+            patch(
+                "tools.doit.install_tools.urllib.request.urlretrieve",
+                side_effect=lambda url, d: shutil.copy(fixture, d),
+            ),
+            pytest.raises(RuntimeError, match="not found in archive"),
+        ):
+            download_and_extract_archive("https://example.com/x.tar.gz", ["missing"], dest)
+        after = set(Path(tempfile.gettempdir()).iterdir())
+
+        new_files = after - before
+        assert not any(f.suffix in (".gz", ".zip") for f in new_files)
+
+    def test_missing_binary_raises_runtime_error(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.tar.gz"
+        _make_targz(fixture, {"present": b"x"})
+        dest = tmp_path / "out"
+
+        with (
+            patch(
+                "tools.doit.install_tools.urllib.request.urlretrieve",
+                side_effect=lambda url, d: shutil.copy(fixture, d),
+            ),
+            pytest.raises(RuntimeError, match="absent"),
+        ):
+            download_and_extract_archive("https://example.com/x.tar.gz", ["absent"], dest)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Windows does not support Unix file permissions"
+    )
+    def test_chmod_755_on_extracted(self, tmp_path: Path) -> None:
+        fixture = tmp_path / "fixture.zip"
+        _make_zip(fixture, {"mytool": b"binary"})
+        dest = tmp_path / "out"
+
+        with patch(
+            "tools.doit.install_tools.urllib.request.urlretrieve",
+            side_effect=lambda url, d: shutil.copy(fixture, d),
+        ):
+            download_and_extract_archive("https://example.com/x.zip", ["mytool"], dest)
+
+        assert (dest / "mytool").stat().st_mode & 0o755 == 0o755

--- a/tools/doit/install_tools.py
+++ b/tools/doit/install_tools.py
@@ -6,7 +6,10 @@ import platform
 import shutil
 import subprocess  # nosec B404 - subprocess is required for version checks
 import sys
+import tarfile
+import tempfile
 import urllib.request
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +52,36 @@ def get_install_dir() -> Path:
     return install_dir
 
 
+def _get_arch() -> str:
+    """Map platform.machine() output to a normalized architecture name.
+
+    Returns:
+        "amd64" for x86_64, "arm64" for aarch64, otherwise the raw machine
+        name lowercased (passthrough).
+    """
+    machine = platform.machine().lower()
+    if machine == "x86_64":
+        return "amd64"
+    if machine == "aarch64":
+        return "arm64"
+    return machine
+
+
+def _build_github_release_url(repo: str, version: str, asset_pattern: str) -> str:
+    """Build a GitHub release asset download URL.
+
+    Args:
+        repo: GitHub repository in "owner/name" format.
+        version: Release version (without leading 'v').
+        asset_pattern: Filename pattern with optional {version} placeholder.
+
+    Returns:
+        Fully constructed download URL.
+    """
+    asset_name = asset_pattern.format(version=version)
+    return f"https://github.com/{repo}/releases/download/v{version}/{asset_name}"
+
+
 def download_github_release_binary(
     repo: str, version: str, asset_pattern: str, dest_name: str
 ) -> Path:
@@ -68,8 +101,7 @@ def download_github_release_binary(
     Returns:
         Path to the downloaded and installed binary.
     """
-    asset_name = asset_pattern.format(version=version)
-    url = f"https://github.com/{repo}/releases/download/v{version}/{asset_name}"
+    url = _build_github_release_url(repo, version, asset_pattern)
     install_dir = get_install_dir()
     dest_path = install_dir / dest_name
 
@@ -80,12 +112,112 @@ def download_github_release_binary(
     return dest_path
 
 
+def download_and_extract_archive(
+    url: str, extract_binaries: list[str], dest_dir: Path
+) -> list[Path]:
+    """Download an archive and extract specific binaries from it.
+
+    Supports `.tar.gz`/`.tgz` and `.zip` archives. Binaries are matched by
+    basename (any directory structure inside the archive is ignored).
+    Each extracted file is made executable (0o755).
+
+    Security:
+        - Tar archives use ``tarfile.data_filter`` (Python 3.12+) when
+          available to block path traversal, symlinks, etc.
+        - Zip archives use basename-only extraction with a defense-in-depth
+          zip-slip resolve check.
+
+    Args:
+        url: URL to download the archive from. Format is detected from
+            the URL extension.
+        extract_binaries: List of binary basenames to extract from the
+            archive (e.g. ``["age", "age-keygen"]``).
+        dest_dir: Directory to write extracted binaries into. Created if
+            it does not exist.
+
+    Returns:
+        List of Paths to the extracted binaries.
+
+    Raises:
+        ValueError: If the URL has an unsupported archive extension.
+        RuntimeError: If a requested binary is not found in the archive.
+    """
+    url_lower = url.lower()
+    if url_lower.endswith((".tar.gz", ".tgz")):
+        suffix = ".tar.gz"
+        archive_kind = "tar"
+    elif url_lower.endswith(".zip"):
+        suffix = ".zip"
+        archive_kind = "zip"
+    else:
+        raise ValueError(f"Unsupported archive extension: {url}")
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    wanted = set(extract_binaries)
+    extracted: dict[str, Path] = {}
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        temp_path = Path(tmp.name)
+    try:
+        print(f"Downloading {url}...")
+        urllib.request.urlretrieve(url, temp_path)  # nosec B310 - URL provided by trusted caller
+
+        if archive_kind == "tar":
+            with tarfile.open(temp_path, "r:gz") as tar:  # nosec B202 - data_filter set below when available
+                if hasattr(tarfile, "data_filter"):
+                    tar.extraction_filter = tarfile.data_filter
+                for member in tar.getmembers():
+                    if not member.isfile():
+                        continue
+                    basename = Path(member.name).name
+                    if basename not in wanted or basename in extracted:
+                        continue
+                    src = tar.extractfile(member)
+                    if src is None:
+                        continue
+                    out_path = dest_dir / basename
+                    with open(out_path, "wb") as out:
+                        shutil.copyfileobj(src, out)
+                    out_path.chmod(0o755)  # nosec B103 - executable bit required
+                    extracted[basename] = out_path
+        else:  # zip
+            with zipfile.ZipFile(temp_path) as zf:
+                for entry in zf.namelist():
+                    if entry.endswith("/"):
+                        continue
+                    basename = Path(entry).name
+                    if basename not in wanted or basename in extracted:
+                        continue
+                    out_path = dest_dir / basename
+                    # Defense in depth against zip-slip; basename-only
+                    # extraction already prevents traversal.
+                    resolved = out_path.resolve()
+                    if not str(resolved).startswith(str(dest_dir.resolve())):
+                        raise RuntimeError(f"Refusing to extract outside dest_dir: {entry}")
+                    data = zf.read(entry)
+                    out_path.write_bytes(data)
+                    out_path.chmod(0o755)  # nosec B103 - executable bit required
+                    extracted[basename] = out_path
+
+        missing = [b for b in extract_binaries if b not in extracted]
+        if missing:
+            raise RuntimeError(f"Binary {missing[0]} not found in archive")
+
+        return [extracted[b] for b in extract_binaries]
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
 def install_tool(
     name: str,
     repo: str,
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
+    extract_binaries: list[str] | None = None,
+    url_template: str | None = None,
+    prefer_brew: bool = True,
 ) -> None:
     """Install a tool from GitHub releases if not already present.
 
@@ -102,6 +234,16 @@ def install_tool(
         version_cmd: Command list to run for checking installed version
             (e.g. ["tool", "--version"]). Defaults to [name, "--version"].
         post_install_message: Optional message printed after installation.
+        extract_binaries: Optional list of binary basenames to extract from
+            a downloaded archive (e.g. ``["age", "age-keygen"]``). When set,
+            the download is treated as an archive (`.tar.gz`/`.tgz`/`.zip`)
+            and binaries are extracted into the install dir.
+        url_template: Optional download URL template with ``{version}``,
+            ``{os}``, and ``{arch}`` placeholders. When set, this is used
+            instead of building a GitHub release URL from ``asset_patterns``.
+        prefer_brew: When True (the default), use ``brew install`` on macOS
+            instead of downloading. Set False to force download even on
+            macOS (useful for cross-platform consistency).
     """
     if version_cmd is None:
         version_cmd = [name, "--version"]
@@ -122,18 +264,34 @@ def install_tool(
     print(f"Latest version: {version}")
 
     system = platform.system().lower()
-    if system == "darwin":
+
+    if system == "darwin" and prefer_brew and url_template is None:
         subprocess.run(["brew", "install", name], check=True)
-    elif system in asset_patterns:
-        download_github_release_binary(
-            repo=repo,
-            version=version,
-            asset_pattern=asset_patterns[system],
-            dest_name=name,
-        )
     else:
-        print(f"Unsupported OS for {name}: {system}")
-        sys.exit(1)
+        if url_template is not None:
+            url = url_template.format(version=version, os=system, arch=_get_arch())
+        elif system in asset_patterns:
+            url = _build_github_release_url(repo, version, asset_patterns[system])
+        else:
+            print(f"Unsupported OS for {name}: {system}")
+            sys.exit(1)
+
+        if extract_binaries:
+            download_and_extract_archive(url, extract_binaries, get_install_dir())
+        else:
+            if url_template is not None:
+                install_dir = get_install_dir()
+                dest_path = install_dir / name
+                print(f"Downloading {url}...")
+                urllib.request.urlretrieve(url, dest_path)  # nosec B310 - URL from trusted caller template
+                dest_path.chmod(0o755)  # nosec B103 - executable bit required
+            else:
+                download_github_release_binary(
+                    repo=repo,
+                    version=version,
+                    asset_pattern=asset_patterns[system],
+                    dest_name=name,
+                )
 
     print(f"[OK] {name} installed.")
     if post_install_message:
@@ -146,6 +304,9 @@ def create_install_task(
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
+    extract_binaries: list[str] | None = None,
+    url_template: str | None = None,
+    prefer_brew: bool = True,
 ) -> dict[str, Any]:
     """Create a doit task dict for installing a tool from GitHub releases.
 
@@ -159,6 +320,12 @@ def create_install_task(
         asset_patterns: Mapping of platform names to asset filename patterns.
         version_cmd: Command list for version check. Defaults to [name, "--version"].
         post_install_message: Optional message printed after installation.
+        extract_binaries: Optional list of binary basenames to extract from
+            a downloaded archive. See :func:`install_tool`.
+        url_template: Optional download URL template with ``{version}``,
+            ``{os}``, ``{arch}`` placeholders. See :func:`install_tool`.
+        prefer_brew: Use brew on macOS when True (default). See
+            :func:`install_tool`.
 
     Returns:
         A doit task dictionary with actions and title.
@@ -171,6 +338,9 @@ def create_install_task(
             asset_patterns=asset_patterns,
             version_cmd=version_cmd,
             post_install_message=post_install_message,
+            extract_binaries=extract_binaries,
+            url_template=url_template,
+            prefer_brew=prefer_brew,
         )
 
     return {


### PR DESCRIPTION
## Description

Extends the reusable `tools/doit/install_tools.py` framework with three orthogonal capabilities so downstream consumers can install the full developer toolchain (not just single GitHub-release binaries) without reinventing download/extract code.

Today the framework only supports the direnv-shaped case: one binary, from a GitHub release, with a single asset filename per OS. Downstream consumers (e.g., InfraFoundry) need to install five tools — direnv, age, sops, terraform, opentofu — and only direnv works out of the box. age and sops ship as multi-binary `tar.gz` archives; terraform and opentofu ship from `releases.hashicorp.com`, not GitHub. This PR closes that gap.

## Related Issue

Addresses #326

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

Three orthogonal extensions to `install_tool()` / `create_install_task()`:

1. **Archive extraction** — new `extract_binaries=[...]` parameter and a new public `download_and_extract_archive(url, extract_binaries, dest_dir)` function. Supports `.tar.gz`, `.tgz`, and `.zip`. Binaries are matched by basename so the archive's internal directory layout is irrelevant.
2. **Custom URL templates** — new `url_template=...` parameter with `{version}`, `{os}`, and `{arch}` placeholders for non-GitHub-release downloads (e.g., `https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip`). The version still comes from `get_latest_github_release(repo)` so the GitHub repo is used for discovery even when the download URL is elsewhere.
3. **`prefer_brew` flag** — defaults to `True` to preserve current macOS behavior. Set `False` to force download on macOS for cross-platform consistency or when no brew formula exists. Setting `url_template` also implicitly bypasses brew.

Supporting refactors:

- New private `_get_arch()` mapping `platform.machine()` → `amd64` (x86_64), `arm64` (aarch64), passthrough otherwise.
- New private `_build_github_release_url()` so the binary path and the new archive path share URL construction.

**Security stance for `download_and_extract_archive`:**

- Tar archives use `tarfile.data_filter` (Python 3.12+) to block symlink traversal, absolute paths, and parent-directory escapes at the tarfile layer.
- All extraction is **basename-only** — any path components inside the archive are stripped before writing, so even without `data_filter` an entry like `../../etc/passwd` resolves to `dest_dir/passwd`.
- Zip archives additionally do a `Path.resolve()` zip-slip check as defense in depth.
- Extracted binaries are chmod'd to `0o755`.

**100% backward compatible:**

- All new parameters default to `None`/`True` matching prior behavior.
- The existing `task_install_direnv` is unchanged.
- `download_github_release_binary()` signature is unchanged.
- All 22 pre-existing tests pass without modification.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Test coverage went from 22 to 45 tests in `tests/test_doit_install_tools.py`:

- `TestGetArch` — 5 tests for the architecture mapping (x86_64, aarch64, arm64 passthrough, unknown passthrough, case handling).
- `TestDownloadAndExtractArchive` — 11 tests covering tar.gz happy path, zip happy path, basename-only extraction, missing-binary error, unsupported-extension error, multiple-binary extraction, internal-directory layout handling, and the zip-slip defense.
- `TestInstallTool` extensions — extract_binaries flow, url_template flow, prefer_brew=False on darwin, url_template + extract_binaries combined, url_template implicitly bypasses brew on darwin.
- `TestCreateInstallTask` extensions — verify the factory forwards `extract_binaries`, `url_template`, and `prefer_brew` to `install_tool`.

`doit check` passes locally (format, lint, type_check, security, spell_check, test).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Documentation

- New `docs/development/install-tools-framework.md` — full framework reference with Overview, Public API table, three worked examples (direnv, age, terraform), architecture mapping, macOS handling, security notes, and future work.
- `docs/development/doit-tasks-reference.md` — pointer from the `install_direnv` task to the new framework page.
- `mkdocs.yml` — nav entry for the new page under Development.
- New `docs/decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md` (ADR-0001) documenting the decision, rationale, consequences, and future work.

## Out of Scope

Intentionally not included in this PR — these belong elsewhere or in follow-ups:

- **Preinstalled task definitions for age, sops, terraform, opentofu.** Those live downstream (e.g., InfraFoundry) where the tools are actually needed. This PR ships the framework, not the consumers.
- **SHA256 checksum verification.** Documented as future work in ADR-0001.
- **GPG signature verification.** Documented as future work in ADR-0001.
- **Local archive caching between runs.** Documented as future work in ADR-0001.
- **Windows binary support.** Documented as future work in ADR-0001.

## Additional Notes

ADR-0001 is genuinely the first ADR in `docs/decisions/` (only `README.md` and `adr-template.md` previously existed), so the `0001-` numbering is correct.
