### PR TITLE
feat: add docs_build job to CI to catch mkdocs regressions at PR time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      newest: ${{ steps.set-matrix.outputs.newest }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,6 +30,7 @@ jobs:
           # Read config
           oldest=$(jq -r '.oldest' .github/python-versions.json)
           newest=$(jq -r '.newest' .github/python-versions.json)
+          echo "newest=$newest" >> $GITHUB_OUTPUT
 
           oldest_minor=${oldest#3.}
           newest_minor=${newest#3.}
@@ -125,19 +127,53 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  docs:
+    needs: setup
+    if: ${{ needs.setup.outputs.matrix != '{"include":[]}' }}
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ needs.setup.outputs.newest }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build documentation
+        run: uv run doit docs_build
+
   ci-complete:
     # Always run unless this is a non-full-matrix label event
     if: always() && (github.event.action != 'labeled' || github.event.label.name == 'full-matrix')
-    needs: [setup, test]
+    needs: [setup, test, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI status
         run: |
           setup_result="${{ needs.setup.result }}"
           test_result="${{ needs.test.result }}"
+          docs_result="${{ needs.docs.result }}"
 
           echo "Setup result: $setup_result"
           echo "Test result: $test_result"
+          echo "Docs result: $docs_result"
 
           # Setup must succeed
           if [[ "$setup_result" != "success" ]]; then
@@ -148,6 +184,12 @@ jobs:
           # Test must succeed or be skipped (skipped = no middle versions)
           if [[ "$test_result" != "success" && "$test_result" != "skipped" ]]; then
             echo "Test job failed"
+            exit 1
+          fi
+
+          # Docs must succeed or be skipped (skipped = no middle versions)
+          if [[ "$docs_result" != "success" && "$docs_result" != "skipped" ]]; then
+            echo "Docs job failed"
             exit 1
           fi
 

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -207,6 +207,28 @@ security:
       run: uv run doit security
 ```
 
+#### Documentation Build Job
+
+Runs `doit docs_build` once on `ubuntu-latest` using the project's newest supported Python version (read dynamically from `.github/python-versions.json`). This job gates PRs against hard-crash regressions in the mkdocs build pipeline — for example, plugin incompatibilities, broken macros, or malformed configuration. See issue [#349](https://github.com/endavis/pyproject-template/issues/349) for the historical incident that motivated this gate.
+
+Note: This job does **not** currently run `mkdocs build --strict`, so doc-link warnings and other non-fatal mkdocs warnings do not fail the build. Tightening this to strict mode is a potential future improvement once the existing warning backlog is cleared.
+
+```yaml
+docs:
+  needs: setup
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ needs.setup.outputs.newest }}
+    - uses: astral-sh/setup-uv@v7
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+    - name: Build documentation
+      run: uv run doit docs_build
+```
+
 ### Coverage Requirements
 
 - **Recommended threshold**: ≥70%
@@ -362,6 +384,7 @@ Before pushing to CI:
 - [ ] Run `doit type_check` to verify types
 - [ ] Run `doit test` to ensure tests pass
 - [ ] Run `doit coverage` to check coverage threshold
+- [ ] Run `doit docs_build` to verify the documentation build succeeds
 - [ ] Review changes and commit messages
 
 ## Testing Best Practices


### PR DESCRIPTION
## Description

Adds a `docs` job to `.github/workflows/ci.yml` that runs `doit docs_build` on every PR, closing a gap where mkdocs build regressions could land on `main` without being caught by CI. This is the regression-protection follow-up to PR #355, which was the immediate hotfix for the `pymdown-extensions` / `pygments 2.20` crash reported in #349.

## Related Issue

Addresses #354

Historical motivator: #349 (docs build crash)
Immediate fix: #355 (pymdown-extensions bump)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.github/workflows/ci.yml`: Add a new `docs` job that runs `uv run doit docs_build` on `ubuntu-latest` against the project's newest supported Python version. The `setup` job now exposes a `newest` output (sourced from `.github/python-versions.json`) that the `docs` job consumes, so the version stays in sync with the rest of CI. `ci-complete` now depends on `docs` and fails the merge gate if the docs build fails.
- `docs/development/ci-cd-testing.md`: Document the new `Documentation Build Job`, including the YAML snippet, the rationale (catch mkdocs regressions like #349 at PR time), and an explicit note that the job is non-strict for now. Added a `doit docs_build` entry to the pre-push checklist.

## Scope note: non-strict build

This PR intentionally runs `mkdocs build` without `--strict`. `main` currently has a backlog of non-fatal mkdocs warnings (unlisted nav files, broken relative links in template/AI docs) that are out of scope here. The gate added in this PR catches hard crashes — plugin incompatibilities, broken macros, malformed configuration — which is exactly what would have caught #349. Tightening to `--strict` can be a follow-up once the warning backlog is cleared.

## Testing

- [x] All existing tests pass (`doit check` green locally)
- [ ] Added new tests for new functionality (N/A — this is CI plumbing; the workflow itself is the test)
- [x] Manually tested the changes

Local validation:

- `doit docs_build` — passes (builds to `site/` in ~2s with warnings only, no errors)
- `doit check` — passes (format, lint, type, security, spell, test)
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML is valid

This PR is itself the first integration test of the new gate: the GitHub Actions run on this PR will exercise the new `docs` job end-to-end, confirming it wires through `ci-complete` correctly.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works (the new CI job is the enforcement; validated locally with `doit docs_build`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (`docs/development/ci-cd-testing.md`)
- [ ] I have updated the CHANGELOG.md (N/A — no CHANGELOG entry required for CI plumbing)
- [x] My changes generate no new warnings

## Additional Notes

No ADR required: this is operational CI tooling, not an architectural decision. The issue does not carry the `needs-adr` label.
