### PR TITLE
fix: use tmp/agents/claude/ for finalize PR body temp file

### DIFF
--- a/.claude/commands/finalize.md
+++ b/.claude/commands/finalize.md
@@ -59,7 +59,8 @@ Use the Task tool with `subagent_type: "general-purpose"` and provide it with th
 
 5. **Draft the PR description** and write it to a temp file:
    - Read `.github/pull_request_template.md` for structure
-   - Write the PR body to `/tmp/pr-body.md`
+   - Run `mkdir -p tmp/agents/claude` to ensure the directory exists
+   - Write the PR body to `tmp/agents/claude/pr-body-issue-<n>.md`
    - The body MUST include `Addresses #<issue-number>`
 
 6. **Return** a summary of:
@@ -67,7 +68,7 @@ Use the Task tool with `subagent_type: "general-purpose"` and provide it with th
    - ADR changes made (if any)
    - Suggested commit message following conventional format: `<type>: <subject>`
    - Suggested PR title following conventional format: `<type>: <subject>`
-   - Path to the PR body file (`/tmp/pr-body.md`)
+   - Path to the PR body file (`tmp/agents/claude/pr-body-issue-<n>.md`)
 
 ### Step 3: Commit and create PR
 
@@ -78,7 +79,8 @@ After the agent returns, in the main context:
 3. **Only after user confirms:**
    - Stage files: `git add <specific files>` (include all changed files from implementation and review/fix cycle)
    - Commit with the approved message
-   - Create PR: `doit pr --title="<type>: <subject>" --body-file=/tmp/pr-body.md`
+   - Create PR: `doit pr --title="<type>: <subject>" --body-file=tmp/agents/claude/pr-body-issue-<n>.md`
+   - Delete the temp file: `rm tmp/agents/claude/pr-body-issue-<n>.md`
 4. **Report** the PR URL to the user
 
 **IMPORTANT:** Do NOT commit or create the PR without explicit user confirmation.


### PR DESCRIPTION
## Description

The `finalize` skill was writing the PR body temp file to `/tmp/pr-body.md` — a generic location that violates the project's AI agent file operations policy and creates collision risk when multiple sub-agents run concurrently. Updated to use the project-scoped path `tmp/agents/claude/pr-body-issue-<n>.md`.

## Related Issue

Addresses #406

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Updated `.claude/commands/finalize.md` Step 2 to write PR body to `tmp/agents/claude/pr-body-issue-<n>.md` instead of `/tmp/pr-body.md`
- Updated Step 3 `doit pr` invocation to reference the corrected path
- Updated Step 3 cleanup (`rm`) to reference the corrected path

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The only check failure is a pre-existing `tomli` import error in `bootstrap.py` on `main` (`Cannot find implementation or library stub for module named "tomli"`). This is unrelated to this fix.

No ADR is required (issue does not have the `needs-adr` label; no existing ADR covers temp file conventions).
