### PR TITLE
docs: add GitHub Copilot CLI workflow support and .copilot/ config directory

### DIFF
--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -1,0 +1,33 @@
+# Copilot CLI Configuration
+
+This directory is the GitHub Copilot CLI configuration directory for this repository, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+
+## Workflow Skills
+
+Copilot CLI automatically discovers project skills from `.claude/commands/`. No separate Copilot command files are needed — the full workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available out of the box.
+
+## Dangerous Command Hook
+
+The dangerous command hook is wired in `.github/hooks/copilot-hooks.json`. It blocks shell commands identified as dangerous before they execute:
+
+```
+.github/hooks/copilot-hooks.json → tools/hooks/ai/block-dangerous-commands.py
+```
+
+No changes to this hook are needed when adding new slash commands.
+
+## Subagent / Implement Worker
+
+The `implement-worker` subagent used by `/implement` is defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when spawning the subagent.
+
+## Temporary Files
+
+Agents must write temporary files to `tmp/agents/copilot/` (not `/tmp/`). Include a context identifier (issue number, PR number, or task ID) in the filename to avoid collisions.
+
+## See Also
+
+- `.claude/commands/` — slash command definitions (auto-discovered by Copilot CLI)
+- `.claude/agents/implement-worker.md` — implement-worker subagent definition
+- `.github/hooks/copilot-hooks.json` — dangerous command hook wiring
+- `docs/development/ai/slash-commands.md` — full workflow and command reference
+- `docs/development/ai/command-blocking.md` — hook documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,19 @@ AI agents with native file tools (Read, Grep, Glob, Edit, Write) **must** prefer
 
 Native tools provide better visibility, review capabilities, and error handling for the user.
 
+### AI Config Directories
+
+Each supported AI CLI has a dedicated config directory at the repo root:
+
+| CLI | Config Directory | Notes |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/` | Commands, agents, settings. Primary source of slash commands. |
+| Gemini CLI | `.gemini/` | Commands and settings. Output-only commands (orchestrated by Claude). |
+| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
+| Codex CLI | `.codex/` | `config.toml` only (command approval policies). No slash commands. |
+
+Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/plan-issue`, `/implement`, `/finalize`, etc.) works out of the box.
+
 ### Temporary Files
 
 AI agents **must never** write temporary files to generic locations like `/tmp/`. Instead, use the project-scoped directory:

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -114,9 +114,21 @@ Invoked by Claude's `/review-both` and `/gemini-review` commands via `gemini -p 
 
 The `.codex/` directory contains only `config.toml`, which configures command approval policies for the Codex CLI. No slash commands ship for Codex. The dual-agent workflow in this template targets Claude and Gemini.
 
+## Copilot
+
+GitHub Copilot CLI automatically discovers project skills from `.claude/commands/`. All workflow commands (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) are available in Copilot sessions without any additional files.
+
+**Config directory:** `.copilot/` — established as the Copilot CLI config directory for this repo, parallel to `.claude/`, `.gemini/`, and `.codex/`.
+
+**Dangerous command hook:** Already wired in `.github/hooks/copilot-hooks.json`. It invokes `tools/hooks/ai/block-dangerous-commands.py` as a `preToolUse` hook, blocking dangerous shell commands before they execute. See [AI Command Blocking](command-blocking.md) for details.
+
+**Implement-worker subagent:** Shared with Claude — defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when `/implement` spawns the subagent.
+
+**No parallel command files needed:** Because Copilot CLI discovers skills from `.claude/commands/` directly, you do not need to maintain a separate `.copilot/commands/` directory unless you need to override Claude-specific behavior for Copilot sessions.
+
 ## Adding a new slash command
 
-1. **Pick the location.** Claude commands live in `.claude/commands/<name>.md` and become `/<name>` in Claude Code. Gemini commands live in `.gemini/commands/<name>.md` and become `/<name>` in Gemini CLI.
+1. **Pick the location.** Claude commands live in `.claude/commands/<name>.md` and become `/<name>` in Claude Code. Gemini commands live in `.gemini/commands/<name>.md` and become `/<name>` in Gemini CLI. Copilot CLI auto-discovers skills from `.claude/commands/` — no separate `.copilot/commands/<name>.md` is needed unless you want to override Claude-specific behaviour for Copilot sessions.
 2. **Use the CLI file format** — not the `docs/` frontmatter format. Start with a top-level `# Title` heading, follow with a one-line description (which may include the `$ARGUMENTS` placeholder if the command takes arguments), then a `## Instructions` section containing the step-by-step body. **Do not add YAML frontmatter.** The CLIs expect plain markdown; frontmatter would appear verbatim in the rendered prompt.
 3. **Use `$ARGUMENTS` for inputs.** When the user invokes `/<command> foo bar`, every `$ARGUMENTS` occurrence in the file is substituted with `foo bar` before the command body is sent to the model. For commands that take no arguments (like `/finalize` or `/where-am-i`), omit the placeholder.
 4. **Decide: subagent or main context?** Delegate to a general-purpose subagent via the Task tool when the command does heavy codebase exploration, writes files, or runs long commands whose output would bloat the main conversation — `.claude/commands/implement.md` is the canonical example. Run in the main context when the user needs to interact step by step (plan mode, iteration, explicit approvals) — `.claude/commands/plan-issue.md` is the canonical example.


### PR DESCRIPTION
## Description

Adds first-class GitHub Copilot CLI support to the project's AI workflow. This establishes the `.copilot/` config directory, documents Copilot's skill auto-discovery from `.claude/commands/`, and updates `AGENTS.md` with the AI config directory reference table so all four supported CLIs (Claude, Gemini, Copilot, Codex) are documented in one place.

## Related Issue

Addresses #400

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- **`AGENTS.md`** — Added "AI Config Directories" section with a table mapping each supported AI CLI (`Claude Code`, `Gemini CLI`, `GitHub Copilot CLI`, `Codex CLI`) to its config directory and a brief note on its capabilities.
- **`docs/development/ai/slash-commands.md`** — Added "Copilot" section documenting skill auto-discovery, the dangerous-command hook wiring, the shared `implement-worker` subagent, and updated the "Adding a new slash command" step to mention that Copilot CLI inherits skills from `.claude/commands/` without needing a separate directory.
- **`.copilot/README.md`** — New file establishing the `.copilot/` config directory with orientation notes: skill discovery, hook wiring, subagent, temp-file conventions, and cross-references.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

> Documentation-only change. No code logic was added or modified. Pre-existing `tomli` type-check failure on `bootstrap.py` is present on `main` and unrelated to this PR.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No ADR required — this is a documentation/tooling-config change with no `needs-adr` label on the issue. The ADR index currently has no entries; if a broader "multi-CLI AI tooling" ADR is desired, it can be created in a follow-up.
