### PR TITLE
feat: have doit pr auto-push branch if needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,8 @@ doit pr --title="feat: add caching" --body="## Summary\nAdded caching support\n\
 doit pr --title="fix: handle null" --body-file=pr.md
 ```
 
+`doit pr` auto-pushes the current branch to `origin` if it has no upstream. Pass `--no-push` to skip the auto-push (the task aborts instead).
+
 ### PR Merge
 ```bash
 doit pr_merge                        # Merge PR for current branch

--- a/tests/test_doit_github.py
+++ b/tests/test_doit_github.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from tools.doit.github import (
     _check_branch_up_to_date,
     _close_linked_issues,
+    _ensure_branch_pushed,
     _extract_linked_issues,
     _format_merge_subject,
 )
@@ -273,3 +274,104 @@ class TestCheckBranchUpToDate:
         output = console.file.getvalue()  # type: ignore[attr-defined]
         assert "abc1234" in output
         assert "def5678" in output
+
+
+class TestEnsureBranchPushed:
+    """Tests for _ensure_branch_pushed helper."""
+
+    @staticmethod
+    def _make_console() -> Console:
+        return Console(file=io.StringIO(), width=200)
+
+    def test_existing_upstream_is_noop(self) -> None:
+        """rev-parse @{u} succeeds → no push, helper returns."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "rev-parse"]:
+                return MagicMock(returncode=0, stdout="origin/feat/x\n", stderr="")
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with patch("tools.doit.github.subprocess.run", side_effect=side_effect) as run:
+            _ensure_branch_pushed("feat/x", console, no_push=False)
+
+        assert run.call_count == 1
+
+    def test_no_upstream_pushes(self) -> None:
+        """rev-parse @{u} fails → git push -u origin is called."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "rev-parse"]:
+                raise subprocess.CalledProcessError(
+                    returncode=128, cmd=cmd, stderr="no upstream configured"
+                )
+            if cmd[:3] == ["git", "push", "-u"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with patch("tools.doit.github.subprocess.run", side_effect=side_effect) as run:
+            _ensure_branch_pushed("feat/x", console, no_push=False)
+
+        assert run.call_count == 2
+        push_cmd = run.call_args_list[1].args[0]
+        assert push_cmd == ["git", "push", "-u", "origin", "feat/x"]
+
+    def test_push_failure_aborts(self) -> None:
+        """rev-parse @{u} fails and git push fails → SystemExit(1)."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "rev-parse"]:
+                raise subprocess.CalledProcessError(returncode=128, cmd=cmd, stderr="no upstream")
+            if cmd[:3] == ["git", "push", "-u"]:
+                raise subprocess.CalledProcessError(
+                    returncode=1, cmd=cmd, stderr="remote rejected: protected branch"
+                )
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with (
+            patch("tools.doit.github.subprocess.run", side_effect=side_effect),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _ensure_branch_pushed("feat/x", console, no_push=False)
+
+        assert excinfo.value.code == 1
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "Failed to push" in output
+        assert "remote rejected" in output
+
+    def test_no_push_flag_and_no_upstream_aborts(self) -> None:
+        """no_push=True with missing upstream → SystemExit(1), no push."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "rev-parse"]:
+                raise subprocess.CalledProcessError(returncode=128, cmd=cmd, stderr="no upstream")
+            raise AssertionError(f"unexpected cmd: {cmd} (push should not run)")
+
+        with (
+            patch("tools.doit.github.subprocess.run", side_effect=side_effect) as run,
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _ensure_branch_pushed("feat/x", console, no_push=True)
+
+        assert excinfo.value.code == 1
+        assert run.call_count == 1
+        output = console.file.getvalue()  # type: ignore[attr-defined]
+        assert "no upstream" in output.lower()
+        assert "--no-push" in output
+
+    def test_no_push_flag_with_upstream_passes(self) -> None:
+        """no_push=True with an upstream → returns, no push."""
+        console = self._make_console()
+
+        def side_effect(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            if cmd[:2] == ["git", "rev-parse"]:
+                return MagicMock(returncode=0, stdout="origin/feat/x\n", stderr="")
+            raise AssertionError(f"unexpected cmd: {cmd}")
+
+        with patch("tools.doit.github.subprocess.run", side_effect=side_effect) as run:
+            _ensure_branch_pushed("feat/x", console, no_push=True)
+
+        assert run.call_count == 1

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -326,11 +326,16 @@ def task_pr() -> dict[str, Any]:
     to date with ``origin/main`` and aborts with a remediation message if
     it is behind. Pass ``--no-update-check`` to skip this guard.
 
+    If the current branch has no upstream, the task pushes it to ``origin``
+    automatically before calling ``gh pr create``. Pass ``--no-push`` to
+    skip the auto-push (the task will then abort if no upstream exists).
+
     Examples:
         Interactive:  doit pr
         From file:    doit pr --title="feat: add export" --body-file=pr.md
         Direct:       doit pr --title="feat: add export" --body="## Description\\n..."
         Skip check:   doit pr --no-update-check
+        No auto-push: doit pr --no-push
     """
 
     def create_pr(
@@ -339,6 +344,7 @@ def task_pr() -> dict[str, Any]:
         body_file: str | None = None,
         draft: bool = False,
         no_update_check: bool = False,
+        no_push: bool = False,
     ) -> None:
         console = Console()
         console.print()
@@ -366,6 +372,8 @@ def task_pr() -> dict[str, Any]:
             console.print("[dim]Skipping up-to-date check (--no-update-check).[/dim]")
         else:
             _check_branch_up_to_date(current_branch, console)
+
+        _ensure_branch_pushed(current_branch, console, no_push)
 
         # Try to extract issue number from branch name (e.g., feat/42-description)
         detected_issue = None
@@ -466,6 +474,13 @@ def task_pr() -> dict[str, Any]:
                 "type": bool,
                 "default": False,
                 "help": "Skip check that branch is up to date with origin/main",
+            },
+            {
+                "name": "no_push",
+                "long": "no-push",
+                "type": bool,
+                "default": False,
+                "help": "Do not auto-push a branch with no upstream (aborts instead)",
             },
         ],
         "title": title_with_actions,
@@ -636,6 +651,56 @@ def _check_branch_up_to_date(current_branch: str, console: Console) -> None:
     console.print()
     console.print("[dim]Use `doit pr --no-update-check` to skip this check.[/dim]")
     sys.exit(1)
+
+
+def _ensure_branch_pushed(current_branch: str, console: Console, no_push: bool) -> None:
+    """Ensure the current branch has an upstream on ``origin``.
+
+    If the branch already has an upstream, returns silently. Otherwise,
+    runs ``git push -u origin <branch>`` to create it. On push failure,
+    calls ``sys.exit(1)``.
+
+    When ``no_push`` is True and the branch has no upstream, aborts with
+    ``sys.exit(1)`` without attempting to push.
+
+    Args:
+        current_branch: Name of the branch to push.
+        console: Rich console for output.
+        no_push: If True, never push; abort if upstream is missing.
+    """
+    try:
+        subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return
+    except subprocess.CalledProcessError:
+        pass
+
+    if no_push:
+        console.print(
+            f"[red]Branch '{current_branch}' has no upstream and --no-push was passed.[/red]"
+        )
+        console.print(f"[yellow]Push manually: git push -u origin {current_branch}[/yellow]")
+        sys.exit(1)
+
+    console.print(f"[dim]Pushing {current_branch} to origin...[/dim]")
+    try:
+        subprocess.run(
+            ["git", "push", "-u", "origin", current_branch],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print(f"[red]Failed to push {current_branch}:[/red]")
+        console.print(f"[red]{stderr}[/red]")
+        sys.exit(1)
+
+    console.print(f"[dim]Pushed {current_branch} to origin.[/dim]")
 
 
 def task_pr_merge() -> dict[str, Any]:


### PR DESCRIPTION
## Description

`doit pr` now auto-pushes the current branch to `origin` if it has no upstream, fixing the `aborted: you must first push the current branch to a remote` error that surfaced on PR #385 after the up-to-date check from PR #385 passed. The push happens after the up-to-date check and before the editor flow, so any failure (protected branch, auth, network) is surfaced early instead of after the user has drafted a PR body. Pass `--no-push` to keep the original behavior (abort if no upstream).

## Related Issue

Addresses #386

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `_ensure_branch_pushed()` helper in `tools/doit/github.py`. Mirrors the shape of `_check_branch_up_to_date` from PR #385.
- Wire the helper into `create_pr` after the up-to-date check and before body/title handling. Add `no_push: bool = False` param and `--no-push` CLI flag.
- Update `create_pr` docstring — `doit help pr` documents the new flag.
- Add `TestEnsureBranchPushed` (5 tests) covering: existing-upstream noop, no-upstream-pushes, push-failure aborts, `--no-push` + no-upstream aborts, `--no-push` + upstream passes.
- Note the auto-push behavior in `AGENTS.md` "PR Creation" section.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

Test plan (all mocked `subprocess.run`):
- `git rev-parse @{u}` succeeds → no push call, helper returns.
- `git rev-parse @{u}` fails → `git push -u origin <branch>` invoked, helper returns.
- `git push` fails → `SystemExit(1)` with stderr surfaced.
- `no_push=True` + no upstream → `SystemExit(1)` before any push.
- `no_push=True` + upstream → returns silently.

## Checklist

- [x] `doit format`, `doit lint`, `doit type_check`, `doit test`, `doit check` all pass.
- [x] Tests added for new behavior.
- [x] AGENTS.md updated.
- [x] No breaking changes; `--no-push` preserves prior "abort if no upstream" behavior.

## Additional Notes

Out of scope (per issue): pushing to a remote other than `origin`; force-pushing on subsequent `doit pr` invocations. No ADR required (no `needs-adr` label; this is a convenience guardrail, same shape as #383).

Flaky test observation (unrelated): `test_temp_file_cleanup_on_success` in `tests/test_doit_install_tools.py` asserts on global `/tmp` state and can race with other xdist workers. Worth a separate issue but not in this PR.
