### PR TITLE
feat: add --auto-close flag to doit pr_merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **Tests:** Creating code = Creating tests. No exceptions. Never modify a failing test to make it pass — stop, explain why it broke, and discuss with the user whether the code or the test should change.
 - **Commits:** One logical change per commit. Use conventional commits.
 - **Releases:** Never run `doit release` without explicit command.
-- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed.
+- **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed — pass `--auto-close` to `doit pr_merge` to close linked issues in one step.
 - **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation.
 - **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
@@ -363,8 +363,9 @@ doit pr --title="fix: handle null" --body-file=pr.md
 
 ### PR Merge
 ```bash
-doit pr_merge                    # Merge PR for current branch
-doit pr_merge --pr=123           # Merge specific PR
+doit pr_merge                        # Merge PR for current branch
+doit pr_merge --pr=123               # Merge specific PR
+doit pr_merge --pr=123 --auto-close  # Also close linked issues after merge
 ```
 
 ### ADR Creation

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -660,15 +660,21 @@ doit pr_merge
 
 # Merge specific PR
 doit pr_merge --pr=123
+
+# Merge and automatically close linked issues
+doit pr_merge --auto-close
 ```
 
 **What it does:**
 1. Finds PR associated with current branch (or uses `--pr`)
 2. Validates PR is approved and checks pass
 3. Merges with conventional commit format: `<type>: <subject> (merges PR #XX, addresses #YY)`
+4. If `--auto-close` is set, closes each linked issue with a `Addressed in PR #XX` comment; otherwise prints the `gh issue close` commands as a reminder.
 
 **Options:**
 - `--pr`: PR number to merge (defaults to PR for current branch)
+- `--delete-branch`: Delete the source branch after merge (default: `true`)
+- `--auto-close`: Close linked issues (parsed from `Addresses #XX` in the PR body) after a successful merge (default: `false`)
 
 ### `adr`
 

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -283,6 +283,9 @@ doit pr_merge --pr=123
 
 # Keep the branch after merge (default deletes it)
 doit pr_merge --delete-branch=false
+
+# Automatically close linked issues after merge
+doit pr_merge --auto-close
 ```
 
 ### What It Does
@@ -333,7 +336,7 @@ Addresses #99
 
 ### Closing Issues After Merge
 
-Issues are **not automatically closed** when using `Addresses`. After merging, manually close linked issues:
+By default, issues are **not automatically closed** when using `Addresses`. After merging, `doit pr_merge` prints the `gh issue close` commands so you can close linked issues manually:
 
 ```bash
 # The task displays these commands after merge
@@ -342,6 +345,17 @@ gh issue close 100 --comment "Addressed in PR #103"
 ```
 
 This ensures issues are explicitly closed with a reference to the PR that addressed them.
+
+#### Auto-closing linked issues
+
+Pass `--auto-close` to have `doit pr_merge` run the `gh issue close` commands itself after a successful merge:
+
+```bash
+doit pr_merge --auto-close
+doit pr_merge --pr=123 --auto-close
+```
+
+Each linked issue is closed with the comment `Addressed in PR #XX`, matching the format used in the manual reminder.
 
 ### Why Use `doit pr_merge`?
 

--- a/tests/test_doit_github.py
+++ b/tests/test_doit_github.py
@@ -1,6 +1,15 @@
 """Tests for github.py doit tasks."""
 
-from tools.doit.github import _extract_linked_issues, _format_merge_subject
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+
+from tools.doit.github import (
+    _close_linked_issues,
+    _extract_linked_issues,
+    _format_merge_subject,
+)
 
 
 class TestExtractLinkedIssues:
@@ -95,3 +104,76 @@ class TestFormatMergeSubject:
         title = "refactor: simplify complex logic"
         result = _format_merge_subject(title, 99, ["55"])
         assert result.startswith(title)
+
+
+class TestCloseLinkedIssues:
+    """Tests for _close_linked_issues helper."""
+
+    def test_closes_single_linked_issue(self) -> None:
+        """Single issue results in one gh issue close invocation."""
+        console = Console()
+        with patch("tools.doit.github.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _close_linked_issues(["123"], 45, console)
+
+        assert mock_run.call_count == 1
+        args, kwargs = mock_run.call_args
+        assert args[0] == [
+            "gh",
+            "issue",
+            "close",
+            "123",
+            "--comment",
+            "Addressed in PR #45",
+        ]
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+
+    def test_closes_multiple_linked_issues(self) -> None:
+        """Multiple issues result in multiple calls in order."""
+        console = Console()
+        with patch("tools.doit.github.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _close_linked_issues(["10", "20", "30"], 7, console)
+
+        assert mock_run.call_count == 3
+        called_issues = [call.args[0][3] for call in mock_run.call_args_list]
+        assert called_issues == ["10", "20", "30"]
+
+    def test_no_issues_is_noop(self) -> None:
+        """Empty issue list results in no subprocess calls."""
+        console = Console()
+        with patch("tools.doit.github.subprocess.run") as mock_run:
+            _close_linked_issues([], 99, console)
+
+        mock_run.assert_not_called()
+
+    def test_partial_failure_continues(self) -> None:
+        """A failure on one issue does not stop subsequent closes."""
+        console = Console()
+
+        def side_effect(cmd: list[str], *_args: object, **_kwargs: object) -> MagicMock:
+            issue = cmd[3]
+            if issue == "20":
+                raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr="boom")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("tools.doit.github.subprocess.run", side_effect=side_effect) as mock_run:
+            # Should not raise.
+            _close_linked_issues(["10", "20", "30"], 7, console)
+
+        assert mock_run.call_count == 3
+        called_issues = [call.args[0][3] for call in mock_run.call_args_list]
+        assert called_issues == ["10", "20", "30"]
+
+    def test_close_comment_format(self) -> None:
+        """The close comment must be exactly 'Addressed in PR #<n>'."""
+        console = Console()
+        with patch("tools.doit.github.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _close_linked_issues(["5"], 123, console)
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[4] == "--comment"
+        assert cmd[5] == "Addressed in PR #123"

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -529,6 +529,37 @@ def _format_merge_subject(title: str, pr_number: int, issues: list[str]) -> str:
     return f"{title} {suffix}"
 
 
+def _close_linked_issues(issues: list[str], pr_number: int, console: Console) -> None:
+    """Close each linked issue via `gh issue close` with a standard comment.
+
+    On per-issue failure, prints a yellow warning and continues. Does not
+    raise — the merge has already succeeded, partial failure is reported
+    but not fatal.
+
+    Args:
+        issues: List of issue numbers to close.
+        pr_number: PR number used in the close comment.
+        console: Rich console for output.
+    """
+    if not issues:
+        console.print("[dim]No linked issues to close.[/dim]")
+        return
+
+    comment = f"Addressed in PR #{pr_number}"
+    for issue in issues:
+        try:
+            subprocess.run(
+                ["gh", "issue", "close", issue, "--comment", comment],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            console.print(f"[green]Closed issue #{issue}[/green]")
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or "").strip()
+            console.print(f"[yellow]Failed to close #{issue}: {stderr}[/yellow]")
+
+
 def task_pr_merge() -> dict[str, Any]:
     """Merge a PR with properly formatted commit message.
 
@@ -542,11 +573,13 @@ def task_pr_merge() -> dict[str, Any]:
         doit pr_merge                    # Merge PR for current branch
         doit pr_merge --pr=123           # Merge specific PR
         doit pr_merge --delete-branch    # Also delete the branch after merge
+        doit pr_merge --pr=123 --auto-close  # Close linked issues after merge
     """
 
     def merge_pr(
         pr: str | None = None,
         delete_branch: bool = True,
+        auto_close: bool = False,
     ) -> None:
         console = Console()
         console.print()
@@ -616,17 +649,21 @@ def task_pr_merge() -> dict[str, Any]:
                 )
             )
 
-            # Reminder to update linked issues
-            console.print()
-            console.print(
-                Panel.fit(
-                    "[bold yellow]Reminder: Update linked issues[/bold yellow]\n\n"
-                    "Examples:\n"
-                    f'  gh issue close <number> --comment "Addressed in PR #{pr_number}"\n'
-                    f'  gh issue comment <number> --body "Addressed in PR #{pr_number}"',
-                    border_style="yellow",
+            if auto_close:
+                console.print()
+                _close_linked_issues(issues, pr_number, console)
+            else:
+                # Reminder to update linked issues
+                console.print()
+                console.print(
+                    Panel.fit(
+                        "[bold yellow]Reminder: Update linked issues[/bold yellow]\n\n"
+                        "Examples:\n"
+                        f'  gh issue close <number> --comment "Addressed in PR #{pr_number}"\n'
+                        f'  gh issue comment <number> --body "Addressed in PR #{pr_number}"',
+                        border_style="yellow",
+                    )
                 )
-            )
         except subprocess.CalledProcessError as e:
             console.print("[red]Failed to merge PR.[/red]")
             if e.stderr:
@@ -648,6 +685,13 @@ def task_pr_merge() -> dict[str, Any]:
                 "type": bool,
                 "default": True,
                 "help": "Delete branch after merge (default: True)",
+            },
+            {
+                "name": "auto_close",
+                "long": "auto-close",
+                "type": bool,
+                "default": False,
+                "help": "Close linked issues after merge with a standard comment",
             },
         ],
         "title": title_with_actions,


### PR DESCRIPTION
## Description

Adds an opt-in `--auto-close` flag to `doit pr_merge`. When set, the task closes each linked issue (parsed from `Addresses #XX` in the PR body) via `gh issue close` with a standard `Addressed in PR #XX` comment after a successful merge. Default behavior is unchanged: the task still prints the `gh issue close` reminder commands when `--auto-close` is not passed, preserving the explicit human-in-the-loop step.

## Related Issue

Addresses #380

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `tools/doit/github.py`: added `_close_linked_issues` helper and a new `--auto-close` boolean parameter on `task_pr_merge`. When `auto_close=True` and linked issues are present, the helper runs `gh issue close <n> --comment "Addressed in PR #<pr>"` for each and reports per-issue success/failure without aborting on partial failure.
- `tests/test_doit_github.py`: added `TestCloseLinkedIssues` (5 tests) covering: closing multiple issues, empty issue list, `gh` failure on one issue not aborting the rest, comment text format, and `CalledProcessError` handling.
- `AGENTS.md`: added `--auto-close` example to the PR Merge block and updated the `**PRs:**` Critical Reminder to document the new flag.
- `docs/development/doit-tasks-reference.md`: documented the new flag and `--delete-branch` under the `pr_merge` options list.
- `docs/development/release-and-automation.md`: added the `--auto-close` example to Basic Usage and a new "Auto-closing linked issues" subsection under "Closing Issues After Merge".

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes locally (format, lint, type-check, security, spell, tests).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- Default behavior is preserved: without `--auto-close`, the task still only prints reminder commands. Opt-in keeps the existing "explicit close" convention described in `docs/development/release-and-automation.md` as the default.
- No ADR is required: no `needs-adr` label on #380, and no existing ADR documents the auto-close policy. ADRs 9008 and 9010 mention `pr_merge` only as historical issue references.
- CHANGELOG is intentionally not updated, per project convention (version/changelog are managed by the release workflow).
