### PR TITLE
feat: auto-merge dependabot PRs once required CI checks pass

### DIFF
--- a/.github/automerge-config.json
+++ b/.github/automerge-config.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Auto-merge configuration for dependabot PRs. See docs/development/dependabot-automerge.md.",
+  "sensitive_dependencies": [
+    "crypt*",
+    "*ssl*",
+    "*security*",
+    "auth*",
+    "*jwt*",
+    "*oauth*"
+  ],
+  "allowed_update_types": [
+    "version-update:semver-patch",
+    "version-update:semver-minor"
+  ],
+  "blocking_labels": [
+    "do-not-merge",
+    "automerge-blocked"
+  ]
+}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,306 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  evaluate:
+    name: Evaluate dependabot PR
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.action != 'labeled'
+    outputs:
+      qualifies: ${{ steps.decide.outputs.qualifies }}
+      reason: ${{ steps.decide.outputs.reason }}
+      pr_number: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide eligibility
+        id: decide
+        uses: actions/github-script@v9
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '.github/automerge-config.json';
+            const config = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+            const updateType = process.env.UPDATE_TYPE || '';
+            const depNames = (process.env.DEPENDENCY_NAMES || '')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+            const prLabels = (context.payload.pull_request.labels || [])
+              .map(l => l.name);
+
+            // Glob to regex: '*' -> '.*', anchored.
+            const globToRegex = (glob) => {
+              const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+              return new RegExp('^' + escaped.replace(/\*/g, '.*') + '$', 'i');
+            };
+
+            const sensitiveRegexes = (config.sensitive_dependencies || [])
+              .map(globToRegex);
+
+            let qualifies = true;
+            let reason = 'eligible for auto-merge';
+
+            // Check update type.
+            if (updateType === 'version-update:semver-major') {
+              qualifies = false;
+              reason = 'major version bump';
+            }
+
+            // Check sensitive dependencies.
+            if (qualifies) {
+              for (const dep of depNames) {
+                const match = sensitiveRegexes.find(re => re.test(dep));
+                if (match) {
+                  qualifies = false;
+                  reason = `sensitive dependency: ${dep}`;
+                  break;
+                }
+              }
+            }
+
+            // Check blocking labels.
+            if (qualifies) {
+              const blocking = config.blocking_labels || [];
+              const hit = prLabels.find(l => blocking.includes(l));
+              if (hit) {
+                qualifies = false;
+                reason = `blocking label present: ${hit}`;
+              }
+            }
+
+            // Optionally enforce allowed update types (defense in depth).
+            if (qualifies) {
+              const allowed = config.allowed_update_types || [];
+              if (allowed.length && updateType && !allowed.includes(updateType)) {
+                qualifies = false;
+                reason = `update type not in allowlist: ${updateType}`;
+              }
+            }
+
+            core.setOutput('qualifies', String(qualifies));
+            core.setOutput('reason', reason);
+            core.info(`update-type=${updateType} deps=${depNames.join(',')} qualifies=${qualifies} reason=${reason}`);
+
+  enable-automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    needs: evaluate
+    if: needs.evaluate.outputs.qualifies == 'true'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+
+      - name: Add ready-to-merge label
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label ready-to-merge
+
+      - name: Post sticky status comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              '\n✅ **Auto-merge enabled.** This PR will merge automatically when required CI checks pass. To block, add label `automerge-blocked`.';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  comment-skip:
+    name: Comment skip reason
+    runs-on: ubuntu-latest
+    needs: evaluate
+    if: needs.evaluate.outputs.qualifies == 'false'
+    steps:
+      - name: Post sticky skip comment
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          REASON: ${{ needs.evaluate.outputs.reason }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const reason = process.env.REASON || 'unknown';
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n⏸️ **Auto-merge skipped:** ${reason}. Human review required.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  handle-blocked-label:
+    name: Handle blocking label
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      (github.event.label.name == 'automerge-blocked' || github.event.label.name == 'do-not-merge')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      LABEL_NAME: ${{ github.event.label.name }}
+    steps:
+      - name: Disable auto-merge
+        run: gh pr merge --disable-auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" || true
+
+      - name: Remove ready-to-merge label
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label ready-to-merge || true
+
+      - name: Post sticky blocked comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const label = process.env.LABEL_NAME;
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n🛑 **Auto-merge disabled** by \`${label}\` label.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+  request-rebase:
+    name: Request dependabot rebase for stale PRs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Find stale dependabot PRs and request rebase
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const oneHourAgo = Date.now() - 60 * 60 * 1000;
+
+            for (const pr of prs) {
+              if (!pr.user || pr.user.login !== 'dependabot[bot]') continue;
+
+              const labels = (pr.labels || []).map(l => l.name);
+              if (!labels.includes('ready-to-merge')) continue;
+
+              // Fetch fresh PR to get mergeable_state.
+              const { data: fresh } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              if (fresh.mergeable_state !== 'behind') continue;
+
+              // Skip if @dependabot rebase was requested in the last hour.
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const recentRebase = comments.some(c =>
+                c.body && c.body.includes('@dependabot rebase') &&
+                new Date(c.created_at).getTime() > oneHourAgo
+              );
+              if (recentRebase) {
+                core.info(`PR #${pr.number}: recent rebase request; skipping`);
+                continue;
+              }
+
+              core.info(`PR #${pr.number}: requesting @dependabot rebase`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '@dependabot rebase',
+              });
+            }

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -76,6 +76,11 @@ jobs:
               return;
             }
 
+            if (pr.user.login === 'dependabot[bot]') {
+              console.log('✅ Dependabot PR - issue link not required');
+              return;
+            }
+
             // Check for issue reference in PR body or title
             const issuePatterns = [
               /addresses\s+#\d+/i,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,8 @@ gh pr list --state open
 
 ### Dependabot PRs
 
+Dependabot PRs that pass CI are now auto-merged by `.github/workflows/dependabot-automerge.yml`. The manual workflow below applies only to PRs the bot skips (major bumps, sensitive deps, or PRs labeled `automerge-blocked`). See [docs/development/dependabot-automerge.md](docs/development/dependabot-automerge.md) for details.
+
 When merging dependabot PRs that are behind `main`, **never** use the GitHub API `update-branch` endpoint or local rebase to update the branch. This strips the verified commit signatures from dependabot commits, which are required by branch protection rules.
 
 Instead, use dependabot's own rebase command:
@@ -324,7 +326,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **Commits:** One logical change per commit. Use conventional commits.
 - **Releases:** Never run `doit release` without explicit command.
 - **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed — pass `--auto-close` to `doit pr_merge` to close linked issues in one step.
-- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation.
+- **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation. Exception: the dependabot auto-merge workflow (`.github/workflows/dependabot-automerge.yml`) applies the `ready-to-merge` label to qualifying dependabot PRs only.
 - **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -40,6 +40,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
+- [Dependabot Auto-merge](development/dependabot-automerge.md) - How the dependabot auto-merge workflow evaluates, enables, and skips PRs
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
@@ -98,6 +99,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
+- [Dependabot Auto-merge](development/dependabot-automerge.md) - How the dependabot auto-merge workflow evaluates, enables, and skips PRs
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments
 - [Doit Tasks Reference](development/doit-tasks-reference.md) - Complete reference for all doit automation tasks
 - [Examples](examples/README.md) - Example scripts demonstrating how to use the package

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -1,0 +1,92 @@
+---
+title: Dependabot Auto-merge
+description: How the dependabot auto-merge workflow evaluates, enables, and skips PRs
+audience:
+  - contributors
+  - maintainers
+tags:
+  - dependabot
+  - automation
+  - ci
+---
+
+# Dependabot Auto-merge
+
+The workflow at `.github/workflows/dependabot-automerge.yml` evaluates each
+dependabot PR and enables GitHub's native auto-merge for PRs that meet the
+project's safety criteria. Qualifying PRs are merged automatically once the
+required CI checks pass.
+
+## What gets auto-merged
+
+A dependabot PR qualifies when **all** of the following are true:
+
+- The update type is `version-update:semver-patch` or `version-update:semver-minor`.
+- None of the updated dependency names match a glob in the
+  `sensitive_dependencies` list.
+- The PR has no label listed in `blocking_labels`.
+
+Qualifying PRs receive:
+
+- GitHub's native auto-merge enabled with the **squash** strategy.
+- The `ready-to-merge` label applied automatically (satisfying the Merge Gate).
+- A sticky status comment confirming auto-merge is enabled.
+
+## What gets skipped
+
+A PR is skipped (no auto-merge, sticky comment posted for human review) when:
+
+- The update is a **major version bump** (`version-update:semver-major`).
+- A **sensitive dependency** is touched (e.g. anything matching `*ssl*`,
+  `*security*`, `auth*`, `crypt*`, `*jwt*`, `*oauth*`).
+- A **blocking label** (`do-not-merge` or `automerge-blocked`) is present.
+
+Skipped PRs require a human reviewer to merge them using the normal workflow.
+
+## The `automerge-blocked` opt-out
+
+To stop auto-merge on a PR that already qualified, add the label
+`automerge-blocked` (or `do-not-merge`). The workflow reacts to the `labeled`
+event:
+
+- Disables GitHub's auto-merge on the PR.
+- Removes the `ready-to-merge` label.
+- Posts a sticky comment recording the block.
+
+## Configuration
+
+Lists live in `.github/automerge-config.json`:
+
+```json
+{
+  "sensitive_dependencies": ["crypt*", "*ssl*", "*security*", "auth*", "*jwt*", "*oauth*"],
+  "allowed_update_types": ["version-update:semver-patch", "version-update:semver-minor"],
+  "blocking_labels": ["do-not-merge", "automerge-blocked"]
+}
+```
+
+Globs use `*` as a wildcard and are matched case-insensitively against the full
+dependency name. Edit the file via a normal PR to change policy.
+
+## Rebase handling for stale PRs
+
+The workflow includes a scheduled job (every 6 hours, plus `workflow_dispatch`)
+that finds qualifying dependabot PRs whose branches have fallen behind `main`
+and asks dependabot to rebase:
+
+```
+@dependabot rebase
+```
+
+This follows the signed-commit rule documented in the
+[Dependabot PRs](../../AGENTS.md#dependabot-prs) section of `AGENTS.md`:
+**never** call the GitHub `update-branch` API or rebase locally, because both
+strip dependabot's verified commit signatures. The job also skips any PR that
+already received a `@dependabot rebase` comment within the last hour, so it
+does not spam the bot while a rebase is in progress.
+
+## Related
+
+- `AGENTS.md` section [Dependabot PRs](../../AGENTS.md#dependabot-prs)
+- `.github/workflows/dependabot-automerge.yml`
+- `.github/automerge-config.json`

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -96,7 +96,7 @@ All labels are replicated from the template by `replicate_labels()`.
 | `needs-adr` | `#d4c5f9` | This issue requires an Architecture Decision Record | PR merge gate |
 | `needs-triage` | `#FBCA04` | Needs review and prioritization | All issue templates |
 | `question` | `#d876e3` | Further information is requested | Manual triage |
-| `ready-to-merge` | `#0E8A16` | PR is reviewed and ready to merge | Merge Gate workflow |
+| `ready-to-merge` | `#0E8A16` | PR is reviewed and ready to merge. Exception: the `dependabot-automerge` workflow applies this label automatically to qualifying dependabot PRs. | Merge Gate workflow |
 | `refactor` | `#F9D0C4` | Code refactoring and cleanup | Issue template |
 | `security` | `#d73a4a` | Security vulnerability or fix | Manual triage |
 | `wontfix` | `#ffffff` | This will not be worked on | Manual triage |


### PR DESCRIPTION
## Description

Adds automated merging for dependabot PRs once required CI checks pass. A new workflow (`.github/workflows/dependabot-automerge.yml`) evaluates each dependabot PR against a JSON config, enables GitHub's native auto-merge (squash) for qualifying PRs, applies the `ready-to-merge` label, and posts a sticky status comment explaining the decision. Major bumps, sensitive dependencies (crypto/auth/ssl/jwt/oauth), and PRs carrying blocking labels (`do-not-merge`, `automerge-blocked`) are skipped with a human-review comment. A scheduled job nudges stale qualifying PRs via `@dependabot rebase` (preserving verified signatures). The PR-checks workflow is updated to skip the "issue link required" rule for dependabot PRs.

## Related Issue

Addresses #382

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- Add `.github/workflows/dependabot-automerge.yml` with four jobs: `evaluate`, `enable-automerge`, `comment-skip`, `handle-blocked-label`, and `request-rebase` (scheduled).
- Add `.github/automerge-config.json` declaring sensitive-dependency globs, allowed update types (patch/minor), and blocking labels.
- Update `.github/workflows/pr-checks.yml` to exempt dependabot PRs from the issue-link requirement.
- Document the automation in new `docs/development/dependabot-automerge.md`.
- Update `AGENTS.md` to note that qualifying dependabot PRs are now auto-merged, with the existing manual rebase procedure reserved for skipped PRs. Add an exception note for the Merge Gate rule: the dependabot workflow is the sole automation allowed to apply `ready-to-merge`.
- Update `docs/development/github-repository-settings.md` label table to reflect that exception for the `ready-to-merge` label.

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type-check, security, spellcheck, pytest)
- [ ] Added new tests for new functionality (not applicable — GitHub Actions workflow; exercises only on real dependabot PRs in GitHub)
- [ ] Manually tested the changes (see note below)

**Real-PR validation required.** The workflow uses `pull_request_target` and `dependabot/fetch-metadata`, which cannot be exercised locally or in this PR. End-to-end validation must happen against the next dependabot PR after merge: confirm the evaluate job decides correctly, auto-merge is enabled (or the skip comment appears), the `ready-to-merge` label is applied for qualifying PRs, and merge proceeds once required checks go green.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (workflow-only change; not unit-testable)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (N/A — release automation manages CHANGELOG)
- [x] My changes generate no new warnings

## Additional Notes

- **Follow-up:** The `automerge-blocked` label is referenced by the config and documented as the human-escape-hatch, but is not yet present in the repo's label set (it is not in `docs/development/github-repository-settings.md`'s label table or replicated by `replicate_labels()`). After this merges, add `automerge-blocked` to the repo labels so the blocking-label path is usable.
- No `needs-adr` label on #382, and no existing ADR covers dependabot or merge automation, so no ADR was created or updated.
- Secrets: the workflow uses only `GITHUB_TOKEN`; no new secrets required. Permissions are scoped to `pull-requests: write` and `contents: write` (required to enable auto-merge).
