### PR TITLE
docs: complete Copilot CLI coverage in AI_SETUP, enforcement-principles, first-5-minutes

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -31,7 +31,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 ### For Contributors
 <!-- BEGIN:audience=contributors -->
 - [Add a Feature: End-to-End Walkthrough](examples/add-a-feature.md) - Step-by-step example of adding a module, CLI subcommand, tests, and docs to the project
-- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
 - [AI Enforcement Principles](development/ai/enforcement-principles.md) - How we enforce AI agent behavior in code and settings
@@ -59,7 +59,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 
 ### For AI Agents
 <!-- BEGIN:audience=ai-agents -->
-- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
 - [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents
@@ -90,7 +90,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9014: Use click for application CLI](template/decisions/9014-use-click-for-application-cli.md)
 - [ADR-9015: install_tools framework: archive extraction and custom URLs](template/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
-- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, and Codex for this project
+- [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template
 - [AI Architectural Conventions](development/ai/architectural-conventions.md) - Imperative-form architectural rules AI agents must follow when generating code
 - [AI Command Blocking](development/ai/command-blocking.md) - Hooks that block dangerous commands from AI agents

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -1,6 +1,6 @@
 ---
 title: AI Agent Setup Guide
-description: Configure Claude, Gemini, and Codex for this project
+description: Configure Claude, Gemini, Copilot, and Codex for this project
 audience:
   - contributors
   - ai-agents
@@ -12,7 +12,7 @@ tags:
 
 # AI Agent Setup Guide
 
-This template is designed primarily for **Claude Code**, which is the only agent that ships the full slash-command workflow and acts as the orchestrator in single-agent and dual-agent flows. **Gemini CLI** is supported in a narrower role (second-opinion planner/reviewer inside Claude-orchestrated commands), and **Codex CLI** is supported as a standalone alternative without slash commands. Support for additional primary agents is planned. See the comparison table below for the per-agent breakdown.
+This template is designed primarily for **Claude Code**, which is the only agent that ships the full slash-command workflow and acts as the orchestrator in single-agent and dual-agent flows. **Gemini CLI** is supported in a narrower role (second-opinion planner/reviewer inside Claude-orchestrated commands). **GitHub Copilot CLI** is supported as a standalone alternative that auto-discovers the full slash-command workflow from `.claude/commands/`. **Codex CLI** is supported as a standalone alternative without slash commands. See the comparison table below for the per-agent breakdown.
 
 > **New here?** Start with the [First 5 Minutes walkthrough](ai/first-5-minutes.md) for a narrative tour of the AI agent workflow. This page is the configuration reference.
 
@@ -24,9 +24,10 @@ This template is designed primarily for **Claude Code**, which is the only agent
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Codex CLI** | TOML approval policies (`.codex/config.toml`) | Project-level `tools/hooks/ai/` apply via shell | None shipped | Not documented | Standalone alternative (not part of dual-agent flow) |
 | **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 2 output-only (`/plan-issue`, `/review-pr`) | Not documented | Second-opinion reviewer / planner in dual-agent flow |
+| **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | Auto-discovers from `.claude/commands/` | Not documented | Standalone alternative (auto-discovers Claude commands) |
 | **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 8 (`plan-issue`, `implement`, `finalize`, `close-issue`, `plan-both`, `review-both`, `gemini-review`, `where-am-i`) | Supported | Primary orchestrator in single-agent and dual-agent flows |
 
-The project-level dangerous-command hooks under `tools/hooks/ai/` apply to all three agents regardless of per-agent config and cannot be bypassed by editing `.claude/settings.local.json`, `.codex/config.toml`, or `.gemini/settings.json`. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+The project-level dangerous-command hooks under `tools/hooks/ai/` apply to all four agents regardless of per-agent config and cannot be bypassed by editing `.claude/settings.local.json`, `.codex/config.toml`, `.gemini/settings.json`, or `.github/hooks/copilot-hooks.json`. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
 ### 1. Codex CLI (OpenAI)
 
@@ -154,11 +155,56 @@ claude
 
 For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
 
-### 4. Other AI Tools
+### 4. GitHub Copilot CLI
+
+**Configuration:** `.copilot/` directory
+
+> **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
+
+GitHub Copilot CLI reads `AGENTS.md` directly and auto-discovers project skills from `.claude/commands/`, so the full slash-command workflow (`/plan-issue`, `/implement`, `/finalize`, `/close-issue`, `/where-am-i`, etc.) is available in Copilot sessions without any parallel command files. The `implement-worker` subagent used by `/implement` is shared with Claude (defined in `.claude/agents/implement-worker.md`).
+
+**Hook wiring:**
+
+The dangerous-command hook is wired in `.github/hooks/copilot-hooks.json`:
+```json
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "cwd": ".github/hooks",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}
+```
+
+**Setup:**
+```bash
+# Copilot CLI automatically picks up .github/hooks/copilot-hooks.json
+# and reads AGENTS.md; no additional setup needed.
+copilot
+```
+
+**Files:**
+- `.copilot/README.md` - Description of the Copilot CLI config directory
+- `.github/hooks/copilot-hooks.json` - `preToolUse` hook wiring
+- `.claude/commands/*.md` - Slash commands (auto-discovered by Copilot CLI)
+- `.claude/agents/implement-worker.md` - Shared subagent definition
+
+**Documentation:**
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Copilot CLI Hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
+
+**Copilot parity status:** Copilot CLI ships no parallel command or agent files — it auto-discovers from `.claude/commands/` and `.claude/agents/`, so every Claude slash command works unchanged in Copilot sessions. Copilot is not part of the dual-agent workflow (Claude and Gemini are); it works as a standalone alternative for contributors who prefer GitHub Copilot. The project-level hooks under `tools/hooks/ai/` apply to Copilot via `.github/hooks/copilot-hooks.json` — see [Command Blocking](ai/command-blocking.md). For the broader slash-command picture, see [Slash Commands and Workflows](ai/slash-commands.md).
+
+### 5. Other AI Tools
 
 The `AGENTS.md` file serves as general-purpose documentation for any AI coding assistant:
 
-- **GitHub Copilot**: Reference in `.github/copilot-instructions.md`
 - **Cursor**: Reference in `.cursorrules`
 - **Codeium**: Reference in project settings
 - **Tabnine**: Reference in configuration
@@ -177,7 +223,7 @@ The `AGENTS.md` file provides comprehensive project context including:
 - Troubleshooting guides
 
 This file is:
-- **Read directly** by Codex CLI and Gemini CLI
+- **Read directly** by Codex CLI, Gemini CLI, and GitHub Copilot CLI
 - **Imported** by Claude Code via `.claude/claude.md`
 - **Referenceable** by other AI tools
 
@@ -187,19 +233,21 @@ This template ships several files that influence agent behavior. They fall into 
 
 **File inventory:**
 
-- **`AGENTS.md`** (project root, ~20 KB) — universal source of truth for architecture, workflow, tooling hierarchy, and security rules. Read directly by Codex CLI and Gemini CLI; imported by Claude Code via `@../AGENTS.md` in `.claude/CLAUDE.md`.
+- **`AGENTS.md`** (project root, ~20 KB) — universal source of truth for architecture, workflow, tooling hierarchy, and security rules. Read directly by Codex CLI, Gemini CLI, and GitHub Copilot CLI; imported by Claude Code via `@../AGENTS.md` in `.claude/CLAUDE.md`.
 - **`.claude/CLAUDE.md`** (~2 KB) — Claude-specific complement. First line is `@../AGENTS.md`, which imports the universal rules; the rest adds Claude-specific layers (token-efficiency guidance, the mandatory TodoWrite plan-test-code loop, the development workflow reminder, and the commit workflow reminder).
 - **`GEMINI.md`** (project root, ~1 KB) — Gemini-specific complement. Covers Gemini's stdout-only collaboration mode (so Claude handles GitHub writes), the output signing footer, and Gemini's tool-usage rules. Read alongside `AGENTS.md` by Gemini CLI, not instead of it.
+- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly and auto-discovers slash commands from `.claude/commands/`; no Copilot-specific context markdown is required.
 - **`.codex/config.toml`** — Codex approval policy file (TOML). Not a context file; configures permissions only. Codex reads `AGENTS.md` directly for instructions.
 - **`.claude/settings.json`** — Claude PreToolUse hooks and statusline configuration. Committed.
 - **`.claude/settings.local.json`** — local Claude permissions overlay. Not committed.
 - **`.gemini/settings.json`** — Gemini tool allowlists and lifecycle hook configuration.
+- **`.github/hooks/copilot-hooks.json`** — Copilot CLI `preToolUse` hook wiring that routes shell commands through `tools/hooks/ai/block-dangerous-commands.py`.
 
 **Precedence rules:**
 
-- All three agents treat `AGENTS.md` as the architectural and workflow source of truth.
+- All four agents treat `AGENTS.md` as the architectural and workflow source of truth.
 - Agent-specific markdown files (`.claude/CLAUDE.md`, `GEMINI.md`) **complement** `AGENTS.md` — they cover behaviors specific to that agent's interaction model and do not override the universal rules.
-- Settings/config files (`.codex/config.toml`, `.gemini/settings.json`, `.claude/settings*.json`) configure **permissions and tooling**, not workflow rules. They cannot grant an agent permission to do something `AGENTS.md` forbids.
+- Settings/config files (`.codex/config.toml`, `.gemini/settings.json`, `.claude/settings*.json`, `.github/hooks/copilot-hooks.json`) configure **permissions and tooling**, not workflow rules. They cannot grant an agent permission to do something `AGENTS.md` forbids.
 - Project-level hooks under `tools/hooks/ai/` apply to all agents and cannot be bypassed by per-agent config. This is the strongest layer.
 
 **Conflict resolution:** if an agent-specific file conflicts with `AGENTS.md`, `AGENTS.md` wins for cross-cutting concerns (workflow, architecture, security). An agent-specific file may further restrict its own agent's behavior, but it should not loosen a universal rule.
@@ -246,6 +294,10 @@ reason = "Description of command"
   }
 }
 ```
+
+**GitHub Copilot CLI** (`.github/hooks/copilot-hooks.json`):
+
+Copilot CLI does not use a per-command allowlist — the dangerous-command hook blocks unsafe patterns; everything else is allowed. To adjust what is blocked, edit the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (which applies to Claude, Gemini, and Copilot alike). New slash commands added under `.claude/commands/<name>.md` are automatically discovered by Copilot CLI — no additional configuration is needed.
 
 ## Security Considerations
 
@@ -322,6 +374,21 @@ gemini --yolo
 - Check `.gemini/settings.json` has `"context": {"files": ["AGENTS.md"]}`
 - Verify settings.json is valid JSON
 
+### Copilot CLI
+
+**Hook not firing (dangerous commands going through):**
+- Verify `.github/hooks/copilot-hooks.json` exists and is valid JSON
+- The hook uses a relative `bash` path (`python3 ../../tools/hooks/ai/block-dangerous-commands.py`) and a `cwd` of `.github/hooks`; both must match your layout
+- Run `python3 tools/hooks/ai/test_hook.py` to confirm the shared hook script still passes its test suite
+
+**Slash commands not appearing:**
+- Copilot CLI auto-discovers skills from `.claude/commands/` — make sure that directory exists and contains `.md` files with the CLI file format (no YAML frontmatter; leading `# Title` and `## Instructions` sections)
+- Restart the Copilot CLI session after adding new command files
+
+**`.copilot/` auto-detection:**
+- The `.copilot/` directory exists primarily to document Copilot-specific wiring; Copilot CLI does not require any config files there
+- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root and the hook from `.github/hooks/copilot-hooks.json`
+
 ## Resources
 
 ### Codex CLI
@@ -342,11 +409,15 @@ gemini --yolo
 - [Claude Code Documentation](https://claude.com/claude-code)
 - [Claude Agent SDK](https://github.com/anthropics/claude-code)
 
-### General AI Coding
+### GitHub Copilot CLI
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli)
+- [Using Copilot in the CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-in-the-cli)
 - [GitHub Copilot](https://github.com/features/copilot)
+
+### General AI Coding
 - [Cursor](https://cursor.sh/)
 - [Codeium](https://codeium.com/)
 
 ---
 
-**Note**: The `.codex/`, `.gemini/`, and `.claude/` directories should be committed to version control to share consistent AI assistant configuration across the team. .local files should not be committed.
+**Note**: The `.codex/`, `.gemini/`, `.claude/`, and `.copilot/` directories should be committed to version control to share consistent AI assistant configuration across the team. .local files should not be committed.

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -164,26 +164,26 @@ reason = "BLOCKED: Use 'doit pr' instead of 'gh pr create'. See AGENTS.md."
 
 > **Note**: GitHub settings require repository admin access to configure. See Settings → Rules → Rulesets.
 
-### By AI Agent Enforcement (Claude, Gemini, Codex)
+### By AI Agent Enforcement (Claude, Gemini, Copilot, Codex)
 
-These patterns are blocked across all AI agents. Claude and Gemini use the shared hook at `tools/hooks/ai/block-dangerous-commands.py`. Codex uses approval policies in `.codex/config.toml` (no hook support).
+These patterns are blocked across all AI agents. Claude, Gemini, and Copilot all use the shared hook at `tools/hooks/ai/block-dangerous-commands.py` (wired via `.claude/settings.json`, `.gemini/settings.json`, and `.github/hooks/copilot-hooks.json` respectively). Codex uses approval policies in `.codex/config.toml` (no hook support).
 
-| Pattern | Command | Claude | Gemini | Codex |
-|---------|---------|--------|--------|-------|
-| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Config |
-| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Config |
-| `--hard` flag | `git reset --hard` | Hook | Hook | Config |
-| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Config |
-| `sudo rm` | Any shell | Hook | Hook | Config |
-| Force push to protected branch | `git push --force origin main` | Hook | Hook | Config |
-| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | — |
-| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | — |
-| `gh pr create` | Use `doit pr` instead | Hook | Hook | Config |
-| `gh issue create` | Use `doit issue` instead | Hook | Hook | Config |
-| `uv add` | User runs manually | Hook | Hook | Config |
-| `doit release*` | User runs manually | Hook | Hook | Config |
+| Pattern | Command | Claude | Gemini | Copilot | Codex |
+|---------|---------|--------|--------|---------|-------|
+| `--admin` flag | `gh pr merge --admin` | Hook | Hook | Hook | Config |
+| `--no-verify` flag | `git commit --no-verify`, `git push --no-verify` | Hook | Hook | Hook | Config |
+| `--hard` flag | `git reset --hard` | Hook | Hook | Hook | Config |
+| `rm -rf /` or `rm -rf ~` | Any shell | Hook | Hook | Hook | Config |
+| `sudo rm` | Any shell | Hook | Hook | Hook | Config |
+| Force push to protected branch | `git push --force origin main` | Hook | Hook | Hook | Config |
+| Delete protected branch | `git push origin --delete main`, `git branch -D main` | Hook | Hook | Hook | — |
+| Merge commit on protected branch | `git merge` (without `--ff-only`) on `main` | Hook | Hook | Hook | — |
+| `gh pr create` | Use `doit pr` instead | Hook | Hook | Hook | Config |
+| `gh issue create` | Use `doit issue` instead | Hook | Hook | Hook | Config |
+| `uv add` | User runs manually | Hook | Hook | Hook | Config |
+| `doit release*` | User runs manually | Hook | Hook | Hook | Config |
 
-> **Note**: "Hook" = `block-dangerous-commands.py`, "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
+> **Note**: "Hook" = `block-dangerous-commands.py` (shared across Claude, Gemini, and Copilot), "Config" = `.codex/config.toml` approval policy, "—" = not enforced for this agent.
 
 ### By Pre-commit Hooks (All Developers and Agents)
 

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -21,6 +21,7 @@ This page is a narrative walkthrough of the AI agent workflow this template ship
 - Claude Code installed and authenticated. See [AI Agent Setup](../AI_SETUP.md) for installation and per-agent configuration.
 - The [GitHub CLI](https://cli.github.com/) (`gh`) installed and logged in. The slash commands shell out to `gh` for issue and PR operations.
 - Optionally, the [Gemini CLI](https://github.com/google-gemini/gemini-cli) if you want to run the dual-agent review commands. The single-agent flow described below does not require it.
+- Alternatively, the [GitHub Copilot CLI](https://github.com/github/copilot-cli) can be used in place of Claude Code for the single-agent flow — it auto-discovers the same slash commands from `.claude/commands/`. See [AI Agent Setup § 4. GitHub Copilot CLI](../AI_SETUP.md#4-github-copilot-cli) for the wiring.
 
 The rest of this page assumes you have these working.
 

--- a/docs/template/decisions/9005-ai-agent-command-restrictions.md
+++ b/docs/template/decisions/9005-ai-agent-command-restrictions.md
@@ -20,6 +20,7 @@ Documentation alone is insufficient - AI agents may violate rules after context 
 - Issue #164: Block doit release in AI agent hooks
 - Issue #166: Block uv add in AI agent hooks
 - Issue #362: Add Copilot CLI command-blocking hook integration
+- Issue #409: Complete Copilot CLI coverage in AI_SETUP, enforcement-principles, first-5-minutes
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

PR #408 landed the initial GitHub Copilot CLI integration (config directory, `preToolUse` hook wiring, auto-discovery of skills from `.claude/commands/`), but three AI agent docs still described a three-CLI world (Claude + Gemini + Codex). This PR closes that documentation gap so the docs describe the reality already shipped by PR #408.

Changes are documentation-only — no runtime, tooling, or CLI behavior changes.

## Related Issue

Addresses #409

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `docs/development/AI_SETUP.md`
  - Updated frontmatter `description` and intro paragraph to include Copilot as a supported agent.
  - Added Copilot row to the agent comparison table (hook config, hook application, command count, LSP, role).
  - Changed "three agents" → "four agents" in the project-level hook note and added `.github/hooks/copilot-hooks.json` to the bypass list.
  - Added a full `### 4. GitHub Copilot CLI` section documenting the config directory, hook wiring JSON, setup steps, files inventory, documentation links, and Copilot parity status.
  - Renumbered the old "Other AI Tools" section to `### 5. Other AI Tools` and removed the now-stale `GitHub Copilot: Reference in .github/copilot-instructions.md` bullet (that file no longer exists).
  - Added `.copilot/README.md` and `.github/hooks/copilot-hooks.json` to the configuration-files inventory, and added Copilot to the precedence/conflict resolution rules.
  - Added a Copilot note to the per-agent permission-config subsection and a Copilot block to the troubleshooting section.
  - Added a Copilot subsection under Resources and updated the footer note to include `.copilot/`.
- `docs/development/ai/enforcement-principles.md`
  - Renamed the "By AI Agent Enforcement" heading to include Copilot, updated the prose to explain the shared hook is wired via `.github/hooks/copilot-hooks.json`, and added a Copilot column to the enforcement matrix for every pattern row.
- `docs/development/ai/first-5-minutes.md`
  - Added a bullet under Prerequisites noting Copilot CLI as an alternative single-agent runner with a link into the new AI_SETUP §4 section.

## Testing

- [x] All existing tests pass (`doit check` — full format, lint, mypy, bandit, codespell, pytest suite)
- [ ] Added new tests for new functionality (N/A — docs-only change)
- [x] Manually tested the changes

### Validation grep results

- `.github/copilot-instructions.md` in the repo: 0 hits (file does not exist; stale reference removed).
- `Claude, Gemini, Codex` in `docs/`: 0 hits (all references updated to include Copilot).
- Anchor `#4-github-copilot-cli` resolves: `### 4. GitHub Copilot CLI` heading exists in `docs/development/AI_SETUP.md` at line 158, and the `first-5-minutes.md` cross-link points to `../AI_SETUP.md#4-github-copilot-cli`.

### Related ADR update

- `docs/template/decisions/9005-ai-agent-command-restrictions.md` — added Issue #409 to the Related Issues list (alongside the existing Issue #362 for the initial Copilot hook integration). No new ADR created; the architectural decision to support Copilot CLI was made when #362/PR #408 landed, and this PR is the doc-completion follow-up. Issue #409 does not carry the `needs-adr` label.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs-only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (this PR is the documentation update)
- [ ] I have updated the CHANGELOG.md (docs-only change; not required)
- [x] My changes generate no new warnings

## Additional Notes

This PR is strictly documentation catch-up behind PR #408. It does not change which commands are allowed, which hooks run, or how agents are configured — it only makes the AI agent docs describe the four-CLI reality that already exists on `main`.
