### PR TITLE
feat: add doit labels_sync and declarative .github/labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,56 @@
+# GitHub label definitions for this repository.
+#
+# Source of truth for labels replicated to GitHub. Edit this file and run
+# `doit labels_sync` (or `doit labels_sync --dry-run` to preview) to reconcile
+# the repository's labels with the list below.
+#
+# Fields:
+#   name        (required) Label name exactly as it appears on GitHub.
+#   color       6-char hex (no leading "#"). Defaults to "ededed".
+#   description Plain text description. Defaults to "".
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+- name: refactor
+  color: F9D0C4
+  description: Code refactoring and cleanup
+- name: chore
+  color: FEF2C0
+  description: Maintenance, tooling, CI tasks
+- name: needs-triage
+  color: FBCA04
+  description: Needs review and prioritization
+- name: needs-adr
+  color: d4c5f9
+  description: This issue requires an Architecture Decision Record
+- name: ready-to-merge
+  color: 0E8A16
+  description: PR is reviewed and ready to merge
+- name: full-matrix
+  color: 1D76DB
+  description: Run CI on all supported Python versions
+- name: automerge-blocked
+  color: B60205
+  description: Block dependabot auto-merge for this PR
+- name: do-not-merge
+  color: B60205
+  description: Prevent the merge gate from allowing this PR
+- name: security
+  color: d73a4a
+  description: Security vulnerability or fix
+- name: automated
+  color: 02db74
+  description: Created or managed by automation
+- name: dependencies
+  color: 0366d6
+  description: Pull requests that update a dependency file
+- name: github_actions
+  color: "000000"
+  description: Pull requests that update GitHub Actions code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ The tool hierarchy (prefer higher over lower):
 | Create PRs | `doit pr` | `gh pr create` |
 | Merge PRs | `doit pr_merge` | `gh pr merge` |
 | Create ADRs | `doit adr` | Manual file creation |
+| Sync GitHub labels | `doit labels_sync` | `gh label create` / `gh label edit` manually |
 | Commit (interactive) | `doit commit` | `git commit` without format |
 | Install/add packages | `uv add <pkg>` | `pip install` |
 | Sync dependencies | `uv sync` | `pip install -r` |

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -38,7 +38,7 @@ doit <task_name>
 | [Security](#security-tasks) | `security`, `audit`, `licenses`, `sbom` | Security scanning and SBOM |
 | [Documentation](#documentation-tasks) | `docs_serve`, `docs_build`, `docs_deploy`, `docs_toc` | Documentation management |
 | [Dependencies](#dependency-tasks) | `install`, `install_dev`, `update_deps` | Package management |
-| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr` | Issue and PR management |
+| [GitHub Workflow](#github-workflow-tasks) | `issue`, `pr`, `pr_merge`, `adr`, `labels_sync` | Issue and PR management |
 | [Release](#release-tasks) | `release`, `release_dev`, `release_pr`, `release_tag`, `publish` | Version and release management |
 | [Version](#version-tasks) | `bump`, `changelog` | Version bumping and changelog |
 | [Setup](#setup-tasks) | `pre_commit_install`, `completions`, `install_direnv` | Development environment |
@@ -700,6 +700,39 @@ doit adr --title="Use Redis" --body-file=adr.md
 - `--body-file`: File containing ADR body (non-interactive)
 
 See [ADR Documentation](../decisions/README.md) for more information.
+
+---
+
+### `labels_sync`
+
+Reconcile GitHub labels with `.github/labels.yml` (idempotent).
+
+```bash
+# Preview changes without touching GitHub
+doit labels_sync --dry-run
+
+# Create missing labels and update drift (no deletion)
+doit labels_sync
+
+# Also delete labels present on GitHub but absent from the file
+doit labels_sync --prune
+
+# Use a different labels file
+doit labels_sync --file=.github/labels.custom.yml
+```
+
+**What it does:**
+- Reads `.github/labels.yml` (flat list of `{name, color, description}` entries).
+- Fetches current labels from GitHub via `gh label list`.
+- Creates, updates, or (with `--prune`) deletes labels to match the file.
+- Color comparison is case-insensitive; running twice is a no-op.
+
+**Options:**
+- `--dry-run`: Print planned changes, make no API calls.
+- `--prune`: Also delete labels on GitHub that are missing from the file (off by default).
+- `--file=<path>`: Path to the labels file (default `.github/labels.yml`).
+
+See [GitHub Repository Settings → Labels](github-repository-settings.md#labels) for the canonical label list and the file schema.
 
 ---
 

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -77,7 +77,18 @@ to the default branch.
 ## Labels
 
 Labels are used by issue templates, workflows, release notes, and Dependabot.
-All labels are replicated from the template by `replicate_labels()`.
+
+**Source of truth:** `.github/labels.yml`. The file is a flat list of entries with `name`, `color` (6-char hex, no leading `#`), and `description`. Run `doit labels_sync` to reconcile the repository's labels with the file.
+
+```bash
+doit labels_sync --dry-run   # Preview changes
+doit labels_sync             # Create missing labels, update drift
+doit labels_sync --prune     # Also delete labels not in the file
+```
+
+The task is idempotent — running it twice in a row is a no-op the second time. Color comparison is case-insensitive. `--prune` is off by default because deletion is destructive.
+
+To add a label: edit `.github/labels.yml`, run `doit labels_sync --dry-run` to preview, then `doit labels_sync` to apply.
 
 | Label | Color | Description | Used By |
 | :--- | :--- | :--- | :--- |

--- a/tests/test_doit_github.py
+++ b/tests/test_doit_github.py
@@ -1,7 +1,9 @@
 """Tests for github.py doit tasks."""
 
 import io
+import json
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,7 +14,11 @@ from tools.doit.github import (
     _close_linked_issues,
     _ensure_branch_pushed,
     _extract_linked_issues,
+    _fetch_github_labels,
     _format_merge_subject,
+    _load_labels_file,
+    _reconcile_labels,
+    task_labels_sync,
 )
 
 
@@ -346,3 +352,303 @@ class TestEnsureBranchPushed:
         _ensure_branch_pushed("feat/x", console, no_push=True)
 
         assert mock_subprocess.call_count == 1
+
+
+class TestLabelsSync:
+    """Tests for the ``labels_sync`` doit task and its helpers."""
+
+    @staticmethod
+    def _make_console() -> Console:
+        return Console(file=io.StringIO(), width=200)
+
+    @staticmethod
+    def _labels_file(tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "labels.yml"
+        path.write_text(body)
+        return path
+
+    @staticmethod
+    def _register_list(mock_subprocess: MagicMock, current: list[dict[str, str]]) -> None:
+        """Wire `gh label list` to return ``current`` as JSON."""
+        mock_subprocess.register({("gh", "label", "list"): {"stdout": json.dumps(current)}})
+
+    def _run_task(
+        self,
+        dry_run: bool = False,
+        prune: bool = False,
+        file: str = "",
+    ) -> None:
+        action = task_labels_sync()["actions"][0]
+        action(dry_run=dry_run, prune=prune, file=file)
+
+    def test_creates_missing_labels(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File has 'foo', GH has none → one gh label create call."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(mock_subprocess, [])
+        mock_subprocess.register({("gh", "label", "create"): {}})
+
+        self._run_task(file=str(labels_file))
+
+        create_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "create"]
+        ]
+        assert len(create_calls) == 1
+        assert create_calls[0].args[0] == [
+            "gh",
+            "label",
+            "create",
+            "foo",
+            "--color",
+            "aaa111",
+            "--description",
+            "Foo label",
+        ]
+
+    def test_updates_mismatched_labels(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File has 'foo' color aaa111, GH has color bbb222 → one gh label edit call."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [{"name": "foo", "color": "bbb222", "description": "Foo label"}],
+        )
+        mock_subprocess.register({("gh", "label", "edit"): {}})
+
+        self._run_task(file=str(labels_file))
+
+        edit_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "edit"]
+        ]
+        assert len(edit_calls) == 1
+        assert edit_calls[0].args[0] == [
+            "gh",
+            "label",
+            "edit",
+            "foo",
+            "--color",
+            "aaa111",
+            "--description",
+            "Foo label",
+        ]
+
+    def test_no_change_when_match(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File and GH identical → no mutating calls."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [{"name": "foo", "color": "aaa111", "description": "Foo label"}],
+        )
+
+        self._run_task(file=str(labels_file))
+
+        mutating = [
+            c
+            for c in mock_subprocess.call_args_list
+            if c.args[0][:3]
+            in (["gh", "label", "create"], ["gh", "label", "edit"], ["gh", "label", "delete"])
+        ]
+        assert mutating == []
+
+    def test_prune_deletes_extras(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """With --prune, GH has a label not in file → gh label delete is called."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "foo", "color": "aaa111", "description": "Foo label"},
+                {"name": "old-label", "color": "cccccc", "description": "legacy"},
+            ],
+        )
+        mock_subprocess.register({("gh", "label", "delete"): {}})
+
+        self._run_task(file=str(labels_file), prune=True)
+
+        delete_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "delete"]
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].args[0] == ["gh", "label", "delete", "old-label", "--yes"]
+
+    def test_no_prune_by_default(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """GH has extra label, no --prune → no delete call; extra is reported as skipped."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "foo", "color": "aaa111", "description": "Foo label"},
+                {"name": "old-label", "color": "cccccc", "description": "legacy"},
+            ],
+        )
+
+        self._run_task(file=str(labels_file))
+
+        delete_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "delete"]
+        ]
+        assert delete_calls == []
+
+    def test_dry_run_makes_no_mutations(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """With --dry-run, only gh label list is called; no create/edit/delete."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: foo\n  color: aaa111\n  description: Foo label\n"
+            "- name: bar\n  color: bbb222\n  description: Bar label\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "bar", "color": "999999", "description": "Bar label"},
+                {"name": "legacy", "color": "cccccc", "description": "to prune"},
+            ],
+        )
+
+        self._run_task(file=str(labels_file), prune=True, dry_run=True)
+
+        mutating = [
+            c
+            for c in mock_subprocess.call_args_list
+            if c.args[0][:3]
+            in (["gh", "label", "create"], ["gh", "label", "edit"], ["gh", "label", "delete"])
+        ]
+        assert mutating == []
+
+    def test_malformed_yaml_raises_clear_error(
+        self, tmp_path: Path, mock_subprocess: MagicMock
+    ) -> None:
+        """Entry without a 'name' field → SystemExit(1) naming the offending entry."""
+        labels_file = self._labels_file(tmp_path, "- color: red\n")
+
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_task(file=str(labels_file))
+
+        assert excinfo.value.code == 1
+        mock_subprocess.assert_not_called()
+
+    def test_missing_file_raises(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """--file pointing at a nonexistent path → SystemExit(1)."""
+        missing = tmp_path / "does-not-exist.yml"
+
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_task(file=str(missing))
+
+        assert excinfo.value.code == 1
+        mock_subprocess.assert_not_called()
+
+    def test_color_comparison_case_insensitive(
+        self, tmp_path: Path, mock_subprocess: MagicMock
+    ) -> None:
+        """File 'FBCA04', GH 'fbca04' → no update."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "- name: needs-triage\n  color: FBCA04\n  description: triage\n",
+        )
+        self._register_list(
+            mock_subprocess,
+            [{"name": "needs-triage", "color": "fbca04", "description": "triage"}],
+        )
+
+        self._run_task(file=str(labels_file))
+
+        mutating = [
+            c
+            for c in mock_subprocess.call_args_list
+            if c.args[0][:3]
+            in (["gh", "label", "create"], ["gh", "label", "edit"], ["gh", "label", "delete"])
+        ]
+        assert mutating == []
+
+    def test_empty_description_handled(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """File entry with empty description → create call uses --description ''."""
+        labels_file = self._labels_file(
+            tmp_path,
+            '- name: foo\n  color: aaa111\n  description: ""\n',
+        )
+        self._register_list(mock_subprocess, [])
+        mock_subprocess.register({("gh", "label", "create"): {}})
+
+        self._run_task(file=str(labels_file))
+
+        create_calls = [
+            c for c in mock_subprocess.call_args_list if c.args[0][:3] == ["gh", "label", "create"]
+        ]
+        assert len(create_calls) == 1
+        cmd = create_calls[0].args[0]
+        assert cmd[-2:] == ["--description", ""]
+
+    def test_summary_counts_correct(self, tmp_path: Path, mock_subprocess: MagicMock) -> None:
+        """Mixed scenario (create + update + no-change + skipped) → counters correct."""
+        labels_file = self._labels_file(
+            tmp_path,
+            "\n".join(
+                [
+                    "- name: new-one",
+                    "  color: aaa111",
+                    "  description: new",
+                    "- name: updated",
+                    "  color: bbb222",
+                    "  description: updated desc",
+                    "- name: same",
+                    "  color: cccccc",
+                    "  description: same",
+                    "",
+                ]
+            ),
+        )
+        self._register_list(
+            mock_subprocess,
+            [
+                {"name": "updated", "color": "999999", "description": "old"},
+                {"name": "same", "color": "cccccc", "description": "same"},
+                {"name": "extra", "color": "111111", "description": "extra"},
+            ],
+        )
+        mock_subprocess.register(
+            {
+                ("gh", "label", "create"): {},
+                ("gh", "label", "edit"): {},
+            }
+        )
+
+        counters = _reconcile_labels(
+            _load_labels_file(labels_file, self._make_console()),
+            _fetch_github_labels(self._make_console()),
+            prune=False,
+            dry_run=False,
+            console=self._make_console(),
+        )
+
+        assert counters["created"] == 1
+        assert counters["updated"] == 1
+        assert counters["unchanged"] == 1
+        assert counters["deleted"] == 0
+        assert counters["skipped"] == 1
+
+    def test_labels_file_parses(self) -> None:
+        """The actual .github/labels.yml parses and has non-empty entries."""
+        repo_labels = Path(__file__).resolve().parent.parent / ".github" / "labels.yml"
+        assert repo_labels.exists(), f"{repo_labels} is missing"
+
+        entries = _load_labels_file(repo_labels, self._make_console())
+        assert entries, "labels.yml should not be empty"
+
+        names = {entry["name"] for entry in entries}
+        # Two labels the issue highlighted as missing on the repo must be present.
+        assert "automerge-blocked" in names
+        assert "do-not-merge" in names
+        # Every entry must have a 6-char hex color.
+        for entry in entries:
+            assert len(entry["color"]) == 6, f"bad color for {entry['name']}: {entry['color']!r}"

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -1,12 +1,15 @@
 """GitHub issue and PR creation doit tasks."""
 
+import json
 import os
 import re
 import subprocess  # nosec B404 - subprocess is required for doit tasks
 import sys
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
 from doit.tools import title_with_actions
 from rich.console import Console
 from rich.panel import Panel
@@ -15,6 +18,9 @@ from tools.doit.templates import get_issue_template, get_pr_template, get_requir
 
 if TYPE_CHECKING:
     from rich.console import Console as ConsoleType
+
+DEFAULT_LABELS_FILE = ".github/labels.yml"
+DEFAULT_LABEL_COLOR = "ededed"
 
 
 def _get_editor() -> str:
@@ -835,6 +841,344 @@ def task_pr_merge() -> dict[str, Any]:
                 "type": bool,
                 "default": False,
                 "help": "Close linked issues after merge with a standard comment",
+            },
+        ],
+        "title": title_with_actions,
+    }
+
+
+def _load_labels_file(path: Path, console: Console) -> list[dict[str, str]]:
+    """Parse a YAML labels file into a list of normalized label dicts.
+
+    Each entry must be a mapping with a required ``name`` field. ``color``
+    defaults to :data:`DEFAULT_LABEL_COLOR` and ``description`` defaults to
+    an empty string. Extra fields are ignored. Malformed entries cause
+    ``sys.exit(1)`` with a message naming the offending index.
+
+    Args:
+        path: Path to the labels YAML file.
+        console: Rich console for error output.
+
+    Returns:
+        List of ``{"name": str, "color": str, "description": str}`` dicts.
+    """
+    if not path.exists():
+        console.print(f"[red]Labels file not found: {path}[/red]")
+        sys.exit(1)
+
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as e:
+        console.print(f"[red]Failed to parse {path}: {e}[/red]")
+        sys.exit(1)
+
+    if raw is None:
+        return []
+
+    if not isinstance(raw, list):
+        console.print(f"[red]Labels file must be a YAML list, got {type(raw).__name__}.[/red]")
+        sys.exit(1)
+
+    labels: list[dict[str, str]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            console.print(
+                f"[red]Labels file entry #{index} must be a mapping, "
+                f"got {type(entry).__name__}.[/red]"
+            )
+            sys.exit(1)
+
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            console.print(
+                f"[red]Labels file entry #{index} is missing a 'name' field "
+                f"(entry: {entry!r}).[/red]"
+            )
+            sys.exit(1)
+
+        color_raw = entry.get("color", DEFAULT_LABEL_COLOR)
+        if not isinstance(color_raw, str):
+            console.print(
+                f"[red]Labels file entry '{name}' has a non-string 'color' "
+                f"(got {type(color_raw).__name__}).[/red]"
+            )
+            sys.exit(1)
+
+        description = entry.get("description", "")
+        if description is None:
+            description = ""
+        if not isinstance(description, str):
+            console.print(
+                f"[red]Labels file entry '{name}' has a non-string 'description' "
+                f"(got {type(description).__name__}).[/red]"
+            )
+            sys.exit(1)
+
+        labels.append(
+            {
+                "name": name.strip(),
+                "color": color_raw.strip().lstrip("#").lower(),
+                "description": description,
+            }
+        )
+
+    return labels
+
+
+def _fetch_github_labels(console: Console) -> dict[str, dict[str, str]]:
+    """Fetch the current label set from GitHub via ``gh label list``.
+
+    Parses the returned JSON into a ``{name: {color, description}}`` map
+    with colors lowercased for case-insensitive comparison.
+
+    Args:
+        console: Rich console for error output.
+
+    Returns:
+        Dict keyed by label name.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "label", "list", "--limit", "200", "--json", "name,color,description"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print("[red]Failed to fetch labels from GitHub:[/red]")
+        console.print(f"[red]{stderr}[/red]")
+        sys.exit(1)
+
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        console.print(f"[red]Could not parse `gh label list` output: {e}[/red]")
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        console.print("[red]Unexpected `gh label list` output (not a list).[/red]")
+        sys.exit(1)
+
+    labels: dict[str, dict[str, str]] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        color = entry.get("color", "") or ""
+        description = entry.get("description", "") or ""
+        labels[name] = {
+            "name": name,
+            "color": str(color).lower(),
+            "description": str(description),
+        }
+    return labels
+
+
+def _reconcile_labels(
+    desired: list[dict[str, str]],
+    current: dict[str, dict[str, str]],
+    *,
+    prune: bool,
+    dry_run: bool,
+    console: Console,
+) -> dict[str, int]:
+    """Reconcile desired labels with the current GitHub state.
+
+    Performs create/edit/delete operations (or prints the planned actions
+    in ``dry_run`` mode). Colors are compared case-insensitively.
+
+    Args:
+        desired: Normalized list of labels from the YAML file.
+        current: Map of current GitHub labels keyed by name.
+        prune: If True, delete labels present on GitHub but absent from the file.
+        dry_run: If True, print planned actions and make no mutating API calls.
+        console: Rich console for output.
+
+    Returns:
+        Dict of counters: ``created``, ``updated``, ``unchanged``, ``deleted``, ``skipped``.
+    """
+    counters = {"created": 0, "updated": 0, "unchanged": 0, "deleted": 0, "skipped": 0}
+    desired_names = {entry["name"] for entry in desired}
+
+    for entry in desired:
+        name = entry["name"]
+        color = entry["color"]
+        description = entry["description"]
+        existing = current.get(name)
+
+        if existing is None:
+            prefix = "would create" if dry_run else "created"
+            console.print(f"[green]+ {prefix}[/green] {name} (color={color})")
+            counters["created"] += 1
+            if not dry_run:
+                _run_label_cmd(
+                    [
+                        "gh",
+                        "label",
+                        "create",
+                        name,
+                        "--color",
+                        color,
+                        "--description",
+                        description,
+                    ],
+                    console,
+                )
+            continue
+
+        if existing["color"] == color and existing["description"] == description:
+            console.print(f"[dim]= no change[/dim] {name}")
+            counters["unchanged"] += 1
+            continue
+
+        prefix = "would update" if dry_run else "updated"
+        console.print(f"[yellow]~ {prefix}[/yellow] {name} (color={color})")
+        counters["updated"] += 1
+        if not dry_run:
+            _run_label_cmd(
+                [
+                    "gh",
+                    "label",
+                    "edit",
+                    name,
+                    "--color",
+                    color,
+                    "--description",
+                    description,
+                ],
+                console,
+            )
+
+    extras = sorted(set(current) - desired_names)
+    for name in extras:
+        if prune:
+            prefix = "would delete" if dry_run else "deleted"
+            console.print(f"[red]- {prefix}[/red] {name}")
+            counters["deleted"] += 1
+            if not dry_run:
+                _run_label_cmd(["gh", "label", "delete", name, "--yes"], console)
+        else:
+            console.print(f"[dim]? skipped[/dim] {name} (not in file; use --prune to delete)")
+            counters["skipped"] += 1
+
+    return counters
+
+
+def _run_label_cmd(cmd: list[str], console: Console) -> None:
+    """Invoke a ``gh label`` subcommand and abort on failure.
+
+    Args:
+        cmd: Full command argument list.
+        console: Rich console for error output.
+    """
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        console.print(f"[red]Command failed: {' '.join(cmd)}[/red]")
+        console.print(f"[red]{stderr}[/red]")
+        sys.exit(1)
+
+
+def task_labels_sync() -> dict[str, Any]:
+    """Sync GitHub labels with ``.github/labels.yml`` (idempotent).
+
+    Reads the labels file and reconciles the repository's GitHub labels:
+
+    - Missing labels are created.
+    - Labels whose color or description differ are updated.
+    - Labels present on GitHub but absent from the file are left alone
+      unless ``--prune`` is passed (then they are deleted).
+
+    Color comparison is case-insensitive.
+
+    Examples:
+        doit labels_sync                        # Reconcile, do not prune.
+        doit labels_sync --dry-run              # Preview changes only.
+        doit labels_sync --prune                # Also delete extra labels.
+        doit labels_sync --file=custom/labels.yml
+    """
+
+    def sync_labels(
+        dry_run: bool = False,
+        prune: bool = False,
+        file: str = DEFAULT_LABELS_FILE,
+    ) -> None:
+        console = Console()
+        console.print()
+        mode = "(dry run)" if dry_run else ""
+        console.print(
+            Panel.fit(
+                f"[bold cyan]Syncing GitHub Labels[/bold cyan] {mode}".rstrip(),
+                border_style="cyan",
+            )
+        )
+        console.print()
+
+        try:
+            desired = _load_labels_file(Path(file), console)
+            if not desired:
+                console.print(f"[yellow]No labels defined in {file}; nothing to sync.[/yellow]")
+                return
+
+            console.print(f"[dim]Loaded {len(desired)} label(s) from {file}[/dim]")
+            current = _fetch_github_labels(console)
+            console.print(f"[dim]Fetched {len(current)} label(s) from GitHub[/dim]")
+            console.print()
+
+            counters = _reconcile_labels(
+                desired,
+                current,
+                prune=prune,
+                dry_run=dry_run,
+                console=console,
+            )
+
+            console.print()
+            summary = (
+                f"{counters['created']} created, "
+                f"{counters['updated']} updated, "
+                f"{counters['unchanged']} unchanged, "
+                f"{counters['deleted']} deleted, "
+                f"{counters['skipped']} skipped"
+            )
+            console.print(
+                Panel.fit(
+                    f"[bold green]Label sync complete[/bold green]\n\n{summary}",
+                    border_style="green",
+                )
+            )
+        except SystemExit:
+            raise
+        except Exception as e:  # pragma: no cover - defensive catch-all
+            console.print(f"[red]Unexpected error during label sync: {e}[/red]")
+            sys.exit(1)
+
+    return {
+        "actions": [sync_labels],
+        "params": [
+            {
+                "name": "dry_run",
+                "long": "dry-run",
+                "type": bool,
+                "default": False,
+                "help": "Print planned changes without calling gh label create/edit/delete",
+            },
+            {
+                "name": "prune",
+                "long": "prune",
+                "type": bool,
+                "default": False,
+                "help": "Delete labels present on GitHub but absent from the file",
+            },
+            {
+                "name": "file",
+                "long": "file",
+                "default": DEFAULT_LABELS_FILE,
+                "help": f"Path to labels YAML file (default: {DEFAULT_LABELS_FILE})",
             },
         ],
         "title": title_with_actions,


### PR DESCRIPTION
## Description

Adds a declarative source of truth for the repository's GitHub labels and a `doit labels_sync` task that reconciles the live label set with it. Fixes the gap where `.github/workflows/dependabot-automerge.yml` references `automerge-blocked` and `do-not-merge` — labels that did not actually exist on the repository.

`.github/labels.yml` is a flat list of 15 `{name, color, description}` entries covering every label used by issue templates, workflows, release notes, and dependabot automation. `doit labels_sync` reads the file, fetches the current labels via `gh label list`, and creates missing labels / updates drift / (optionally) prunes extras. Color comparison is case-insensitive; running twice in a row is a no-op.

## Related Issue

Addresses #388

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **New** `.github/labels.yml` (56 lines): 15-entry list with name, color, description for every label used by the repo's automation and templates. `automerge-blocked` and `do-not-merge` added in red (`B60205`) to close the workflow-reference gap.
- **Modified** `tools/doit/github.py` (+344 lines): added `_load_labels_file`, `_fetch_github_labels`, `_reconcile_labels`, and `task_labels_sync`. The task takes `--dry-run`, `--prune`, and `--file=<path>` options. Error paths mirror existing tasks (red Rich panel → `sys.exit(1)`). All subprocess calls use `subprocess.run(..., check=True, capture_output=True, text=True)` so they're mockable via the `mock_subprocess` fixture.
- **Modified** `tests/test_doit_github.py` (+306 lines): `TestLabelsSync` class with 12 tests covering create / update / no-change / prune / no-prune-by-default / dry-run / malformed YAML / missing file / case-insensitive color comparison / empty description / summary counts / labels-file smoke parse. All use the `mock_subprocess` fixture from #387.
- **Modified** `AGENTS.md`: added `Sync GitHub labels | doit labels_sync | gh label create / gh label edit manually` row to the Tool Reference table.
- **Modified** `docs/development/github-repository-settings.md`: added a "Source of truth" subsection to the existing Labels section pointing at `.github/labels.yml` and documenting `doit labels_sync` / `--prune` / `--dry-run`.
- **Modified** `docs/development/doit-tasks-reference.md`: added `labels_sync` to the GitHub Workflow task category and a full entry documenting the command options.

## Testing

- [x] `doit check` passes: format, lint, mypy, security, spell-check, 465 tests. (One unrelated flake in `test_temp_file_cleanup_on_*` — global `/tmp` race with xdist workers, documented as a known issue; passes on rerun.)
- [x] 12 new tests in `TestLabelsSync` cover every algorithm branch and error path.
- [x] `doit list` shows `labels_sync` with its docstring: `Sync GitHub labels with `.github/labels.yml` (idempotent).`
- [x] Not yet run against the live repository — deferred to after merge so reviewers can see the intended state before any GitHub mutations happen. Plan is to run `doit labels_sync --dry-run`, confirm the two missing labels are reported as `+ create`, then run `doit labels_sync` (without `--prune`) to apply.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`) — mypy strict-clean
- [x] I have added tests that prove the feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (AGENTS.md, GitHub repo settings, doit tasks reference)

## Additional Notes

- **ADR:** not required. Issue has no `needs-adr` label; this is an ops/automation task, not an architectural decision.
- **Scope of labels file:** includes 15 entries that the repo actively uses. GitHub's default labels (`duplicate`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`) are intentionally omitted — `--prune` would remove them from a fresh repo on sync, which is the correct behavior since the repo doesn't depend on them. Users who want them back can add them to the file.
- **Prune safety:** `--prune` is off by default and requires an explicit flag. The first live sync run for this PR will be without `--prune` so the GitHub-default labels stay put.
- **Algorithm:** first-registered-wins dispatch via insertion-ordered dict; color comparison case-insensitive (GitHub returns lowercase; the file may contain mixed case).
