### PR TITLE
chore: add actionlint pre-commit hook for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v6
         with:
-          file: ./tmp/coverage.xml
+          files: ./tmp/coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
         stages: [commit-msg]
         args: [--strict]
 
+  # GitHub Actions workflow linting
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   # Local hooks using project's installed tools via uv
   # This ensures version consistency with pyproject.toml
   - repo: local

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -199,6 +199,7 @@ These patterns are blocked across all AI agents. Claude, Gemini, and Copilot all
 | Type checking | `mypy` | Blocks commits with type errors |
 | Security scan | `bandit` | Blocks commits with security issues |
 | Spelling | `codespell` | Blocks commits with spelling errors |
+| GitHub Actions linting | `actionlint` | Blocks commits with invalid workflow syntax |
 | Private key detection | `detect-private-key` | Blocks commits containing secrets |
 | Large file prevention | `check-added-large-files` | Blocks commits with large files |
 

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -357,6 +357,7 @@ uv run pre-commit autoupdate
 | `mypy` | Type checking (strict mode, `src/` only) |
 | `bandit` | Security scanning (skipped if not installed) |
 | `codespell` | Spell checking |
+| `actionlint` | Lint GitHub Actions workflow files |
 | `check-branch-name` | Enforce branch naming convention |
 | `generate-doc-toc` | Update documentation TOC when docs change |
 | `no-commit-to-main` | Prevent direct commits to main branch |

--- a/docs/template/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
+++ b/docs/template/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
@@ -17,6 +17,7 @@ Ensures bad code never enters the repository, provides fast feedback loop (secon
 - Issue #184: Use project's tool versions in pre-commit hooks
 - Issue #128: Align pre-commit, CI, and doit check to use consistent checks
 - Issue #19: Fix resolve pre-commit hook failures in template files
+- Issue #415: Add actionlint hook for GitHub Actions workflow validation
 
 ## Related Documentation
 


### PR DESCRIPTION
## Description

Adds [actionlint](https://github.com/rhysd/actionlint) as a pre-commit hook to
catch GitHub Actions workflow errors locally before they reach CI. actionlint
statically validates workflow YAML for schema issues, expression syntax,
shellcheck warnings inside `run:` blocks, and action input names.

Running the hook across the repo's 9 workflows + 1 composite action surfaced
exactly one real issue, which is also fixed in this PR:

- `.github/workflows/ci.yml`: `codecov/codecov-action@v6` was passed `file:`,
  but the v6 input was renamed to `files:`. The stale name was silently
  ignored by the action, meaning the explicit coverage path was a no-op. This
  is corrected alongside adding the hook so the tree is clean.

Scope is deliberately pre-commit-only — wiring actionlint into CI as a
separate gate is out of scope here.

## Related Issue

Addresses #415

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [x] Other: tooling (pre-commit hook addition)

## Changes Made

- `.pre-commit-config.yaml`: Added `rhysd/actionlint@v1.7.12` hook block
  between `conventional-pre-commit` and the `# Local hooks` comment.
- `.github/workflows/ci.yml`: Fixed `file:` → `files:` input for
  `codecov/codecov-action@v6` (input rename that actionlint caught; the
  stale name was silently ignored by the action).
- `docs/development/ci-cd-testing.md`: Added `actionlint` row to the
  pre-commit stage hooks table.
- `docs/development/ai/enforcement-principles.md`: Added `actionlint` row
  to the "By Pre-commit Hooks" enforcement table.
- `docs/template/decisions/9009-use-pre-commit-hooks-for-quality-gates.md`:
  Appended Issue #415 to the Related Issues section of ADR-9009.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality (N/A — tooling-only change)
- [x] Manually tested the changes

Testing performed:

- `doit check` — passes cleanly (format, lint, type-check, security, spell,
  tests).
- `pre-commit run actionlint --all-files` — passes across all 9 workflows and
  the composite action with no findings (smoke test performed locally).
- Verified `codecov/codecov-action@v6` accepts `files:` (input rename was the
  only actionlint finding; fixed in this PR).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — tooling-only change)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (not required for this change)
- [x] My changes generate no new warnings

## Additional Notes

ADR-9009 (pre-commit hooks for quality gates) has been updated with the
Issue #415 link in its Related Issues section. Issue #415 does not carry the
`needs-adr` label — no new ADR required.
