### PR TITLE
refactor: extract python-versions.json reader into a reusable composite action

### DIFF
--- a/.github/actions/python-versions/action.yml
+++ b/.github/actions/python-versions/action.yml
@@ -1,0 +1,25 @@
+# Reusable composite action that reads .github/python-versions.json and exposes
+# the oldest and newest supported Python versions as outputs. Callers should
+# check out the repository (so .github/python-versions.json is on disk) before
+# invoking this action. Centralizing the jq parsing here keeps every workflow
+# that picks a Python version in sync with a single source of truth.
+name: Python Versions
+description: Read oldest and newest supported Python versions from .github/python-versions.json
+outputs:
+  oldest:
+    description: Oldest supported Python version (e.g., "3.12")
+    value: ${{ steps.read.outputs.oldest }}
+  newest:
+    description: Newest supported Python version (e.g., "3.14")
+    value: ${{ steps.read.outputs.newest }}
+runs:
+  using: composite
+  steps:
+    - name: Read python-versions.json
+      id: read
+      shell: bash
+      run: |
+        oldest=$(jq -r '.oldest' .github/python-versions.json)
+        newest=$(jq -r '.newest' .github/python-versions.json)
+        echo "oldest=$oldest" >> "$GITHUB_OUTPUT"
+        echo "newest=$newest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,10 +30,14 @@ jobs:
             echo "::notice::No benchmark tests found at tests/benchmarks/; skipping benchmark workflow."
           fi
 
+      - id: pv
+        if: steps.check-benchmarks.outputs.exists == 'true'
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         if: steps.check-benchmarks.outputs.exists == 'true'
         with:
-          python-version: "3.14"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         if: steps.check-benchmarks.outputs.exists == 'true'

--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -21,9 +21,12 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }}
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - name: Install griffe
         run: pip install griffe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,27 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      newest: ${{ steps.set-matrix.outputs.newest }}
+      oldest: ${{ steps.pv.outputs.oldest }}
+      newest: ${{ steps.pv.outputs.newest }}
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/python-versions.json
+          sparse-checkout: |
+            .github/python-versions.json
+            .github/actions/python-versions
           sparse-checkout-cone-mode: false
+
+      - id: pv
+        uses: ./.github/actions/python-versions
 
       - name: Set matrix based on config and label
         id: set-matrix
+        env:
+          OLDEST: ${{ steps.pv.outputs.oldest }}
+          NEWEST: ${{ steps.pv.outputs.newest }}
         run: |
-          # Read config
-          oldest=$(jq -r '.oldest' .github/python-versions.json)
-          newest=$(jq -r '.newest' .github/python-versions.json)
-          echo "newest=$newest" >> $GITHUB_OUTPUT
+          oldest="$OLDEST"
+          newest="$NEWEST"
 
           oldest_minor=${oldest#3.}
           newest_minor=${newest#3.}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -17,9 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -23,9 +23,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - id: pv
+        uses: ./.github/actions/python-versions
+
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ steps.pv.outputs.newest }}
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/docs/template/decisions/9013-python-version-support-policy.md
+++ b/docs/template/decisions/9013-python-version-support-policy.md
@@ -38,6 +38,7 @@ Testing every Python version on every PR creates excessive CI load without propo
 ## Related Issues
 
 - Issue #168: Add Python 3.14 to CI testing matrix
+- Issue #413: Extract python-versions.json readers into a reusable composite action
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

Extract the `.github/python-versions.json` reader logic into a reusable composite action at `.github/actions/python-versions/action.yml` and adopt it across every workflow that picks a Python version.

Issue #411 / PR #412 fixed one instance of version-drift (the codecov upload gate in `ci.yml`) by wiring it to `needs.setup.outputs.newest`. This change generalizes that fix: the remaining five workflows each hardcoded a Python version string that had to be hand-edited whenever `.github/python-versions.json` changed. Rather than duplicate the inline `jq` parsing from `ci.yml`'s `setup` job across five more workflows, a single composite action owns the parsing and every workflow calls it.

### Semantic flips (oldest -> newest)

Three of the five migrated workflows previously hardcoded `3.12` (the current `oldest`). Per planning discussion, all three flip to `newest`:

- `breaking-change-detection.yml` - the `griffe`-based API diff only needs a working Python interpreter; the analyzer is the subject under test, not the code being analyzed. Converging on `newest` is consistent with the other analyzer-style jobs.
- `testpypi.yml` - building a pure-Python wheel with `newest` is the conventional choice; the wheel is Python-version-agnostic and consumers install under whatever interpreter they use.
- `release.yml` - same reasoning as `testpypi.yml`; release builds should run under `newest` for consistency.

The other two (`benchmark.yml`, `mutation.yml`) already used `3.14`; they gain the composite action reference without changing which version they resolve to.

### CI-specific note

`benchmark.yml` gates the composite-action step on `steps.check-benchmarks.outputs.exists == 'true'` to preserve the existing skip-when-empty behavior for repositories with no `tests/benchmarks/` directory.

## Related Issue

Addresses #413

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `.github/actions/python-versions/action.yml` composite action that reads `.github/python-versions.json` and exposes `oldest` / `newest` outputs.
- Updated `.github/workflows/ci.yml`: the `setup` job now dogfoods the composite action; the matrix script reads `OLDEST` / `NEWEST` from env vars; `oldest` is added to job outputs alongside `newest`.
- Updated `.github/workflows/benchmark.yml`: replaced hardcoded `3.14` with the composite action; action-call gated on `steps.check-benchmarks.outputs.exists == 'true'`.
- Updated `.github/workflows/mutation.yml`: replaced hardcoded `3.14` with the composite action.
- Updated `.github/workflows/breaking-change-detection.yml`: replaced hardcoded `3.12` with `steps.pv.outputs.newest` (semantic flip).
- Updated `.github/workflows/testpypi.yml`: replaced hardcoded `3.12` with `steps.pv.outputs.newest` (semantic flip).
- Updated `.github/workflows/release.yml`: replaced hardcoded `3.12` with `steps.pv.outputs.newest` (semantic flip).
- Updated `docs/template/decisions/9013-python-version-support-policy.md`: added issue #413 to the Related Issues section.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

Notes:
- `doit check` passes locally (tests, lint, format, type-check, security, spell-check).
- This refactor changes only GitHub Actions workflow wiring; there is no Python code to unit-test. End-to-end validation depends on CI runs against this PR:
  - `ci.yml` and `breaking-change-detection.yml` fire automatically on PR open.
  - `benchmark.yml` fires automatically on PR open (and skips internally when `tests/benchmarks/` does not exist).
  - `mutation.yml` requires manual `workflow_dispatch`.
  - `testpypi.yml` and `release.yml` fire only on matching version tags; they cannot be exercised from a PR branch.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

No new ADR is required. The existing ADR-9013 (Python version support policy with bookend CI strategy) already establishes `.github/python-versions.json` as the single source of truth for supported Python versions; this refactor only changes the mechanism by which workflows read that file. The ADR's Related Issues section has been updated to link to #413.
