### PR TITLE
refactor: move doit from runtime to dev dependencies

### DIFF
--- a/docs/development/tooling-roles.md
+++ b/docs/development/tooling-roles.md
@@ -77,17 +77,20 @@ The template is opinionated about a small number of things:
 - **ADRs document the *why*.** When a tooling decision is non-obvious, it
   gets an ADR under `docs/template/decisions/` or `docs/decisions/`.
 
-## Current vs Target State
+## Dependency placement
 
-> **Note — current state of doit and rich:**
-> The target state described above is that `doit` and `rich` are
-> **development-only** dependencies. As of this writing they are still
-> declared in `[project] dependencies` in `pyproject.toml` for historical
-> reasons (see [#65](https://github.com/endavis/pyproject-template/issues/65)).
-> A separate refactor will move them out of the runtime dependency set. The
-> rules on this page describe the intended architecture; the runtime-dependency
-> placement of `doit` is a packaging convenience for adopters and does **not**
-> make `doit` a runtime CLI surface for the application.
+`doit` is declared under `[project.optional-dependencies] dev` in
+`pyproject.toml` and is **not** installed when adopters install the
+published package. `rich` remains a runtime dependency because most CLIs
+built on this template use it for user-facing output, which is a
+legitimate runtime use.
+
+> **Historical note:** `doit` was briefly placed in `[project] dependencies`
+> per [#65](https://github.com/endavis/pyproject-template/issues/65) as a
+> packaging convenience for adopters of the template. That placement
+> contradicted the boundary documented above and was reversed in
+> [#348](https://github.com/endavis/pyproject-template/issues/348). Current
+> state matches target state.
 
 ## See also
 

--- a/docs/template/decisions/9002-use-doit-for-task-automation.md
+++ b/docs/template/decisions/9002-use-doit-for-task-automation.md
@@ -21,9 +21,11 @@ and discoverable. It is not part of the published package's public API.
 - doit must **not** be used to front the application's user-facing CLI. The
   application's CLI is a console script under `src/package_name/`. End users
   of the published package should never need to install `doit` to use it.
-- The runtime-dependency status of `doit` (see #65) is a **packaging
-  convenience** for adopters of the template and does **not** make `doit` a
-  runtime CLI surface for the application.
+- `doit` is a **development dependency only**, declared under
+  `[project.optional-dependencies] dev` in `pyproject.toml`. It is not
+  installed when adopters install the published package. (Historical note:
+  it was briefly placed in `[project] dependencies` per #65 as a packaging
+  convenience; #348 moved it to dev to align with the boundary above.)
 
 For the broader layering rationale, see
 [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md).
@@ -35,6 +37,7 @@ For the broader layering rationale, see
 - Issue #80: Add doit issue and doit pr commands for GitHub workflow
 - Issue #65: Promote doit and rich to runtime dependencies
 - Issue #340: Document tooling roles and architectural boundaries
+- Issue #348: Move doit from runtime to dev dependencies
 
 ## Related Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "doit>=0.36.0",
     "rich>=13.0",
 ]
 
 [project.optional-dependencies]
 dev = [
+    "doit>=0.36.0",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pytest-xdist>=3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,6 @@ wheels = [
 name = "package-name"
 source = { editable = "." }
 dependencies = [
-    { name = "doit" },
     { name = "rich" },
 ]
 
@@ -1173,6 +1172,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "commitizen" },
+    { name = "doit" },
     { name = "hypothesis" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1206,7 +1206,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.2" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "cyclonedx-bom", marker = "extra == 'security'", specifier = ">=4.0" },
-    { name = "doit", specifier = ">=0.36.0" },
+    { name = "doit", marker = "extra == 'dev'", specifier = ">=0.36.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.24" },


### PR DESCRIPTION
## Description

Moves `doit` from `[project] dependencies` to `[project.optional-dependencies] dev` in `pyproject.toml`, aligning its declared placement with the architectural boundary documented in [`docs/development/tooling-roles.md`](../docs/development/tooling-roles.md) (added in PR #347, addresses #340) and ADR-9002. `doit` is a development task runner, not a runtime CLI surface, so it should not be a transitive runtime dependency of the published package.

## Summary

- **Move `doit` to dev extra.** `doit>=0.36.0` is now declared under `[project.optional-dependencies] dev` instead of `[project] dependencies`. `uv.lock` refreshed to match.
- **Docs updated to match reality.** ADR-9002 Scope rephrased so it no longer treats #65's runtime placement as authoritative, and `tooling-roles.md`'s "Current vs Target State" gap callout is replaced with a "Dependency placement" section documenting the actual current state.
- **`rich` is unchanged.** It remains in `[project] dependencies` because most CLIs built on this template use it for user-facing output, which is a legitimate runtime concern.

## Related Issue

Addresses #348

Related context:
- #65 — original runtime-dependency placement of `doit` and `rich`
- #340 / PR #347 — introduced `docs/development/tooling-roles.md`, which documented the boundary this PR now enforces in `pyproject.toml`
- ADR-9002 — `use-doit-for-task-automation` (updated in this PR)

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Documentation update

## Changes Made

- `pyproject.toml` — `doit>=0.36.0` removed from `[project] dependencies`, added to `[project.optional-dependencies] dev`.
- `uv.lock` — regenerated to reflect `doit`'s new group placement (now listed under the `dev` extra; no version change).
- `docs/template/decisions/9002-use-doit-for-task-automation.md` — Scope section rewritten to state that `doit` is a dev-only dependency and to demote #65 to a historical note; `#348` added to Related Issues.
- `docs/development/tooling-roles.md` — "Current vs Target State" gap callout replaced with a "Dependency placement" section documenting the actual current state (doit under dev extra, rich runtime) with a historical note about #65 and #348.

## Breaking Change

This is a breaking change for any downstream consumer that relied on `doit` being a transitive runtime dependency of this package. After this change, installing the package without the `[dev]` extra no longer pulls in `doit`. Consumers who need `doit` from this package must install with:

```bash
pip install package_name[dev]
# or
uv add 'package_name[dev]'
```

In practice no such consumer is expected because this project is a template — downstream users copy the template and manage their own dependency manifest rather than depending on `package_name` as a library. The change is called out explicitly for completeness and to follow the breaking-change policy in `AGENTS.md`.

## Testing

- `doit check` passes locally (tests, lint, format, type-check, security, spell-check).
- `doit docs_build` passes locally (the new docs_build CI gate from PR #356 will also exercise this on CI).
- Built wheel (`uv build --wheel`) inspected — `METADATA` `Requires-Dist:` confirms `doit` is now only under the `dev` extra and `rich` remains a bare runtime requirement:

  ```
  Requires-Dist: rich>=13.0
  Requires-Dist: doit>=0.36.0; extra == 'dev'
  ```

  There is no bare `Requires-Dist: doit>=0.36.0` line.

- [x] All existing tests pass
- [ ] Added new tests for new functionality (N/A — dependency-manifest refactor, no runtime code changed)
- [x] Manually tested the changes (built wheel, inspected metadata)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — manifest-only change)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (ADR-9002 and `tooling-roles.md`)
- [ ] I have updated the CHANGELOG.md (handled by conventional-commit tooling at release time)
- [x] My changes generate no new warnings

## Additional Notes

No new ADR was created. Per `AGENTS.md`, refactors that implement an existing architectural decision should update the related ADR rather than create a new one; ADR-9002 already exists and has been updated in this branch with the Scope rewording and a link to #348 in Related Issues.
