### PR TITLE
refactor: move install_tools ADR to template decisions directory

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -67,7 +67,6 @@ Complete index of all documentation, organized by audience and as a full alphabe
 
 ## Complete Index
 <!-- BEGIN:all -->
-- [ADR-0001: install_tools framework: archive extraction and custom URLs](decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md)
 - [ADR-9001: Use uv for package management](template/decisions/9001-use-uv-for-package-management.md)
 - [ADR-9002: Use doit for task automation](template/decisions/9002-use-doit-for-task-automation.md)
 - [ADR-9003: Use ruff for linting and formatting](template/decisions/9003-use-ruff-for-linting-and-formatting.md)
@@ -82,6 +81,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9012: Use mkdocs with Material theme for documentation](template/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md)
 - [ADR-9013: Python version support policy with bookend CI strategy](template/decisions/9013-python-version-support-policy.md)
 - [ADR-9014: Use click for application CLI](template/decisions/9014-use-click-for-application-cli.md)
+- [ADR-9015: install_tools framework: archive extraction and custom URLs](template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
 - [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template

--- a/docs/development/install-tools-framework.md
+++ b/docs/development/install-tools-framework.md
@@ -142,4 +142,4 @@ the download path on every OS.
 
 ## Related ADR
 
-- [ADR-0001: install_tools framework: archive extraction and custom URLs](../decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md)
+- [ADR-9015: install_tools framework: archive extraction and custom URLs](../template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)

--- a/docs/template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -1,4 +1,4 @@
-# ADR-0001: install_tools framework: archive extraction and custom URLs
+# ADR-9015: install_tools framework: archive extraction and custom URLs
 
 ## Status
 
@@ -44,4 +44,4 @@ The three capabilities are intentionally orthogonal so simple cases stay simple 
 
 ## Related Documentation
 
-- [install_tools Framework](../development/install-tools-framework.md)
+- [install_tools Framework](../../development/install-tools-framework.md)

--- a/docs/template/decisions/README.md
+++ b/docs/template/decisions/README.md
@@ -25,3 +25,5 @@ Template ADRs use the **9XXX** range to avoid conflicts with project-specific AD
 | [9011](9011-use-pytest-for-testing.md) | Use pytest for testing | Accepted |
 | [9012](9012-use-mkdocs-with-material-theme-for-documentation.md) | Use mkdocs with Material theme for documentation | Accepted |
 | [9013](9013-python-version-support-policy.md) | Python version support policy with bookend CI strategy | Accepted |
+| [9014](9014-use-click-for-application-cli.md) | Use click for application CLI | Accepted |
+| [9015](9015-install-tools-framework-archive-extraction-and-custom-urls.md) | install_tools framework: archive extraction and custom URLs | Accepted |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
           - ADR-9012 mkdocs: template/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md
           - ADR-9013 Python versions: template/decisions/9013-python-version-support-policy.md
           - ADR-9014 click CLI: template/decisions/9014-use-click-for-application-cli.md
+          - ADR-9015 install_tools: template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
   - Decisions:
       - Overview: decisions/README.md
   - Reference:


### PR DESCRIPTION
## Description

Moves the misplaced `0001-install-tools-framework-...` ADR from `docs/decisions/` to `docs/template/decisions/9015-...` where the rest of the template-meta ADRs (9001-9014) live, and updates references. Also adds the missing ADR-9014 row to the template decisions index that was left over from PR #358.

The `install_tools` framework is template-meta tooling (lives under `tools/doit/install_tools.py`) and is a feature of the template itself, not of any project built from it — so its ADR belongs in the 9000-series alongside the other template decisions.

### Scope correction

I filed this issue with two scope additions that exploration during planning showed were wrong: "delete `docs/decisions/` entirely" and "change `doit adr` default location." Per the explicit design intent in `tests/test_doit_adr.py:66-67`, `docs/decisions/` is the **scaffold for project-level ADRs** that downstream consumers will use after spawning a real project from this template. The `0001-install-tools-...` file is the only previously-misplaced ADR. A scope-correction comment was posted on issue #359 before the implementation plan.

## Related Issue

Addresses #359
Related: #326 (the original issue that the moved ADR documents), PR #358 (which introduced the missing ADR-9014 row in the template index).

## Type of Change

- [x] Code refactoring
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **Created** `docs/template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md` — copy of the old 0001 file with `# ADR-0001` → `# ADR-9015` in the title and the `Related Documentation` link rewritten as `../../development/install-tools-framework.md` (one level deeper from the new location).
- **Deleted** `docs/decisions/0001-install-tools-framework-archive-extraction-and-custom-urls.md` (git detected this as a 94% rename of the new 9015 file — clean diff).
- **Modified** `docs/development/install-tools-framework.md` — line 145 reference updated to `ADR-9015` at the new path.
- **Modified** `docs/template/decisions/README.md` — added rows for both ADR-9014 (leftover from PR #358) and ADR-9015 to the index table.
- **Modified** `mkdocs.yml` — new `ADR-9015 install_tools` nav entry under Template Decisions.
- **Auto-regenerated** `docs/TABLE_OF_CONTENTS.md` (via the `generate-doc-toc` pre-commit hook).

### Files explicitly NOT touched

- `docs/decisions/` directory + its `README.md` + `adr-template.md` — preserved as the project-level ADR scaffold.
- `tools/doit/adr.py` — `ADR_DIR = Path("docs/decisions")` is unchanged. After this PR, `_get_next_adr_number()` returns `1` because the project ADR directory is empty, exactly as `tests/test_doit_adr.py` expects.
- `tests/test_doit_adr.py` — unchanged. Its inline `"""# ADR-0001: Test"""` strings are placeholder fixtures, not references to the moved file.
- `AGENTS.md`, `.github/CONTRIBUTING.md` — unchanged. Their `docs/decisions/` references are guidance for project-level ADR creation.

## Testing

- [x] All existing tests pass — `doit check` clean (the existing `tests/test_doit_adr.py::test_returns_sequential_number` continues to pass; `_get_next_adr_number()` now returns `1`)
- [x] No new tests added (this is a static file relocation; the build pipeline is the integration test)
- [x] Manually verified via `doit docs_build` — the new docs_build CI gate from #356 catches any broken link this PR could introduce. Pre-existing warnings on main reproduce; no new warnings from this branch.
- [x] Grep verification: no stale `0001-install-tools` or `ADR-0001` references in tracked source files (only `docs/TABLE_OF_CONTENTS.md` which is auto-regenerated, and 6 intentional inline test fixtures in `tests/test_doit_adr.py`)

## Checklist

- [x] My code follows the code style of this project (`doit format` clean)
- [x] I have run linting checks (`doit lint` clean)
- [x] I have run type checking (`doit type_check` clean)
- [x] I have added tests that prove my fix is effective or that my feature works (n/a — file relocation; existing tests cover the relevant invariant)
- [x] All new and existing tests pass (`doit test` clean)
- [x] I have updated the documentation accordingly (the moved ADR + index + nav are themselves the doc changes)
- [ ] I have updated the CHANGELOG.md (not required for refactors per CONTRIBUTING.md)
- [x] My changes generate no new warnings (`doit docs_build` clean vs main)

## Additional Notes

After this PR, `docs/decisions/` is empty of numbered ADRs and contains only the README and adr-template scaffold. This makes the design intent that `tests/test_doit_adr.py:66-67` already documented literally true: `docs/decisions/` is reserved for future project-level ADRs (0001-series), `docs/template/decisions/` holds template-meta ADRs (9XXX-series), and `doit adr` correctly defaults to the project-level scaffold for downstream consumers.
