### PR TITLE
refactor: gate codecov upload on needs.setup.outputs.newest in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v6
         with:
           file: ./tmp/coverage.xml


### PR DESCRIPTION
## Description

Replaces the hardcoded Python version in the Codecov upload gate with the dynamic `needs.setup.outputs.newest` output from the `setup` job. The `docs` job at `ci.yml:142` already uses this same pattern — this change brings the test job's upload gate in line, and makes the filter self-updating when `.github/python-versions.json` is bumped.

Previously: gate matched `(3.12, ubuntu-latest)` — the oldest Python row.
Now: gate matches `(newest, ubuntu-latest)` — currently `(3.14, ubuntu-latest)`.

## Related Issue

Addresses #411

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.github/workflows/ci.yml` (L120): Codecov upload `if:` expression changed from `matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'` to `matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'`.

## Testing

- [x] All existing tests pass (`doit check`)
- [ ] Added new tests for new functionality (N/A — workflow-only change)
- [x] Manually reviewed the diff

The CI run on this PR branch should show the Codecov upload step executing only on `(python 3.14, ubuntu-latest)` and skipped on the other 5 matrix cells.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] Tests added (N/A — CI workflow change)
- [x] All new and existing tests pass
- [x] Documentation updated (no doc change required)
- [x] No new warnings
