### PR TITLE
feat: add PostToolUse hook to run ruff --fix on edited Python files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/ruff-fix-on-edit.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -51,6 +51,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
+- [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
 - [Template Tools Reference](template/tools-reference.md) - Complete reference for all template tools in tools/pyproject_template/
 - [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
@@ -65,6 +66,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
 - [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
 <!-- END:audience=ai-agents -->
@@ -115,6 +117,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
 - [Release Automation & Security](development/release-and-automation.md) - Automated versioning, release management, and security tooling
+- [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
 - [Template Architecture Decision Records](template/decisions/README.md)
 - [Template Management](template/manage.md) - Unified interface for creating projects, checking updates, and syncing

--- a/docs/development/ai/ruff-fix-hook.md
+++ b/docs/development/ai/ruff-fix-hook.md
@@ -1,0 +1,86 @@
+---
+title: Ruff Auto-Fix on Edit Hook
+description: PostToolUse hook that runs ruff --fix on edited Python files
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - hooks
+  - ruff
+---
+
+# Ruff Auto-Fix on Edit
+
+A Claude Code `PostToolUse` hook that runs `ruff --fix` plus `ruff format` on a Python file immediately after an AI agent edits it. Cuts the feedback loop on trivial issues (unused imports, unused variables, import ordering) from "discovered at `doit check` many turns later" to "fixed before the next tool call".
+
+## What It Does
+
+After every `Edit`, `Write`, or `MultiEdit` call, the hook:
+
+1. Reads the tool payload from stdin and extracts `tool_input.file_path`.
+2. Skips the file unless it's a tracked Python source path (see scope below).
+3. Runs `uv run ruff check --fix --select F401,F841,I --quiet <path>`.
+4. Runs `uv run ruff format --quiet <path>`.
+5. Always exits 0. Hook errors must never block tool calls.
+
+The hook is best-effort — timeouts, missing `ruff`, malformed payloads, and ruff non-zero exits are all swallowed silently. The next `doit check` will surface anything genuine.
+
+## Scope
+
+| Path pattern | Auto-fixed? |
+|---|---|
+| `src/**/*.py` | yes |
+| `tests/**/*.py` | yes |
+| `tools/**/*.py` | yes |
+| `bootstrap.py` | yes |
+| Anything else (including `scripts/*.py`, `*.md`, `*.toml`, etc.) | no |
+
+This mirrors the scope `doit format` and `doit lint` already target.
+
+## Rules Fixed
+
+Only deterministic, judgment-free rules are selected:
+
+| Rule | Description |
+|---|---|
+| `F401` | Unused imports |
+| `F841` | Unused local variables |
+| `I` | Import sorting (`isort`-compatible) |
+
+All other ruff rules (`E`, `W`, `B`, `RUF`, etc.) are intentionally **not** enabled by the hook — they require human judgment. They still run as part of `doit lint` / `doit check`.
+
+## Disabling Locally
+
+Override the hook entry in `.claude/settings.local.json` (gitignored):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": []
+  }
+}
+```
+
+Restart Claude Code for the change to take effect.
+
+## Known Limitation: Stale `old_string` After Reorder
+
+If you make two consecutive `Edit` calls on the same file and the first edit's ruff pass reorders imports or removes a line you were about to target, the second `Edit`'s `old_string` may no longer match. Mitigations:
+
+- Use `Write` for large rewrites that touch many lines.
+- Re-`Read` the file between consecutive `Edit` calls on imports or unused-variable-adjacent code.
+
+The friction is intentional — silencing the noise on every other turn is worth the occasional re-read.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`tools/hooks/ai/ruff-fix-on-edit.py`](../../../tools/hooks/ai/ruff-fix-on-edit.py) | The hook script |
+| [`tests/test_hook_ruff_fix.py`](../../../tests/test_hook_ruff_fix.py) | Pytest coverage |
+| [`.claude/settings.json`](../../../.claude/settings.json) | Wires the hook into `PostToolUse` |
+
+## Related
+
+- [AI Command Blocking](command-blocking.md) — sibling `PreToolUse` hook for dangerous commands

--- a/tests/test_hook_ruff_fix.py
+++ b/tests/test_hook_ruff_fix.py
@@ -1,0 +1,264 @@
+"""Tests for the ``ruff-fix-on-edit`` PostToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/ruff-fix-on-edit.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "ruff-fix-on-edit.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("ruff_fix_on_edit", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook(monkeypatch: pytest.MonkeyPatch) -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["ruff_fix_on_edit"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("ruff_fix_on_edit", None)
+
+
+@pytest.fixture
+def call_log(hook: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Replace ``run_ruff`` with a recorder; return the list of received paths."""
+    calls: list[Path] = []
+
+    def _record(path: Path) -> None:
+        calls.append(path)
+
+    monkeypatch.setattr(hook, "run_ruff", _record)
+    return calls
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _payload(file_path: str) -> str:
+    """Build a minimal Edit-tool payload referencing *file_path*."""
+    return json.dumps({"tool_name": "Edit", "tool_input": {"file_path": file_path}})
+
+
+def _setup_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``CLAUDE_PROJECT_DIR`` at *tmp_path*."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+
+def _touch(tmp_path: Path, rel: str, contents: str = "x = 1\n") -> Path:
+    """Create *rel* under *tmp_path* with *contents* and return the absolute path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(contents)
+    return target
+
+
+def test_non_python_file_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """README.md (non-.py) should not invoke ruff."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "README.md", "# hi\n")
+    _set_stdin(monkeypatch, _payload("README.md"))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_python_file_outside_scope_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A .py file outside src/tests/tools and not bootstrap.py is skipped."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "scripts/adhoc.py")
+    _set_stdin(monkeypatch, _payload("scripts/adhoc.py"))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_python_file_in_src_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """src/foo.py triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "src/foo.py")
+    _set_stdin(monkeypatch, _payload("src/foo.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_python_file_in_tests_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """tests/test_foo.py triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "tests/test_foo.py")
+    _set_stdin(monkeypatch, _payload("tests/test_foo.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_python_file_in_tools_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """tools/doit/github.py triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "tools/doit/github.py", "pass\n")
+    _set_stdin(monkeypatch, _payload("tools/doit/github.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_bootstrap_py_invokes_ruff(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """bootstrap.py at the project root triggers a ruff fix."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "bootstrap.py")
+    _set_stdin(monkeypatch, _payload("bootstrap.py"))
+
+    assert hook.main() == 0
+    assert call_log == [target]
+
+
+def test_missing_file_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A path that does not exist on disk is skipped (likely a deletion)."""
+    _setup_project(tmp_path, monkeypatch)
+    # Note: we do NOT create tests/nope.py.
+    _set_stdin(monkeypatch, _payload("tests/nope.py"))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_ruff_failure_still_exits_zero(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If ``run_ruff`` raises a generic exception, main() still returns 0."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "src/foo.py")
+
+    def _boom(_path: Path) -> None:
+        raise RuntimeError("ruff exploded")
+
+    monkeypatch.setattr(hook, "run_ruff", _boom)
+    _set_stdin(monkeypatch, _payload("src/foo.py"))
+
+    assert hook.main() == 0
+
+
+def test_ruff_timeout_still_exits_zero(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If ``run_ruff`` raises ``TimeoutExpired``, main() still returns 0."""
+    _setup_project(tmp_path, monkeypatch)
+    _touch(tmp_path, "src/foo.py")
+
+    def _timeout(_path: Path) -> None:
+        raise subprocess.TimeoutExpired(cmd="ruff", timeout=30)
+
+    monkeypatch.setattr(hook, "run_ruff", _timeout)
+    _set_stdin(monkeypatch, _payload("src/foo.py"))
+
+    assert hook.main() == 0
+
+
+def test_malformed_stdin_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invalid JSON on stdin returns 0 with no ruff call."""
+    _setup_project(tmp_path, monkeypatch)
+    _set_stdin(monkeypatch, "not json")
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_missing_tool_input_is_noop(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """JSON without ``tool_input.file_path`` returns 0 with no ruff call."""
+    _setup_project(tmp_path, monkeypatch)
+    _set_stdin(monkeypatch, json.dumps({"tool_name": "Edit", "tool_input": {}}))
+
+    assert hook.main() == 0
+    assert call_log == []
+
+
+def test_absolute_path_inside_project(
+    hook: types.ModuleType,
+    call_log: list[Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An absolute path inside the project is normalized and fixed."""
+    _setup_project(tmp_path, monkeypatch)
+    target = _touch(tmp_path, "src/foo.py")
+    _set_stdin(monkeypatch, _payload(str(target)))
+
+    assert hook.main() == 0
+    assert call_log == [target]

--- a/tools/hooks/ai/ruff-fix-on-edit.py
+++ b/tools/hooks/ai/ruff-fix-on-edit.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook that runs ``ruff --fix`` on edited Python files.
+
+Triggered after ``Edit``/``Write``/``MultiEdit`` tool calls. When the touched
+file is a tracked Python source path, runs a fast ``ruff check --fix`` for
+unused imports/variables and import ordering, followed by ``ruff format``.
+
+The hook is best-effort: any failure (timeout, ruff missing, malformed payload)
+is swallowed and the hook exits 0 so it never blocks a tool call. The next
+``doit check`` will surface any genuine issue.
+
+For full documentation, see: docs/development/ai/ruff-fix-hook.md
+"""
+
+import json
+import os
+import subprocess  # nosec B404 - required to invoke ruff
+import sys
+from pathlib import Path
+
+# Path roots whose Python files are eligible for the auto-fix.
+# Mirrors the scope of ``doit format`` / ``doit lint``.
+ALLOWED_ROOTS: tuple[str, ...] = ("src/", "tests/", "tools/")
+
+# Specific files at the project root that are also eligible.
+ALLOWED_FILES: tuple[str, ...] = ("bootstrap.py",)
+
+# Ruff rule selectors restricted to deterministic, judgment-free fixes:
+#   F401 - unused imports
+#   F841 - unused local variables
+#   I    - import ordering
+SELECTED_RULES = "F401,F841,I"
+
+# Per-invocation timeout for ruff (covers both ``check`` and ``format`` calls).
+RUFF_TIMEOUT_SECONDS = 30
+
+
+def _is_in_scope(rel_path: str) -> bool:
+    """Return True iff *rel_path* is a Python file inside the auto-fix scope."""
+    if not rel_path.endswith(".py"):
+        return False
+    if rel_path in ALLOWED_FILES:
+        return True
+    return any(rel_path.startswith(root) for root in ALLOWED_ROOTS)
+
+
+def run_ruff(path: Path) -> None:
+    """Run ``ruff check --fix`` then ``ruff format`` on *path*.
+
+    Best-effort: every exception is swallowed. This function must never raise.
+    """
+    try:
+        subprocess.run(  # nosec B603 B607 - trusted ruff invocation
+            [
+                "uv",
+                "run",
+                "ruff",
+                "check",
+                "--fix",
+                "--select",
+                SELECTED_RULES,
+                "--quiet",
+                str(path),
+            ],
+            capture_output=True,
+            timeout=RUFF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    except Exception:  # nosec B110 - hook must never raise; errors would block tool calls
+        pass
+
+    try:
+        subprocess.run(  # nosec B603 B607 - trusted ruff invocation
+            ["uv", "run", "ruff", "format", "--quiet", str(path)],
+            capture_output=True,
+            timeout=RUFF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    except Exception:  # nosec B110 - hook must never raise; errors would block tool calls
+        pass
+
+
+def _normalize_path(raw_path: str, project_dir: str) -> str | None:
+    """Return *raw_path* as a project-relative POSIX-style string.
+
+    Returns None if the path is absolute and outside the project directory
+    (we never auto-fix files we don't own).
+    """
+    path = Path(raw_path)
+    if not path.is_absolute():
+        return raw_path
+
+    if not project_dir:
+        return None
+
+    try:
+        return path.relative_to(project_dir).as_posix()
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+
+        if not isinstance(input_data, dict):
+            return 0
+
+        tool_input = input_data.get("tool_input")
+        if not isinstance(tool_input, dict):
+            return 0
+
+        raw_file_path = tool_input.get("file_path")
+        if not isinstance(raw_file_path, str) or not raw_file_path:
+            return 0
+
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+        rel_path = _normalize_path(raw_file_path, project_dir)
+        if rel_path is None:
+            return 0
+
+        if not _is_in_scope(rel_path):
+            return 0
+
+        # Resolve to an absolute path for the existence check and ruff call.
+        target = Path(project_dir) / rel_path if project_dir else Path(rel_path)
+        if not target.is_file():
+            return 0
+
+        run_ruff(target)
+    except Exception:  # hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds a `PostToolUse` hook that runs `ruff check --fix --select F401,F841,I` followed by `ruff format` on Python files after any `Edit` / `Write` / `MultiEdit` operation. Cuts the feedback loop for trivial findings (unused imports, unused locals, import ordering) from "surface at next `doit check`" to "fixed before the next tool call". The hook fires only for files under `src/`, `tests/`, `tools/`, or for the top-level `bootstrap.py` — the scope `doit format` / `doit lint` already target.

## Related Issue

Addresses #390

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

**New files:**
- `tools/hooks/ai/ruff-fix-on-edit.py` (143 LOC, mode 0755): `PostToolUse` hook script. Reads JSON from stdin, normalizes the target path against `$CLAUDE_PROJECT_DIR`, scope-checks the path, then invokes `uv run ruff check --fix --select F401,F841,I --quiet <path>` and `uv run ruff format --quiet <path>`. Module-level `run_ruff()` so tests can patch it. Every code path catches all exceptions and returns `0` — a broken hook must never block a tool call.
- `tests/test_hook_ruff_fix.py` (265 LOC): 12 pytest cases covering the six in-scope / out-of-scope / missing-file / malformed-stdin / ruff-failure / ruff-timeout / absolute-path branches. Uses `importlib` to load the hyphen-named hook module. All 12 pass in ~0.03s.
- `docs/development/ai/ruff-fix-hook.md`: scope, rules, local-disable instructions (override via `.claude/settings.local.json`), and the known "consecutive-edit `old_string` staleness" caveat.

**Modified:**
- `.claude/settings.json`: added a `PostToolUse` block matching `Edit|Write|MultiEdit`. The existing `PreToolUse` block-dangerous-commands hook is untouched.
- `docs/TABLE_OF_CONTENTS.md`: auto-regenerated by `tools/generate_doc_toc.py` to include the new doc.

## Testing

- [x] `doit check` passes: format, lint, mypy, security, spell-check, full pytest including the 12 new hook tests.
- [x] Pyright `★` hints on `monkeypatch` (pytest fixture injection) and `_path` (underscore-prefixed unused callback args) are intentional and ignored by mypy/ruff.
- [x] The hook's `main()` has been exercised against every branch documented in the plan's test plan.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`) — mypy strict-clean
- [x] I have added tests that prove the feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly

## Additional Notes

- **Hook activation:** Claude Code reads `.claude/settings.json` at session start. Existing Claude Code sessions will not see the new hook until they are restarted. Fresh sessions after merge will pick it up automatically.
- **ADR:** not required. Issue has no `needs-adr` label; this is a process/automation hook, not an architectural decision.
- **Rule scope:** only `F401` (unused imports), `F841` (unused local variables), and `I` (import ordering) are auto-fixed. Any other ruff finding still surfaces at `doit check` time, where the agent / user can exercise judgment.
- **Disable locally:** override via `.claude/settings.local.json` — set `hooks.PostToolUse` to an empty array or remove the `Edit|Write|MultiEdit` matcher. Documented in `docs/development/ai/ruff-fix-hook.md`.
- **Known limitation:** if Claude performs two consecutive `Edit` calls on the same file and the first edit's ruff pass reorders imports or removes a line, the second `Edit`'s `old_string` may fail to match. Mitigation is editorial — use `Write` for large rewrites, or re-read the file between edits. Net win on balance (noise reduction > friction).
