### PR TITLE
feat: add doit task to install the gh CLI

### DIFF
--- a/docs/development/install-tools-framework.md
+++ b/docs/development/install-tools-framework.md
@@ -71,6 +71,30 @@ def task_install_age():
 `extract_binaries` matches by **basename**, so any directory structure
 inside the archive (e.g., `age/age`, `age/age-keygen`) is ignored.
 
+### Multi-arch archive from GitHub releases via `url_template` (gh)
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_gh():
+    return create_install_task(
+        name="gh",
+        repo="cli/cli",
+        asset_patterns={},
+        url_template=(
+            "https://github.com/cli/cli/releases/download/v{version}/"
+            "gh_{version}_{os}_{arch}.tar.gz"
+        ),
+        extract_binaries=["gh"],
+        version_cmd=["gh", "--version"],
+        prefer_brew=False,
+    )
+```
+
+When the release URL itself is on GitHub but includes architecture-specific
+filenames (e.g., `gh_2.45.0_linux_amd64.tar.gz`), `url_template` is the
+right choice because `asset_patterns` does not support `{arch}` placeholders.
+
 ### Zip from a non-GitHub URL (terraform)
 
 ```python

--- a/tests/test_doit_install.py
+++ b/tests/test_doit_install.py
@@ -1,6 +1,8 @@
 """Tests for install.py doit tasks."""
 
-from tools.doit.install import task_install, task_install_dev
+from unittest.mock import MagicMock, patch
+
+from tools.doit.install import task_install, task_install_dev, task_install_gh
 
 
 class TestTaskInstall:
@@ -49,3 +51,61 @@ class TestTaskInstallDev:
             "git update-index --assume-unchanged src/package_name/_version.py"
         )
         assert sync_idx < assume_idx
+
+
+class TestTaskInstallGh:
+    """Tests for task_install_gh function."""
+
+    def test_returns_valid_doit_task(self) -> None:
+        """Test that task_install_gh returns a valid doit task dict."""
+        result = task_install_gh()
+        assert isinstance(result, dict)
+        assert "actions" in result
+        assert "title" in result
+        assert len(result["actions"]) == 1
+        assert callable(result["actions"][0])
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_action_calls_install_tool_with_correct_args(self, mock_install: MagicMock) -> None:
+        """Test that the task action calls install_tool with gh-specific args."""
+        result = task_install_gh()
+        result["actions"][0]()
+
+        mock_install.assert_called_once_with(
+            name="gh",
+            repo="cli/cli",
+            asset_patterns={},
+            version_cmd=["gh", "--version"],
+            post_install_message=None,
+            extract_binaries=["gh"],
+            url_template="https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.tar.gz",
+            prefer_brew=False,
+        )
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_uses_url_template_not_asset_patterns(self, mock_install: MagicMock) -> None:
+        """Test that gh uses url_template with empty asset_patterns."""
+        result = task_install_gh()
+        result["actions"][0]()
+
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["asset_patterns"] == {}
+        assert "{version}" in kwargs["url_template"]
+        assert "{os}" in kwargs["url_template"]
+        assert "{arch}" in kwargs["url_template"]
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_prefer_brew_is_false(self, mock_install: MagicMock) -> None:
+        """Test that prefer_brew is False for consistent cross-platform behavior."""
+        result = task_install_gh()
+        result["actions"][0]()
+
+        assert mock_install.call_args.kwargs["prefer_brew"] is False
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_extract_binaries_contains_gh(self, mock_install: MagicMock) -> None:
+        """Test that extract_binaries is set to extract the gh binary."""
+        result = task_install_gh()
+        result["actions"][0]()
+
+        assert mock_install.call_args.kwargs["extract_binaries"] == ["gh"]

--- a/tools/doit/install.py
+++ b/tools/doit/install.py
@@ -39,6 +39,19 @@ def task_install_dev() -> dict[str, Any]:
     }
 
 
+def task_install_gh() -> dict[str, Any]:
+    """Install GitHub CLI for repository operations."""
+    return create_install_task(
+        name="gh",
+        repo="cli/cli",
+        asset_patterns={},
+        url_template="https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.tar.gz",
+        extract_binaries=["gh"],
+        version_cmd=["gh", "--version"],
+        prefer_brew=False,
+    )
+
+
 def task_install_direnv() -> dict[str, Any]:
     """Install direnv for automatic environment loading."""
     return create_install_task(


### PR DESCRIPTION
## Description

Add a `doit install_gh` task that installs the GitHub CLI (`gh`) using the
existing install-tools framework. The task uses `url_template` with
`extract_binaries` to download architecture-specific tar.gz archives from
GitHub releases, with `prefer_brew=False` for consistent cross-platform
behavior.

## Related Issue

Addresses #374

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `task_install_gh()` to `tools/doit/install.py` using `create_install_task` with `url_template` and `extract_binaries`
- Added tests in `tests/test_doit_install.py` verifying task structure, `install_tool` arguments, `url_template` usage, `prefer_brew=False`, and `extract_binaries` configuration
- Added documentation example in `docs/development/install-tools-framework.md` showing the `url_template` pattern for GitHub-hosted arch-specific archives

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
