### PR TITLE
feat: add click-based application CLI with greet subcommand

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -11,6 +11,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 <!-- BEGIN:audience=users -->
 - [API Development Guide](examples/api.md) - Building REST APIs with FastAPI - patterns, testing, and best practices
 - [API Reference](reference/api.md) - Complete API documentation for Package Name
+- [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - Example scripts demonstrating how to use the package
@@ -36,6 +37,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [API Reference](reference/api.md) - Complete API documentation for Package Name
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
@@ -79,6 +81,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9011: Use pytest for testing](template/decisions/9011-use-pytest-for-testing.md)
 - [ADR-9012: Use mkdocs with Material theme for documentation](template/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md)
 - [ADR-9013: Python version support policy with bookend CI strategy](template/decisions/9013-python-version-support-policy.md)
+- [ADR-9014: Use click for application CLI](template/decisions/9014-use-click-for-application-cli.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
 - [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
@@ -90,6 +93,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Architecture Decision Records](decisions/README.md)
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
+- [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - Example scripts demonstrating how to use the package

--- a/docs/development/tooling-roles.md
+++ b/docs/development/tooling-roles.md
@@ -46,7 +46,7 @@ itself (and needs to be tested as runtime code).
 
 | Tool | Role | Audience | Never use for |
 | :--- | :--- | :--- | :--- |
-| **Application console script** | The package's user-facing command-line interface, defined as a `[project.scripts]` entry under `src/package_name/`. | End users of the published package. | Development workflow tasks. See [#341](https://github.com/endavis/pyproject-template/issues/341) for the application-CLI guide. |
+| **Application console script** | The package's user-facing command-line interface, defined as a `[project.scripts]` entry under `src/package_name/`. | End users of the published package. | Development workflow tasks. See the [CLI Guide](../usage/cli.md) for the application CLI. |
 | **`doit`** | Development task runner. Wraps tests, linting, type-checking, releases, issue and PR creation, and other contributor workflows. | Contributors and CI. | Fronting the application's user-facing CLI. doit is a *dev* surface, not a runtime surface. |
 | **`uv`** | Package and environment management. Installs dependencies, runs Python, manages the lockfile. | Contributors and CI. | Replacing the application's runtime entry point. |
 | **`gh`** | GitHub API access for operations not wrapped by `doit` (read-only queries, ad-hoc API calls). | Contributors and CI. | Write operations that already have a `doit` wrapper (e.g. use `doit pr` not `gh pr create`). |
@@ -71,9 +71,9 @@ The template is opinionated about a small number of things:
   not part of the package's public API.
 - **The application's user-facing CLI is a console script under
   `src/package_name/`, not a doit task.** End users should never need to
-  install `doit` to use the published package. See
-  [#341](https://github.com/endavis/pyproject-template/issues/341) for the
-  application-CLI guide.
+  install `doit` to use the published package. See the
+  [CLI Guide](../usage/cli.md) for how the CLI is structured and how to
+  add subcommands.
 - **ADRs document the *why*.** When a tooling decision is non-obvious, it
   gets an ADR under `docs/template/decisions/` or `docs/decisions/`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ print(message)  # Output: Hello, Python!
 
 - **[Installation](getting-started/installation.md)** - How to install the package
 - **[Usage Guide](usage/basics.md)** - How to use the package
+- **[CLI Guide](usage/cli.md)** - Command-line interface reference and how to add subcommands
 - **[API Reference](reference/api.md)** - Complete API documentation
 
 ### For Contributors

--- a/docs/template/decisions/9002-use-doit-for-task-automation.md
+++ b/docs/template/decisions/9002-use-doit-for-task-automation.md
@@ -37,8 +37,14 @@ For the broader layering rationale, see
 - Issue #80: Add doit issue and doit pr commands for GitHub workflow
 - Issue #65: Promote doit and rich to runtime dependencies
 - Issue #340: Document tooling roles and architectural boundaries
+- Issue #341: Add application CLI guide (implements the runtime-CLI half of the split)
 - Issue #348: Move doit from runtime to dev dependencies
+
+## Related Decisions
+
+- [ADR-9014: Use click for application CLI](9014-use-click-for-application-cli.md) — defines the runtime CLI surface that complements doit's dev-only role.
 
 ## Related Documentation
 
 - [Tools Reference](../tools-reference.md)
+- [CLI Guide](../../usage/cli.md)

--- a/docs/template/decisions/9014-use-click-for-application-cli.md
+++ b/docs/template/decisions/9014-use-click-for-application-cli.md
@@ -1,0 +1,92 @@
+# ADR-9014: Use click for application CLI
+
+## Status
+
+Accepted
+
+## Decision
+
+Use **[click](https://click.palletsprojects.com/)** as the framework for
+the package's user-facing command-line interface. The CLI lives at
+`src/package_name/cli.py` and is registered as a console script via
+`[project.scripts]` in `pyproject.toml`:
+
+```toml
+[project.scripts]
+package-name = "package_name.cli:main"
+```
+
+`click` is added to `[project] dependencies` as a runtime dependency
+alongside `rich`.
+
+## Rationale
+
+The template previously shipped with an empty `[project.scripts]` block
+and no CLI module. Contributors adding a CLI had no obvious convention to
+follow, and `docs/development/tooling-roles.md` forward-referenced a
+guide that did not yet exist. This ADR documents the chosen framework and
+grounds the new [CLI Guide](../../usage/cli.md) in real code.
+
+The runtime/dev split documented in
+[ADR-9002](9002-use-doit-for-task-automation.md)
+and [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md)
+requires the application CLI to live under `src/package_name/` and to be
+runnable without any dev tooling (no `doit`, no `uv`). A standardized
+runtime CLI framework is needed to make that boundary concrete.
+
+`click` was chosen because it is:
+
+- **Mature and widely known.** Most Python developers have used it; the
+  learning curve is near zero.
+- **Decorator-based.** Commands, options, and arguments compose with
+  `@click.command`, `@click.option`, and `@click.argument`, which matches
+  the style already used by `pytest` fixtures and other decorator-heavy
+  libraries in the ecosystem.
+- **Low ceremony for nested subcommands.** `click.Group` + `@main.command()`
+  makes adding new subcommands a single function definition.
+- **Testable in-process.** `click.testing.CliRunner` allows asserting on
+  output and exit codes without spawning subprocesses.
+- **Small, focused, and stable.** One runtime dependency with a long
+  track record of backward compatibility.
+
+## Alternatives Considered
+
+- **`argparse` (stdlib).** No new runtime dependency, but significantly
+  more boilerplate for nested subcommands, and no in-process test runner
+  equivalent to `CliRunner`. Rejected because the boilerplate cost
+  outweighs the "no new dep" benefit for a template that expects
+  contributors to extend the CLI.
+- **`typer`.** Ergonomic type-hint-driven API, but it is built on top of
+  `click` (so it drags click in anyway), and its Rich-based help
+  formatting adds hidden coupling between the CLI framework and
+  presentation. Rejected as heavier than necessary for a template
+  baseline.
+
+## Consequences
+
+**Positive:**
+
+- The template now has a concrete, testable CLI surface that contributors
+  can extend by copying the pattern in `src/package_name/cli.py`.
+- The runtime/dev boundary is enforceable: end users of the published
+  package run `package-name ...` without needing `doit` installed.
+- New subcommands have one obvious home and one obvious test pattern.
+
+**Negative:**
+
+- Adds one runtime dependency (`click>=8.1`) to every install of the
+  published package.
+- The template now has an opinion about CLI framework that adopters who
+  prefer `argparse` or `typer` will need to replace.
+
+## Related Issues
+
+- Issue #341: Add application CLI and CLI guide
+- Issue #340: Document tooling roles and architectural boundaries
+- Issue #342: End-to-end "add a feature" example (forward reference)
+
+## Related Documentation
+
+- [CLI Guide](../../usage/cli.md)
+- [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md)
+- [ADR-9002: Use doit for task automation](9002-use-doit-for-task-automation.md)

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -12,6 +12,10 @@ tags:
 
 This guide covers both package usage and development workflows.
 
+> Looking for the `package-name` command-line interface? See the
+> [CLI Guide](cli.md) for the console script, subcommands, and how to
+> extend them.
+
 ## Package Usage
 
 ### Basic Usage

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,0 +1,198 @@
+---
+title: CLI Guide
+description: The application's user-facing command-line interface and how to extend it
+audience:
+  - users
+  - contributors
+tags:
+  - cli
+  - usage
+---
+
+# CLI Guide
+
+## Purpose
+
+This page documents the **application's user-facing command-line
+interface** — the `package-name` console script shipped by the published
+package. It covers the entry point, the module layout, how to add new
+subcommands, and how to test them.
+
+This page does **not** cover `doit`, which is a contributor-only
+development task runner. For `doit` tasks, see the
+[Doit Tasks Reference](../development/doit-tasks-reference.md). For the
+architectural rationale behind the runtime/dev split, see
+[Tooling Roles and Architectural Boundaries](../development/tooling-roles.md).
+
+## Quick reference
+
+After installing the package, the `package-name` command is available on
+your `PATH`:
+
+```bash
+$ package-name greet
+Hello, World!
+
+$ package-name greet --name Python
+Hello, Python!
+
+$ package-name greet -n Python
+Hello, Python!
+
+$ package-name --version
+package_name, version 0.0.0
+```
+
+During development, prefix invocations with `uv run` to use the project
+virtual environment:
+
+```bash
+uv run package-name greet --name Python
+```
+
+## Entry point and module layout
+
+The CLI is registered in `pyproject.toml` as a console script:
+
+```toml
+[project.scripts]
+package-name = "package_name.cli:main"
+```
+
+The script name on the left (`package-name`) is the hyphen-cased
+distribution name. The value on the right points at the `main` function
+in `src/package_name/cli.py`. When the package is installed (via `uv
+sync`, `pip install`, etc.), the build backend generates an executable
+shim that calls `package_name.cli.main()`.
+
+The CLI module lives at `src/package_name/cli.py` and is a single file
+for the baseline template. Larger projects may split it into a
+`cli/` package with one file per subcommand group.
+
+## How the CLI is structured
+
+The CLI uses [click](https://click.palletsprojects.com/) as its
+framework. The top-level entry point is a `click.Group` named `main`, and
+subcommands attach to it via the `@main.command()` decorator:
+
+```python
+import click
+
+from package_name.core import greet as _greet
+
+
+@click.group()
+@click.version_option(package_name="package_name")
+def main() -> None:
+    """package_name command-line interface."""
+
+
+@main.command()
+@click.option("--name", "-n", default="World", show_default=True, help="Name to greet.")
+def greet(name: str) -> None:
+    """Print a greeting for NAME."""
+    click.echo(_greet(name))
+```
+
+Key properties:
+
+- **`main` is a `click.Group`.** This is what `[project.scripts]` points
+  at. It has no behavior of its own — it dispatches to subcommands.
+- **`@click.version_option(package_name="package_name")`** wires up
+  `--version` using the installed package metadata, so the version never
+  drifts out of sync with the git tag.
+- **Subcommands call into the runtime package.** The `greet` command
+  delegates to `package_name.core.greet`. The CLI layer handles parsing
+  and output; the core module owns the logic. This keeps the core
+  testable without invoking click and makes the CLI a thin presentation
+  layer.
+
+For the rationale behind choosing click (versus `argparse` or `typer`),
+see [ADR-9014: Use click for application CLI](../template/decisions/9014-use-click-for-application-cli.md).
+
+## How to add a new subcommand
+
+1. **Open `src/package_name/cli.py`.**
+2. **Write a function decorated with `@main.command()`.** Add options
+   and arguments with `@click.option` / `@click.argument`.
+3. **Delegate to a function in the runtime package.** Do not put business
+   logic in `cli.py` — call into `package_name.core` (or a new module)
+   and use the CLI function as a thin adapter.
+4. **Add tests in `tests/test_cli.py`** (see [Testing CLI commands](#testing-cli-commands)
+   below).
+
+Example: adding a `shout` subcommand that uppercases a name and greets
+it loudly.
+
+```python
+# src/package_name/cli.py
+
+@main.command()
+@click.argument("name")
+@click.option("--exclaim", "-e", default=1, show_default=True, help="Number of !s.")
+def shout(name: str, exclaim: int) -> None:
+    """Print an uppercase greeting for NAME."""
+    message = _greet(name.upper())
+    click.echo(message + "!" * (exclaim - 1))
+```
+
+Usage:
+
+```bash
+$ package-name shout python --exclaim 3
+Hello, PYTHON!!!
+```
+
+## Testing CLI commands
+
+Use click's in-process `CliRunner` to invoke the CLI without spawning a
+subprocess. This is faster than `subprocess.run`, has no shell-quoting
+pitfalls, and gives you direct access to exit codes and captured output.
+
+```python
+# tests/test_cli.py
+from click.testing import CliRunner
+
+from package_name.cli import main
+
+
+def test_greet_default_name() -> None:
+    """greet with no arguments prints the default greeting."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, World!\n"
+
+
+def test_greet_custom_name_long_option() -> None:
+    """greet --name substitutes the provided name."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet", "--name", "Python"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, Python!\n"
+```
+
+What to cover for every new subcommand:
+
+- **Happy path** with default arguments (exit code 0, expected output).
+- **Each option**, long form and short form.
+- **`--help`** — exit code 0 and the option text appears.
+- **Error paths** — missing required arguments, invalid values. Click
+  returns a non-zero exit code and writes a usage message to
+  `result.output`.
+
+## See also
+
+- [Usage Guide](basics.md) — importing the package as a library.
+- [API Reference](../reference/api.md) — full API documentation.
+- [Doit Tasks Reference](../development/doit-tasks-reference.md) — the
+  contributor-only task runner. Not the same thing as this page.
+- [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md) —
+  why runtime CLI and dev tooling are kept separate.
+- [ADR-9014: Use click for application CLI](../template/decisions/9014-use-click-for-application-cli.md)
+
+<!--
+TODO(#342): When the end-to-end "add a feature" example lands, link to
+it here as the narrative counterpart to this reference page. This page
+is the cookbook; #342 will be the walkthrough.
+-->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Installation: getting-started/installation.md
   - Usage:
       - Basics: usage/basics.md
+      - CLI Guide: usage/cli.md
   - Development:
       - Coding Standards: development/coding-standards.md
       - CI/CD & Testing: development/ci-cd-testing.md
@@ -111,6 +112,7 @@ nav:
           - ADR-9011 pytest: template/decisions/9011-use-pytest-for-testing.md
           - ADR-9012 mkdocs: template/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md
           - ADR-9013 Python versions: template/decisions/9013-python-version-support-policy.md
+          - ADR-9014 click CLI: template/decisions/9014-use-click-for-application-cli.md
   - Decisions:
       - Overview: decisions/README.md
   - Reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
+    "click>=8.1",
     "rich>=13.0",
 ]
 
@@ -66,6 +67,7 @@ Documentation = "https://github.com/username/package_name/tree/main/docs"
 Issues = "https://github.com/username/package_name/issues"
 
 [project.scripts]
+package-name = "package_name.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/package_name"]

--- a/src/package_name/cli.py
+++ b/src/package_name/cli.py
@@ -1,0 +1,41 @@
+"""Command-line interface for package_name.
+
+This module defines the user-facing CLI for the package. It is registered
+as a console script via ``[project.scripts]`` in ``pyproject.toml``:
+
+.. code-block:: toml
+
+    [project.scripts]
+    package-name = "package_name.cli:main"
+
+The CLI is built with `click`_ and uses a :class:`click.Group` as the top
+level entry point so new subcommands can be added by decorating functions
+with ``@main.command()``.
+
+.. _click: https://click.palletsprojects.com/
+"""
+
+from __future__ import annotations
+
+import click
+
+from package_name.core import greet as _greet
+
+
+@click.group()
+@click.version_option(package_name="package_name")
+def main() -> None:
+    """package_name command-line interface."""
+
+
+@main.command()
+@click.option(
+    "--name",
+    "-n",
+    default="World",
+    show_default=True,
+    help="Name to greet.",
+)
+def greet(name: str) -> None:
+    """Print a greeting for NAME."""
+    click.echo(_greet(name))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,62 @@
+"""Tests for the package_name command-line interface."""
+
+from click.testing import CliRunner
+
+from package_name import __version__
+from package_name.cli import main
+
+
+def test_greet_default_name() -> None:
+    """greet with no arguments prints the default greeting."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, World!\n"
+
+
+def test_greet_custom_name_long_option() -> None:
+    """greet --name substitutes the provided name."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet", "--name", "Python"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, Python!\n"
+
+
+def test_greet_custom_name_short_option() -> None:
+    """greet -n is the short alias for --name."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet", "-n", "Python"])
+    assert result.exit_code == 0
+    assert result.output == "Hello, Python!\n"
+
+
+def test_top_level_help() -> None:
+    """--help on the top-level group lists the greet subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "greet" in result.output
+
+
+def test_greet_help() -> None:
+    """greet --help documents the --name option without executing the command."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["greet", "--help"])
+    assert result.exit_code == 0
+    assert "--name" in result.output
+    assert "Hello, Python!" not in result.output
+
+
+def test_version_option() -> None:
+    """--version prints the installed package version."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+def test_main_is_importable() -> None:
+    """The entry-point target is importable and callable."""
+    from package_name.cli import main as imported_main
+
+    assert callable(imported_main)

--- a/uv.lock
+++ b/uv.lock
@@ -1165,6 +1165,7 @@ wheels = [
 name = "package-name"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "rich" },
 ]
 
@@ -1203,6 +1204,7 @@ security = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'security'", specifier = ">=1.7" },
+    { name = "click", specifier = ">=8.1" },
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.2" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "cyclonedx-bom", marker = "extra == 'security'", specifier = ">=4.0" },


### PR DESCRIPTION
## Description

Adds a real click-based application CLI to the template, backed by tests,
documentation, and an ADR. Previously the template shipped with an empty
`[project.scripts]` block and no `cli.py`, which left contributors with
no concrete pattern to copy and made the runtime/dev tooling split
documented in `tooling-roles.md` purely aspirational. This PR closes that
gap end to end.

### Scope expansion note

Issue #341 was originally filed as a **doc-only** request ("add an
application CLI guide"). While planning, it became clear that writing a
guide grounded in real code requires the code to exist — the template had
no CLI module, no entry point, and no test pattern to point readers at.
The user explicitly approved expanding scope to add the feature itself in
the same PR. Labels were updated from `documentation` to
`enhancement` + `needs-adr` to reflect the actual scope.

## Related Issue

Addresses #341

Also related:
- #340 — `tooling-roles.md` previously forward-referenced #341 as a TODO; this PR replaces those references with direct links to the new CLI Guide.
- #342 — planned end-to-end "add a feature" example; `docs/usage/cli.md` includes a `TODO(#342)` marker to cross-link once that lands.
- ADR-9002 (`doit` for task automation) — established the runtime-vs-dev tooling split that this PR makes concrete on the runtime side.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

Purely additive — new module, new entry point, new runtime dep. No
existing public API changes.

## Changes Made

### Summary

- **New click-based CLI** at `src/package_name/cli.py` with a `greet` subcommand and `--version` wired to installed package metadata.
- **Full test coverage** via `click.testing.CliRunner` (7 tests, in-process, no subprocess).
- **New CLI Guide** at `docs/usage/cli.md` with a copyable subcommand walkthrough, testing recipe, and cross-links to `tooling-roles.md`.
- **ADR-9014** documenting the choice of `click` over `argparse` and `typer`.

### Files (10 total — 4 created, 6 modified)

**Created:**

- `src/package_name/cli.py` — click `Group` `main` with `greet` subcommand and `@click.version_option(package_name="package_name")`. Delegates to `package_name.core.greet`; the CLI is a thin presentation layer.
- `tests/test_cli.py` — 7 `CliRunner` tests covering default greet, `--name`/`-n`, top-level `--help`, `greet --help`, `--version`, and entry-point importability.
- `docs/usage/cli.md` — narrative + reference CLI Guide: entry-point layout, how to add subcommands, how to test them, and links to ADR-9014 and `tooling-roles.md`.
- `docs/template/decisions/9014-use-click-for-application-cli.md` — ADR-9014. Placed under `template/decisions/` (the 9000-series for template-meta decisions) rather than project-level `docs/decisions/`, per the user's correction during planning.

**Modified:**

- `pyproject.toml` — added `click>=8.1` to `[project] dependencies` (runtime dep, not dev); populated `[project.scripts]` with `package-name = "package_name.cli:main"`.
- `uv.lock` — refreshed with click and its transitive deps.
- `mkdocs.yml` — added `CLI Guide` nav entry under `Usage` and `ADR-9014 click CLI` nav entry under template decisions.
- `docs/index.md` — added CLI Guide bullet under "For Users".
- `docs/usage/basics.md` — added a one-line callout pointing readers to the CLI Guide.
- `docs/development/tooling-roles.md` — replaced the two `#341` forward-references with direct links to `../usage/cli.md`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### What was run

- `doit check` — **all checks passed** (format, lint, mypy, bandit, codespell, and the full pytest suite including the 7 new `test_cli.py` cases).
- `doit docs_build` — builds cleanly. The new CI gate from #356 will enforce this on the PR. ADR-9014 is registered in `mkdocs.yml` nav (no new "pages not in nav" entries introduced by this branch). No new warnings introduced; remaining warnings are pre-existing on `main`.
- **Manual smoke test** of the actual feature:
  - `uv run package-name greet` → `Hello, World!`
  - `uv run package-name greet --name Python` → `Hello, Python!`
  - `uv run package-name --version` → prints the installed package version (proves `@click.version_option` metadata wiring works).
- The built wheel's `Requires-Dist:` now includes `click>=8.1` as a runtime dep, so end users installing the published package get the CLI working out of the box without any dev extras.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (handled automatically by commitizen at release time from the `feat:` commit)
- [x] My changes generate no new warnings
- [x] **ADR created** — ADR-9014 at `docs/template/decisions/9014-use-click-for-application-cli.md` (this PR has the `needs-adr` label). ADR-9014 links to the new CLI Guide, `tooling-roles.md`, and ADR-9002 under "Related Documentation".

## Additional Notes

- **No `BREAKING CHANGE:`** — purely additive. Existing consumers using the package as a library are unaffected; the new console script is opt-in by nature (you only get it if you install the package).
- **Why `click` and not `argparse` or `typer`** — see ADR-9014. Short version: `argparse` has too much boilerplate for nested subcommands and no `CliRunner` equivalent; `typer` is built on top of `click` anyway and adds presentation coupling.
- **ADR placement** — ADR-9014 lives under `docs/template/decisions/` (the 9000-series for template-meta decisions), not `docs/decisions/` (project-level). The choice of CLI framework is a template-baseline decision, not a decision specific to a project built from the template.
