### PR TITLE
feat: add plan-mode state hook for sub-agent safety

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,26 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "EnterPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/plan-mode-enter.py"
+          }
+        ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/plan-mode-exit.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ coverage.xml
 .nfs*
 .gemini/settings.json.orig
 tools/hooks/ai/hook-debug.jsonl
+
+# Claude Code local state
+.claude/.plan-mode-state

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -48,6 +48,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Package Name Documentation](index.md) - Welcome and overview of the project
+- [Plan-Mode State Hook](development/ai/plan-mode-hook.md) - PostToolUse hooks that expose Claude Code plan mode as a file
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
@@ -65,6 +66,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [Plan-Mode State Hook](development/ai/plan-mode-hook.md) - PostToolUse hooks that expose Claude Code plan mode as a file
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
 - [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
 <!-- END:audience=ai-agents -->
@@ -112,6 +114,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [New Project Setup](template/new-project.md) - Create a new Python project from this template
 - [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Package Name Documentation](index.md) - Welcome and overview of the project
+- [Plan-Mode State Hook](development/ai/plan-mode-hook.md) - PostToolUse hooks that expose Claude Code plan mode as a file
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling

--- a/docs/development/ai/plan-mode-hook.md
+++ b/docs/development/ai/plan-mode-hook.md
@@ -1,0 +1,92 @@
+---
+title: Plan-Mode State Hook
+description: PostToolUse hooks that expose Claude Code plan mode as a file
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - hooks
+  - plan-mode
+---
+
+# Plan-Mode State Hook
+
+Claude Code enters "plan mode" via the `EnterPlanMode` tool and exits via
+`ExitPlanMode`. The state is not otherwise observable from disk, which
+makes it impossible for slash commands (notably `/implement`) to
+programmatically detect that their parent session is in plan mode before
+they spawn a sub-agent via the Task tool.
+
+This hook pair writes the current plan-mode state to a small file so
+other tooling can check it.
+
+## State file
+
+- **Path:** `.claude/.plan-mode-state` (relative to `$CLAUDE_PROJECT_DIR`)
+- **Values:**
+    - `active` — plan mode is on.
+    - `inactive` — plan mode is off.
+    - *file missing* — treat as inactive (readers must handle this).
+- **Format:** exactly one word, **no trailing newline**, so shell
+  consumers can compare with `==`.
+- **Gitignored:** yes — it is local runtime state.
+
+## How it works
+
+Two PostToolUse hooks are registered in
+[`.claude/settings.json`](../../../.claude/settings.json):
+
+| Matcher         | Script                                     | Writes       |
+| --------------- | ------------------------------------------ | ------------ |
+| `EnterPlanMode` | `tools/hooks/ai/plan-mode-enter.py`        | `active`     |
+| `ExitPlanMode`  | `tools/hooks/ai/plan-mode-exit.py`         | `inactive`   |
+
+Both scripts:
+
+- Read and discard stdin (so Claude Code does not SIGPIPE on them).
+- Write atomically (temp file in the same directory + `os.replace`), so
+  a concurrent reader never sees a partial write.
+- Create the `.claude/` directory if it is missing.
+- Always exit `0`, even on failure — a hook error must never block a
+  tool call. Failures are logged to stderr.
+
+## Why `PostToolUse`, not `PreToolUse`
+
+A `PreToolUse` hook fires before the tool runs, including for tool calls
+the user then rejects. If plan-mode-exit were wired `Pre`, a user who
+rejected `ExitPlanMode` would still end up with `inactive` on disk even
+though plan mode is still on.
+
+`PostToolUse` only runs after the tool successfully executes, so a
+rejected `ExitPlanMode` leaves the state file at `active`. This is the
+correct, conservative default.
+
+## Known limitation: stale state
+
+Plan mode can be exited **without** an explicit `ExitPlanMode` tool call
+(for example, the user clears it via the CLI, or the session ends). In
+that case no hook fires and the file stays at `active` even though plan
+mode is off. Readers should treat the file as a hint, not a source of
+truth, and should still surface the CLI status line to the user as a
+backup.
+
+## Consuming the state from shell
+
+```bash
+if [[ "$(cat "$CLAUDE_PROJECT_DIR/.claude/.plan-mode-state" 2>/dev/null)" == "active" ]]; then
+    echo "plan mode is active"
+fi
+```
+
+A missing file is treated as inactive by this pattern (the subshell
+prints nothing and the comparison fails).
+
+## Related
+
+- [Command blocking hook](command-blocking.md) — the other hook under
+  `tools/hooks/ai/`.
+- Issue [#389](https://github.com/endavis/pyproject-template/issues/389)
+  — the warning preamble in `/implement` that this hook enables to be
+  upgraded from "ask the user to eyeball the status line" to a
+  programmatic check.

--- a/tests/test_hooks_plan_mode.py
+++ b/tests/test_hooks_plan_mode.py
@@ -1,0 +1,147 @@
+"""Tests for the plan-mode PostToolUse hooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = REPO_ROOT / "tools" / "hooks" / "ai"
+ENTER_HOOK = HOOKS_DIR / "plan-mode-enter.py"
+EXIT_HOOK = HOOKS_DIR / "plan-mode-exit.py"
+
+
+def _run_hook(
+    hook_path: Path,
+    project_dir: Path,
+    stdin_payload: str,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke a hook script as Claude Code would."""
+    env = {
+        "CLAUDE_PROJECT_DIR": str(project_dir),
+        "PATH": os.environ["PATH"],
+    }
+    # Preserve Python env bits so interpreter can find stdlib in venvs.
+    for key in ("PYTHONPATH", "VIRTUAL_ENV", "HOME"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=stdin_payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+        check=False,
+    )
+
+
+def _state_file(project_dir: Path) -> Path:
+    return project_dir / ".claude" / ".plan-mode-state"
+
+
+@pytest.fixture
+def payload() -> str:
+    """Minimal plausible PostToolUse JSON payload."""
+    return json.dumps(
+        {
+            "tool_name": "EnterPlanMode",
+            "tool_input": {"plan": "do stuff"},
+            "tool_response": {},
+        }
+    )
+
+
+class TestEnterHook:
+    def test_writes_active(self, tmp_path: Path, payload: str) -> None:
+        result = _run_hook(ENTER_HOOK, tmp_path, payload)
+        assert result.returncode == 0, result.stderr
+        state = _state_file(tmp_path)
+        assert state.exists()
+        assert state.read_bytes() == b"active"
+
+    def test_overwrites_existing_inactive(self, tmp_path: Path, payload: str) -> None:
+        state = _state_file(tmp_path)
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text("inactive")
+
+        result = _run_hook(ENTER_HOOK, tmp_path, payload)
+        assert result.returncode == 0, result.stderr
+        assert state.read_bytes() == b"active"
+
+    def test_creates_claude_dir_if_missing(self, tmp_path: Path, payload: str) -> None:
+        # tmp_path has no .claude/ subdir
+        assert not (tmp_path / ".claude").exists()
+        result = _run_hook(ENTER_HOOK, tmp_path, payload)
+        assert result.returncode == 0, result.stderr
+        assert _state_file(tmp_path).read_bytes() == b"active"
+
+    def test_malformed_json_stdin_exits_zero(self, tmp_path: Path) -> None:
+        result = _run_hook(ENTER_HOOK, tmp_path, "not valid json {{{")
+        assert result.returncode == 0, result.stderr
+        # Even with bad JSON, the hook still writes state (it ignores the payload).
+        assert _state_file(tmp_path).read_bytes() == b"active"
+
+    def test_empty_stdin_exits_zero(self, tmp_path: Path) -> None:
+        result = _run_hook(ENTER_HOOK, tmp_path, "")
+        assert result.returncode == 0, result.stderr
+        assert _state_file(tmp_path).read_bytes() == b"active"
+
+    def test_no_trailing_newline(self, tmp_path: Path, payload: str) -> None:
+        _run_hook(ENTER_HOOK, tmp_path, payload)
+        content = _state_file(tmp_path).read_bytes()
+        assert not content.endswith(b"\n")
+        assert content == b"active"
+
+
+class TestExitHook:
+    def test_writes_inactive(self, tmp_path: Path, payload: str) -> None:
+        result = _run_hook(EXIT_HOOK, tmp_path, payload)
+        assert result.returncode == 0, result.stderr
+        state = _state_file(tmp_path)
+        assert state.exists()
+        assert state.read_bytes() == b"inactive"
+
+    def test_overwrites_existing_active(self, tmp_path: Path, payload: str) -> None:
+        state = _state_file(tmp_path)
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text("active")
+
+        result = _run_hook(EXIT_HOOK, tmp_path, payload)
+        assert result.returncode == 0, result.stderr
+        assert state.read_bytes() == b"inactive"
+
+    def test_creates_claude_dir_if_missing(self, tmp_path: Path, payload: str) -> None:
+        assert not (tmp_path / ".claude").exists()
+        result = _run_hook(EXIT_HOOK, tmp_path, payload)
+        assert result.returncode == 0, result.stderr
+        assert _state_file(tmp_path).read_bytes() == b"inactive"
+
+    def test_malformed_json_stdin_exits_zero(self, tmp_path: Path) -> None:
+        result = _run_hook(EXIT_HOOK, tmp_path, "{ bad json")
+        assert result.returncode == 0, result.stderr
+        assert _state_file(tmp_path).read_bytes() == b"inactive"
+
+    def test_no_trailing_newline(self, tmp_path: Path, payload: str) -> None:
+        _run_hook(EXIT_HOOK, tmp_path, payload)
+        content = _state_file(tmp_path).read_bytes()
+        assert not content.endswith(b"\n")
+        assert content == b"inactive"
+
+
+class TestRoundTrip:
+    def test_enter_then_exit(self, tmp_path: Path, payload: str) -> None:
+        _run_hook(ENTER_HOOK, tmp_path, payload)
+        assert _state_file(tmp_path).read_bytes() == b"active"
+
+        _run_hook(EXIT_HOOK, tmp_path, payload)
+        assert _state_file(tmp_path).read_bytes() == b"inactive"
+
+        _run_hook(ENTER_HOOK, tmp_path, payload)
+        assert _state_file(tmp_path).read_bytes() == b"active"

--- a/tools/hooks/ai/plan-mode-enter.py
+++ b/tools/hooks/ai/plan-mode-enter.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook for EnterPlanMode.
+
+Writes the word ``active`` (no trailing newline) to
+``$CLAUDE_PROJECT_DIR/.claude/.plan-mode-state`` so that other tooling
+(e.g. /implement) can detect that the parent Claude session is currently
+in plan mode before spawning sub-agents.
+
+The write is atomic (temp file + os.replace) so a concurrent reader never
+observes a partial write. The hook always exits 0 so a failure here can
+never block a tool call.
+
+For full documentation, see: docs/development/ai/plan-mode-hook.md
+"""
+
+import contextlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+STATE_DIR_NAME = ".claude"
+STATE_FILE_NAME = ".plan-mode-state"
+
+
+def write_state(project_dir: Path, value: str) -> None:
+    """Atomically write ``value`` (no trailing newline) to the state file."""
+    target = project_dir / STATE_DIR_NAME / STATE_FILE_NAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".plan-mode-state.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(value)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, target)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def main() -> int:
+    """Entry point. Always returns 0."""
+    try:
+        sys.stdin.read()
+    except Exception as exc:
+        print(f"plan-mode-enter: failed to read stdin: {exc}", file=sys.stderr)
+
+    try:
+        project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", "."))
+        write_state(project_dir, "active")
+    except Exception as exc:
+        print(f"plan-mode-enter: failed to write state: {exc}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/plan-mode-exit.py
+++ b/tools/hooks/ai/plan-mode-exit.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook for ExitPlanMode.
+
+Writes the word ``inactive`` (no trailing newline) to
+``$CLAUDE_PROJECT_DIR/.claude/.plan-mode-state`` so that other tooling
+can detect that plan mode has been exited.
+
+The write is atomic (temp file + os.replace). The hook always exits 0
+so a failure here can never block a tool call. Because this runs as
+``PostToolUse``, a rejected ``ExitPlanMode`` does not fire it — the
+state file stays ``active``.
+
+For full documentation, see: docs/development/ai/plan-mode-hook.md
+"""
+
+import contextlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+STATE_DIR_NAME = ".claude"
+STATE_FILE_NAME = ".plan-mode-state"
+
+
+def write_state(project_dir: Path, value: str) -> None:
+    """Atomically write ``value`` (no trailing newline) to the state file."""
+    target = project_dir / STATE_DIR_NAME / STATE_FILE_NAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".plan-mode-state.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(value)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, target)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def main() -> int:
+    """Entry point. Always returns 0."""
+    try:
+        sys.stdin.read()
+    except Exception as exc:
+        print(f"plan-mode-exit: failed to read stdin: {exc}", file=sys.stderr)
+
+    try:
+        project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", "."))
+        write_state(project_dir, "inactive")
+    except Exception as exc:
+        print(f"plan-mode-exit: failed to write state: {exc}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds a pair of Claude Code `PostToolUse` hooks that maintain `.claude/.plan-mode-state` on disk. The hooks fire on `EnterPlanMode` and `ExitPlanMode`, writing `active` or `inactive` atomically (temp file + `os.replace`). Other tooling — starting with the revised `/implement` command (follow-up to #389) — can read this file to detect parent plan-mode state before spawning a sub-agent, instead of relying on the user to eyeball the CLI status line.

Diagnostic probing during the #389 session showed parent plan-mode state propagates to spawned sub-agents after the sub-agent's first non-readonly action, freezing it. `/implement`'s preamble currently tells users to self-check; this lands the programmatic check so that warning can become a hard abort.

## Related Issue

Addresses #392

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `tools/hooks/ai/plan-mode-enter.py` — atomic write of `active` to `.claude/.plan-mode-state`.
- `tools/hooks/ai/plan-mode-exit.py` — atomic write of `inactive`. `PostToolUse` ensures rejected `ExitPlanMode` doesn't fire it.
- `.claude/settings.json` — new `PostToolUse` section wiring both matchers.
- `.gitignore` — excludes the state file (per-session transient, not repo state).
- `tests/test_hooks_plan_mode.py` — 12 pytest cases: correct value/path, overwrite, missing `.claude/` dir, malformed JSON / empty stdin, no trailing newline, round-trip.
- `docs/development/ai/plan-mode-hook.md` — contract, rationale, known limitation, shell one-liner for consumers.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] `doit check` passes

Manual verification plan (post-merge):
- Enter plan mode via `/plan-issue N`; observe `.claude/.plan-mode-state` becomes `active`.
- `ExitPlanMode` approved; file becomes `inactive`.
- `ExitPlanMode` rejected; file stays `active` (PostToolUse did not fire).

## Checklist

- [x] `doit check` passes (format, lint, mypy, bandit, codespell, pytest).
- [x] Tests added.
- [x] Documentation added.
- [x] No breaking changes; hooks are observe-only and never block a tool call.

## Additional Notes

**Deviations from plan:**
- Shared `_plan_mode_common.py` helper inlined into each hook script. The sub-agent's initial extraction used `sys.path.insert` which Pyright can't resolve, producing LSP noise. ~20 lines duplicated across two scripts is cleaner than the path-manipulation alternative.
- Concurrency test from the plan (monkeypatched partial-write race) dropped; timing-dependent and hard to exercise deterministically. Atomicity is guaranteed by `os.replace` POSIX semantics, which the implementation review covers.

**Known limitation** (documented in `plan-mode-hook.md`): the state file can go stale if plan mode exits without an explicit `ExitPlanMode` tool call. Consumers should treat the file as a best-effort signal and the CLI status line as the ground truth.

**Relationship to #389:** #389 has a local-only commit on `refactor/389-implement-inline` with a preamble telling users to check the status line manually. After this merges, #389's branch will be rebased on main and its preamble revised to read `.claude/.plan-mode-state` automatically.

No ADR required (no `needs-adr` label; defensive tooling category, same as the existing dangerous-command hook).
