### PR TITLE
feat: add Copilot CLI command-blocking hook integration

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -10,7 +10,17 @@
 default_policy = "untrusted"  # Prompt before running untrusted commands
 
 # =============================================================================
-# BLOCKED COMMANDS - These bypass security controls
+# PRE-TOOL-USE HOOK — Primary defense
+# =============================================================================
+# The shared hook script provides context-aware blocking (shlex tokenization,
+# protected-branch detection, chained-command scanning). The approval_policy
+# deny rules below act as a secondary (belt-and-suspenders) defense layer in
+# case the hook fails to load or Codex evaluates policies before hooks.
+[hooks]
+pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+
+# =============================================================================
+# BLOCKED COMMANDS - Secondary defense (approval_policy deny rules)
 # =============================================================================
 
 # Block --admin flag (bypasses branch protection)

--- a/.github/hooks/copilot-hooks.json
+++ b/.github/hooks/copilot-hooks.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ site/
 coverage.xml
 .nfs*
 .gemini/settings.json.orig
+tools/hooks/ai/hook-debug.jsonl

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -12,7 +12,7 @@ tags:
 
 # AI CLI Hooks
 
-The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI).
+The `tools/hooks/ai/` directory contains hooks for AI coding assistants (Claude Code, Gemini CLI, Copilot CLI, Codex CLI).
 
 ## Block Dangerous Commands
 
@@ -42,6 +42,20 @@ The hook uses Python's `shlex` module to properly parse shell quoting:
 6. **Check** for merge commits on protected branches (linear history)
 7. **Block** (exit code 2) or **Allow** (exit code 0)
 
+#### Key Feature: Chained Command Detection
+
+The hook scans all token positions, so chained commands using `&&` or `;` are caught:
+
+```bash
+# BLOCKED - dangerous command after safe one
+git status; git push --force origin main
+cd /path && doit release
+
+# ALLOWED - all commands in the chain are safe
+cd /path && doit check
+git status; git push origin feat/branch
+```
+
 #### Key Feature: Quote-Aware Parsing
 
 The hook correctly distinguishes between:
@@ -64,7 +78,7 @@ EOF
 
 | File | Description |
 |------|-------------|
-| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude and Gemini) |
+| [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude, Gemini, Copilot, and Codex) |
 | [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
 
 ### Configuration
@@ -112,9 +126,34 @@ EOF
 }
 ```
 
+#### Copilot CLI
+
+`.github/hooks/copilot-hooks.json`:
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
 #### Codex CLI
 
-Codex uses approval policies instead of hooks. See `.codex/config.toml` for deny rules.
+`.codex/config.toml`:
+```toml
+[hooks]
+pre_tool_use = "python3 tools/hooks/ai/block-dangerous-commands.py"
+```
+
+Codex also keeps `approval_policy` deny rules as a secondary defense layer. See `.codex/config.toml` for the full configuration.
 
 ### Testing
 

--- a/docs/template/decisions/9005-ai-agent-command-restrictions.md
+++ b/docs/template/decisions/9005-ai-agent-command-restrictions.md
@@ -19,6 +19,7 @@ Documentation alone is insufficient - AI agents may violate rules after context 
 - Issue #163: Add pre-commit hook to block pyproject.toml version changes
 - Issue #164: Block doit release in AI agent hooks
 - Issue #166: Block uv add in AI agent hooks
+- Issue #362: Add Copilot CLI command-blocking hook integration
 
 ## Related Documentation
 

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -16,9 +16,11 @@ For full documentation, see: docs/development/ai/command-blocking.md
 """
 
 import json
+import os
 import shlex
 import subprocess  # nosec B404 - needed for git branch detection
 import sys
+from pathlib import Path
 
 # Protected branches - operations on these require extra scrutiny
 PROTECTED_BRANCHES = {"main", "master"}
@@ -126,6 +128,8 @@ def check_push_to_protected(tokens: list[str]) -> tuple[bool, str]:
 
     Blocks any git push when the current branch is a protected branch.
     Force pushes to protected branches are also blocked even from feature branches.
+
+    Scans all positions to handle chained commands (e.g., git status; git push --force).
     """
     tokens_lower = [t.lower() for t in tokens]
 
@@ -133,48 +137,61 @@ def check_push_to_protected(tokens: list[str]) -> tuple[bool, str]:
     if "git" not in tokens_lower or "push" not in tokens_lower:
         return False, ""
 
-    try:
-        git_idx = tokens_lower.index("git")
-        push_idx = tokens_lower.index("push")
-    except ValueError:
-        return False, ""
+    # Find ALL positions where git + push appear as a pair
+    for git_idx in range(len(tokens_lower) - 1):
+        if tokens_lower[git_idx] != "git":
+            continue
 
-    # Ensure "push" is the git subcommand, not part of another command like "git stash push"
-    subcommand_idx = git_idx + 1
-    if subcommand_idx >= len(tokens_lower) or tokens_lower[subcommand_idx] != "push":
-        return False, ""
+        # Ensure "push" is the git subcommand, not part of another command like "git stash push"
+        subcommand_idx = git_idx + 1
+        if tokens_lower[subcommand_idx] != "push":
+            continue
 
-    # Check if any force flag is present
-    has_force_flag = any(flag in tokens for flag in FORCE_PUSH_FLAGS)
+        # Determine the end of this git push command (next git/doit/gh/uv token or end)
+        cmd_end = len(tokens)
+        for j in range(subcommand_idx + 1, len(tokens_lower)):
+            # A new command starts at a token that is a known command root
+            # Also handle shell operators that got merged with tokens (e.g., "status;")
+            if tokens_lower[j] in ("git", "doit", "gh", "uv"):
+                cmd_end = j
+                break
+        cmd_tokens = tokens[git_idx:cmd_end]
 
-    # Look for branch name in tokens after 'push'
-    # Skip flags (tokens starting with -)
-    after_push = [t for t in tokens[push_idx + 1 :] if not t.startswith("-")]
+        # Check if any force flag is present in this git push command
+        has_force_flag = any(flag in cmd_tokens for flag in FORCE_PUSH_FLAGS)
 
-    # Check if explicitly pushing to a protected branch
-    for token in after_push:
-        # Handle origin/main format
-        branch = token.split("/")[-1] if "/" in token else token
+        # Look for branch name in tokens after 'push'
+        # Skip flags (tokens starting with -)
+        push_idx = subcommand_idx
+        after_push = [t for t in tokens[push_idx + 1 : cmd_end] if not t.startswith("-")]
 
-        if branch.lower() in PROTECTED_BRANCHES:
+        # Check if explicitly pushing to a protected branch
+        for token in after_push:
+            # Handle origin/main format
+            branch = token.split("/")[-1] if "/" in token else token
+
+            if branch.lower() in PROTECTED_BRANCHES:
+                action = "Force push" if has_force_flag else "Push"
+                return True, f"{action} to protected branch '{branch}'"
+
+        # Check if currently on a protected branch (catches bare `git push`)
+        current_branch = get_current_branch()
+        if (
+            current_branch
+            and current_branch.lower() in PROTECTED_BRANCHES
+            and (not after_push or (len(after_push) == 1 and after_push[0] == "origin"))
+        ):
             action = "Force push" if has_force_flag else "Push"
-            return True, f"{action} to protected branch '{branch}'"
+            return True, (
+                f"{action} while on protected branch '{current_branch}'. "
+                f"Create a feature branch first"
+            )
 
-    # Check if currently on a protected branch (catches bare `git push`)
-    current_branch = get_current_branch()
-    if (
-        current_branch
-        and current_branch.lower() in PROTECTED_BRANCHES
-        and (not after_push or (len(after_push) == 1 and after_push[0] == "origin"))
-    ):
-        action = "Force push" if has_force_flag else "Push"
-        return True, (
-            f"{action} while on protected branch '{current_branch}'. Create a feature branch first"
-        )
-
-    # Force push without explicit branch from a feature branch — block as safety
-    if has_force_flag and (not after_push or (len(after_push) == 1 and after_push[0] == "origin")):
-        return True, "Force push without explicit branch (could affect protected branch)"
+        # Force push without explicit branch from a feature branch — block as safety
+        if has_force_flag and (
+            not after_push or (len(after_push) == 1 and after_push[0] == "origin")
+        ):
+            return True, "Force push without explicit branch (could affect protected branch)"
 
     return False, ""
 
@@ -188,30 +205,47 @@ def check_delete_protected_branch(tokens: list[str]) -> tuple[bool, str]:
     - git push origin :main
     - git branch -D main
     - git branch -d main
+
+    Scans all positions to handle chained commands (e.g., git log; git push origin --delete main).
     """
     tokens_lower = [t.lower() for t in tokens]
 
-    # Check for remote branch deletion: git push origin --delete main
-    if "git" in tokens_lower and "push" in tokens_lower and "--delete" in tokens_lower:
-        for token in tokens:
-            if token.lower() in PROTECTED_BRANCHES:
-                return True, f"Deleting protected remote branch '{token}'"
+    # Scan for all git token positions
+    for git_idx in range(len(tokens_lower)):
+        if tokens_lower[git_idx] != "git":
+            continue
 
-    # Check for remote branch deletion with colon syntax: git push origin :main
-    if "git" in tokens_lower and "push" in tokens_lower:
-        for token in tokens:
-            if token.startswith(":") and token[1:].lower() in PROTECTED_BRANCHES:
-                return True, f"Deleting protected remote branch '{token[1:]}'"
+        if git_idx + 1 >= len(tokens_lower):
+            continue
 
-    # Check for local branch deletion: git branch -D main or git branch -d main
-    if (
-        "git" in tokens_lower
-        and "branch" in tokens_lower
-        and ("-d" in tokens_lower or "-D" in tokens)
-    ):
-        for token in tokens:
-            if token.lower() in PROTECTED_BRANCHES:
-                return True, f"Deleting protected local branch '{token}'"
+        subcommand = tokens_lower[git_idx + 1]
+
+        # Determine the end of this git command (next command root or end)
+        cmd_end = len(tokens)
+        for j in range(git_idx + 2, len(tokens_lower)):
+            if tokens_lower[j] in ("git", "doit", "gh", "uv"):
+                cmd_end = j
+                break
+        cmd_tokens = tokens[git_idx:cmd_end]
+        cmd_tokens_lower = tokens_lower[git_idx:cmd_end]
+
+        # Check for remote branch deletion: git push origin --delete main
+        if subcommand == "push" and "--delete" in cmd_tokens_lower:
+            for token in cmd_tokens:
+                if token.lower() in PROTECTED_BRANCHES:
+                    return True, f"Deleting protected remote branch '{token}'"
+
+        # Check for remote branch deletion with colon syntax: git push origin :main
+        if subcommand == "push":
+            for token in cmd_tokens:
+                if token.startswith(":") and token[1:].lower() in PROTECTED_BRANCHES:
+                    return True, f"Deleting protected remote branch '{token[1:]}'"
+
+        # Check for local branch deletion: git branch -D main or git branch -d main
+        if subcommand == "branch" and ("-d" in cmd_tokens_lower or "-D" in cmd_tokens):
+            for token in cmd_tokens:
+                if token.lower() in PROTECTED_BRANCHES:
+                    return True, f"Deleting protected local branch '{token}'"
 
     return False, ""
 
@@ -241,13 +275,15 @@ def check_blocked_workflow_commands(tokens: list[str]) -> tuple[bool, str]:
     Check if command uses blocked workflow commands.
 
     These commands should use doit wrappers instead of direct gh commands.
+    Scans all positions to catch commands chained with && or ;.
     """
     tokens_lower = [t.lower() for t in tokens]
 
     for cmd_tuple, reason in BLOCKED_WORKFLOW_COMMANDS.items():
         cmd_len = len(cmd_tuple)
-        if len(tokens_lower) >= cmd_len and tuple(tokens_lower[:cmd_len]) == cmd_tuple:
-            return True, reason
+        for i in range(len(tokens_lower) - cmd_len + 1):
+            if tuple(tokens_lower[i : i + cmd_len]) == cmd_tuple:
+                return True, reason
     return False, ""
 
 
@@ -363,6 +399,54 @@ def check_command(command: str) -> tuple[bool, str]:
     return False, ""
 
 
+def _parse_input(input_data: dict) -> tuple[str, str]:
+    """
+    Parse tool name and command from hook input.
+
+    Handles two input formats:
+    - Claude/Gemini: {"tool_name": "Bash", "tool_input": {"command": "..."}}
+    - Copilot CLI:   {"toolName": "bash", "toolArgs": "{\"command\":\"...\"}"}
+
+    Returns:
+        (tool_name, command) tuple
+    """
+    # Copilot CLI format uses camelCase keys
+    if "toolName" in input_data:
+        tool_name = input_data.get("toolName", "")
+        tool_args_raw = input_data.get("toolArgs", "{}")
+        try:
+            tool_args = (
+                json.loads(tool_args_raw) if isinstance(tool_args_raw, str) else tool_args_raw
+            )
+        except json.JSONDecodeError:
+            tool_args = {}
+        return tool_name, tool_args.get("command", "")
+
+    # Claude/Gemini format uses snake_case keys
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+    return tool_name, tool_input.get("command", "")
+
+
+def _is_copilot_format(input_data: dict) -> bool:
+    """Return True if input uses Copilot CLI hook format (camelCase keys)."""
+    return "toolName" in input_data
+
+
+LOG_FILE = Path(__file__).parent / "hook-debug.jsonl"
+
+
+def _log(entry: dict) -> None:
+    """Append a JSON log entry. Only active when HOOK_DEBUG=1 is set."""
+    if not os.environ.get("HOOK_BLOCKCOMMAND_DEBUG"):
+        return
+    try:
+        with LOG_FILE.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass  # Never fail due to logging
+
+
 def main() -> int:
     """Main entry point."""
     try:
@@ -371,28 +455,53 @@ def main() -> int:
         print(f"Invalid JSON input: {e}", file=sys.stderr)
         return 1
 
-    tool_name = input_data.get("tool_name", "")
-    tool_input = input_data.get("tool_input", {})
+    tool_name, command = _parse_input(input_data)
+    copilot_format = _is_copilot_format(input_data)
 
-    # Only check shell commands (Bash for Claude, run_shell_command for Gemini)
-    if tool_name not in ("Bash", "run_shell_command"):
+    _log(
+        {
+            "raw_input": input_data,
+            "tool_name": tool_name,
+            "command": command,
+            "copilot_format": copilot_format,
+        }
+    )
+
+    # Only check shell commands:
+    # - "Bash" for Claude
+    # - "run_shell_command" for Gemini
+    # - "bash" for Copilot CLI
+    if tool_name not in ("Bash", "run_shell_command", "bash"):
         return 0
 
-    command = tool_input.get("command", "")
     if not command:
         return 0
 
     is_dangerous, reason = check_command(command)
     if is_dangerous:
-        print(
-            f"BLOCKED: Command contains dangerous pattern.\n"
-            f"Reason: {reason}\n"
-            f"Command: {command}\n"
-            f"\n"
-            f"If this is intentional, ask the user to run it manually.",
-            file=sys.stderr,
-        )
-        return 2  # Exit 2 = Block and show stderr to Claude
+        if copilot_format:
+            # Copilot CLI: deny via JSON output to stdout
+            output = json.dumps(
+                {
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        f"Blocked: {reason}. If intentional, ask the user to run it manually."
+                    ),
+                }
+            )
+            print(output)
+            return 0
+        else:
+            # Claude/Gemini: block via exit code 2 + stderr message
+            print(
+                f"BLOCKED: Command contains dangerous pattern.\n"
+                f"Reason: {reason}\n"
+                f"Command: {command}\n"
+                f"\n"
+                f"If this is intentional, ask the user to run it manually.",
+                file=sys.stderr,
+            )
+            return 2  # Exit 2 = Block and show stderr to Claude/Gemini
 
     return 0
 

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -119,6 +119,18 @@ EOF
     # === SHOULD ALLOW - Other labels ===
     ("gh pr edit 123 --add-label bug", "ALLOW", "add bug label"),
     ("gh pr edit 123 --add-label enhancement", "ALLOW", "add enhancement label"),
+    # === SHOULD BLOCK - Nested/chained commands ===
+    ("cd /path && doit release", "BLOCK", "chained doit release"),
+    ("cd /path && gh pr create --fill", "BLOCK", "chained gh pr create"),
+    ("cd /path && uv add requests", "BLOCK", "chained uv add"),
+    ("cd /path && git push --force origin main", "BLOCK", "chained force push main"),
+    ("git status; git push --force origin main", "BLOCK", "semicolon force push main"),
+    ("git status; git push origin --delete main", "BLOCK", "semicolon delete main"),
+    ("git log; git branch -D main", "BLOCK", "semicolon branch -D main"),
+    # === SHOULD ALLOW - Nested/chained safe commands ===
+    ("cd /path && doit check", "ALLOW", "chained doit check"),
+    ("cd /path && git status", "ALLOW", "chained git status"),
+    ("git status; git push origin feat/branch", "ALLOW", "semicolon push feature"),
     # === SHOULD ALLOW - Other gh commands ===
     ("gh issue list", "ALLOW", "gh issue list"),
     ("gh pr list", "ALLOW", "gh pr list"),


### PR DESCRIPTION
## Description

Add Copilot CLI command-blocking hook integration and harden the shared hook script against chained/nested commands. This branch was started by Copilot CLI (hook wiring and gitignore), then completed by Claude (bug fixes, multi-position scanning, Codex hook config, documentation, and tests).

Addresses #362

## Related Issue

Addresses #362

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Add `.github/hooks/copilot-hooks.json` wiring Copilot CLI preToolUse to the shared hook script
- Add `.gitignore` entry for `hook-debug.jsonl`
- Fix `.index()` bug in `check_push_to_protected` that only matched the first `git` token, missing chained commands (e.g., `git status; git push --force origin main`)
- Refactor `check_push_to_protected` and `check_delete_protected_branch` to scan all token positions for `git push`/`git branch` pairs
- Add Codex `[hooks]` section to `.codex/config.toml` for primary hook-based defense (existing deny rules remain as secondary layer)
- Update `docs/development/ai/command-blocking.md` to document all four agents (Claude, Gemini, Copilot, Codex) and the chained-command detection feature
- Add 10 test cases to `test_hook.py` covering chained/nested commands with `&&` and `;`
- Apply `ruff format` fixes to long lines in the hook script

## Testing

- [x] All existing tests pass (`doit check` passes)
- [x] Added new tests for new functionality (10 chained-command test cases)
- [x] Manually tested the changes (`python3 tools/hooks/ai/test_hook.py` -- 76/76 pass)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- ADR-9005 updated with Issue #362 link
- The hook script now properly handles shell operators (`&&`, `;`) by scanning all token positions rather than only the first occurrence of `git`
