### PR TITLE
feat: have doit pr check branch is up to date with origin/main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **No Speculation:** Don't read files you don't need.
 
 ## Critical Reminders
-- **Flow:** Issue (`doit issue`) -> **`git checkout main && git pull`** -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main. Always pull `main` before branching — local `main` may be behind the remote (e.g., after dependabot PRs merged via the web UI).
+- **Flow:** Issue (`doit issue`) -> **`git checkout main && git pull`** -> Branch -> Commit -> PR (`doit pr`) -> Merge (`doit pr_merge`). NEVER commit to main. Pull `main` before branching — local `main` may be behind the remote (e.g., after dependabot PRs merged via the web UI). `doit pr` enforces this by aborting if the branch is behind `origin/main`; pass `--no-update-check` to override.
 - **Scope:** Never mix refactoring, features, and docs in one PR. Create separate branches.
 - **Verify:** Check file paths (`ls`) and branch (`git status`) before assuming they exist.
 - **Security:** NEVER bypass security checks (e.g., `--no-verify`, ignoring secrets).

--- a/tests/test_doit_github.py
+++ b/tests/test_doit_github.py
@@ -1,11 +1,14 @@
 """Tests for github.py doit tasks."""
 
+import io
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
 from rich.console import Console
 
 from tools.doit.github import (
+    _check_branch_up_to_date,
     _close_linked_issues,
     _extract_linked_issues,
     _format_merge_subject,
@@ -177,3 +180,96 @@ class TestCloseLinkedIssues:
         cmd = mock_run.call_args.args[0]
         assert cmd[4] == "--comment"
         assert cmd[5] == "Addressed in PR #123"
+
+
+class TestCheckBranchUpToDate:
+    """Tests for _check_branch_up_to_date helper."""
+
+    @staticmethod
+    def _make_console() -> Console:
+        return Console(file=io.StringIO(), width=200)
+
+    def test_up_to_date_branch_passes(self) -> None:
+        """rev-list --count == 0 → helper returns cleanly."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "fetch"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if cmd[:3] == ["git", "rev-list", "--count"]:
+                return MagicMock(returncode=0, stdout="0\n", stderr="")
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with patch("tools.doit.github.subprocess.run", side_effect=side_effect):
+            _check_branch_up_to_date("feat/x", console)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "up to date" in output.lower()
+
+    def test_behind_branch_aborts(self) -> None:
+        """rev-list --count > 0 → SystemExit(1) with remediation message."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "fetch"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if cmd[:3] == ["git", "rev-list", "--count"]:
+                return MagicMock(returncode=0, stdout="3\n", stderr="")
+            if cmd[:2] == ["git", "log"]:
+                return MagicMock(returncode=0, stdout="abc1 one\n", stderr="")
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with (
+            patch("tools.doit.github.subprocess.run", side_effect=side_effect),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _check_branch_up_to_date("feat/x", console)
+
+        assert excinfo.value.code == 1
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "3 commit" in output
+        assert "git rebase origin/main" in output
+        assert "feat/x" in output
+
+    def test_fetch_failure_warns_and_proceeds(self) -> None:
+        """git fetch failure → warning printed, helper returns."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "fetch"]:
+                raise subprocess.CalledProcessError(
+                    returncode=128, cmd=cmd, stderr="could not resolve host"
+                )
+            raise AssertionError(f"unexpected cmd after fetch failed: {cmd}")
+
+        with patch("tools.doit.github.subprocess.run", side_effect=side_effect):
+            _check_branch_up_to_date("feat/x", console)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "warning" in output.lower()
+        assert "could not resolve host" in output
+
+    def test_behind_branch_lists_missing_commits(self) -> None:
+        """Missing commit SHAs from `git log` appear in the output."""
+        console = self._make_console()
+
+        log_out = "abc1234 feat: one\ndef5678 fix: two\n"
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "fetch"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if cmd[:3] == ["git", "rev-list", "--count"]:
+                return MagicMock(returncode=0, stdout="2\n", stderr="")
+            if cmd[:2] == ["git", "log"]:
+                return MagicMock(returncode=0, stdout=log_out, stderr="")
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with (
+            patch("tools.doit.github.subprocess.run", side_effect=side_effect),
+            pytest.raises(SystemExit),
+        ):
+            _check_branch_up_to_date("feat/x", console)
+
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "abc1234" in output
+        assert "def5678" in output

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -322,10 +322,15 @@ def task_pr() -> dict[str, Any]:
     2. --body-file: Reads body from a file
     3. --title + --body: Provides content directly (for AI/scripts)
 
+    Before creating the PR, the task verifies that the current branch is up
+    to date with ``origin/main`` and aborts with a remediation message if
+    it is behind. Pass ``--no-update-check`` to skip this guard.
+
     Examples:
         Interactive:  doit pr
         From file:    doit pr --title="feat: add export" --body-file=pr.md
         Direct:       doit pr --title="feat: add export" --body="## Description\\n..."
+        Skip check:   doit pr --no-update-check
     """
 
     def create_pr(
@@ -333,6 +338,7 @@ def task_pr() -> dict[str, Any]:
         body: str | None = None,
         body_file: str | None = None,
         draft: bool = False,
+        no_update_check: bool = False,
     ) -> None:
         console = Console()
         console.print()
@@ -355,6 +361,11 @@ def task_pr() -> dict[str, Any]:
             sys.exit(1)
 
         console.print(f"[dim]Current branch: {current_branch}[/dim]")
+
+        if no_update_check:
+            console.print("[dim]Skipping up-to-date check (--no-update-check).[/dim]")
+        else:
+            _check_branch_up_to_date(current_branch, console)
 
         # Try to extract issue number from branch name (e.g., feat/42-description)
         detected_issue = None
@@ -448,6 +459,13 @@ def task_pr() -> dict[str, Any]:
                 "type": bool,
                 "default": False,
                 "help": "Create as draft PR",
+            },
+            {
+                "name": "no_update_check",
+                "long": "no-update-check",
+                "type": bool,
+                "default": False,
+                "help": "Skip check that branch is up to date with origin/main",
             },
         ],
         "title": title_with_actions,
@@ -558,6 +576,66 @@ def _close_linked_issues(issues: list[str], pr_number: int, console: Console) ->
         except subprocess.CalledProcessError as e:
             stderr = (e.stderr or "").strip()
             console.print(f"[yellow]Failed to close #{issue}: {stderr}[/yellow]")
+
+
+def _check_branch_up_to_date(current_branch: str, console: Console) -> None:
+    """Abort PR creation if the current branch is behind ``origin/main``.
+
+    Fetches ``origin/main`` and compares it to ``HEAD``. If the branch is
+    behind, prints the count, the missing commits, and the rebase command
+    to run, then calls ``sys.exit(1)``. If the fetch itself fails (network
+    down, unreachable remote), prints a warning and returns — a flaky
+    network should not block PR creation.
+
+    Args:
+        current_branch: Name of the feature branch (used in remediation message).
+        console: Rich console for output.
+    """
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print(f"[yellow]Warning: `git fetch origin main` failed: {stderr}[/yellow]")
+        console.print("[yellow]Skipping up-to-date check; proceeding.[/yellow]")
+        return
+
+    count_result = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD..origin/main"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    behind = int(count_result.stdout.strip() or "0")
+
+    if behind == 0:
+        console.print("[green]Branch is up to date with origin/main.[/green]")
+        return
+
+    log_result = subprocess.run(
+        ["git", "log", "--oneline", "-n", "10", "HEAD..origin/main"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    console.print()
+    console.print(f"[red]Branch is {behind} commit(s) behind origin/main.[/red]")
+    console.print("[dim]Missing commits:[/dim]")
+    for line in log_result.stdout.strip().splitlines():
+        console.print(f"  {line}")
+    console.print()
+    console.print("[yellow]Rebase and force-push, then re-run `doit pr`:[/yellow]")
+    console.print(
+        f"  git rebase origin/main && git push --force-with-lease origin {current_branch}"
+    )
+    console.print()
+    console.print("[dim]Use `doit pr --no-update-check` to skip this check.[/dim]")
+    sys.exit(1)
 
 
 def task_pr_merge() -> dict[str, Any]:


### PR DESCRIPTION
## Description

`doit pr` now verifies the current branch is up to date with `origin/main` before opening a PR. If the branch is behind, it aborts with the commit count, a list of missing commits, and the exact rebase command to run. Pass `--no-update-check` to skip the guard. Network failures during `git fetch` print a warning and proceed.

Motivation: PR #379 shipped from a local `main` that was 10 commits behind the remote, requiring a post-hoc rebase and force-push. `AGENTS.md` already named the rule ("pull `main` before branching"); this change moves enforcement from discipline to tooling.

## Related Issue

Addresses #383

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `_check_branch_up_to_date()` helper in `tools/doit/github.py`.
- Wire the check into `create_pr` after the "not on main" guard; add `no_update_check: bool = False` param and `--no-update-check` CLI flag.
- Update the `create_pr` docstring so `doit help pr` documents the check and the opt-out.
- Soften the AGENTS.md Critical Reminders `**Flow:**` line: the manual `git pull` guidance now notes that `doit pr` enforces it.
- Add `TestCheckBranchUpToDate` (4 tests) covering up-to-date pass, behind-branch abort, fetch-failure warning, and missing-commit listing.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

Test plan:
- Up-to-date branch → helper returns, no exit.
- Behind branch → `SystemExit(1)`, output contains the count, rebase command, and missing commit SHAs.
- `git fetch` failure → warning printed, helper returns (does not block PR creation).

## Checklist

- [x] `doit format`, `doit lint`, `doit type_check`, `doit test`, `doit check` all pass.
- [x] Tests added for new behavior.
- [x] AGENTS.md updated to reflect the tooling-enforced rule.
- [x] No breaking changes; opt-out preserves prior behavior.

## Additional Notes

Out of scope (per issue): auto-rebase, checking against branches other than `main`, applying the same check to `doit pr_merge`. No ADR required (no `needs-adr` label; this is a defensive guardrail, not an architectural pattern).
