### PR TITLE
fix: label dependabot PRs before calling gh pr merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -114,21 +114,28 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
     steps:
-      - name: Enable auto-merge (squash)
-        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
-
       - name: Add ready-to-merge label
         run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label ready-to-merge
 
+      - name: Enable auto-merge (squash)
+        id: automerge
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+
       - name: Post sticky status comment
+        if: always()
         uses: actions/github-script@v9
+        env:
+          AUTOMERGE_OUTCOME: ${{ steps.automerge.outcome }}
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
             const marker = '<!-- dependabot-automerge:status -->';
-            const body =
-              marker +
-              '\n✅ **Auto-merge enabled.** This PR will merge automatically when required CI checks pass. To block, add label `automerge-blocked`.';
+            const succeeded = process.env.AUTOMERGE_OUTCOME === 'success';
+            const body = succeeded
+              ? marker +
+                '\n✅ **Auto-merge enabled.** This PR will merge automatically when required CI checks pass. To block, add label `automerge-blocked`.'
+              : marker +
+                '\n⚠️ **Auto-merge could not be enabled**, but the `ready-to-merge` label has been applied so the Merge Gate is satisfied. A maintainer will need to merge this PR manually (or re-run the workflow once the underlying issue is resolved). See the workflow run logs for details. To opt this PR out of auto-merge entirely, add the `automerge-blocked` label.';
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -28,9 +28,16 @@ A dependabot PR qualifies when **all** of the following are true:
 
 Qualifying PRs receive:
 
-- GitHub's native auto-merge enabled with the **squash** strategy.
 - The `ready-to-merge` label applied automatically (satisfying the Merge Gate).
-- A sticky status comment confirming auto-merge is enabled.
+  This happens first and is **unconditional** for qualifying PRs.
+- GitHub's native auto-merge attempted with the **squash** strategy. This step
+  can fail for reasons outside the workflow (e.g. the repository does not have
+  `allow_auto_merge` enabled), in which case the run is marked as a failure but
+  the label above is already applied.
+- A sticky status comment describing the outcome. If auto-merge was enabled, it
+  confirms that; if the auto-merge step failed, it notes that the label was
+  applied anyway and points at the workflow logs so a maintainer can investigate
+  and/or merge manually.
 
 ## What gets skipped
 

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -1,0 +1,162 @@
+"""Tests for the dependabot auto-merge GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow — they only verify its shape. The most important guarantee here is the
+step ordering inside the ``enable-automerge`` job (see issue #423): the
+``ready-to-merge`` label must be applied *before* ``gh pr merge --auto`` is
+invoked so that a failure of the merge call cannot skip the label.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "dependabot-automerge.yml"
+
+
+def _load_workflow() -> dict[str, Any]:
+    """Load and parse the dependabot auto-merge workflow YAML."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _enable_automerge_steps() -> list[dict[str, Any]]:
+    """Return the list of steps in the ``enable-automerge`` job."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["enable-automerge"]
+    steps: list[dict[str, Any]] = job["steps"]
+    return steps
+
+
+class TestDependabotAutomergeWorkflowExists:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The dependabot auto-merge workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+
+
+class TestEnableAutomergeJobShape:
+    """The ``enable-automerge`` job has the expected top-level shape."""
+
+    def test_enable_automerge_job_exists(self) -> None:
+        """Workflow should define the ``enable-automerge`` job."""
+        workflow = _load_workflow()
+        assert "enable-automerge" in workflow["jobs"]
+
+    def test_enable_automerge_needs_evaluate(self) -> None:
+        """``enable-automerge`` must depend on the ``evaluate`` job."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["enable-automerge"]
+        assert job["needs"] == "evaluate"
+
+    def test_enable_automerge_qualifies_guard(self) -> None:
+        """The job should only run when ``evaluate`` reports ``qualifies == 'true'``."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["enable-automerge"]
+        assert job["if"] == "needs.evaluate.outputs.qualifies == 'true'"
+
+
+class TestEnableAutomergeStepOrdering:
+    """Regression guard for issue #423.
+
+    The label must be applied before the auto-merge call so a merge failure
+    cannot skip the label. The sticky comment must run last and use
+    ``if: always()`` so it posts on both success and failure.
+    """
+
+    def test_has_three_steps(self) -> None:
+        """``enable-automerge`` should have exactly three steps."""
+        steps = _enable_automerge_steps()
+        assert len(steps) == 3, f"expected 3 steps, got {len(steps)}: {steps}"
+
+    def test_first_step_is_label(self) -> None:
+        """The label step must run first so it is applied unconditionally.
+
+        This is the core regression guard for issue #423 — if the merge call is
+        reordered to run before the label, a merge failure will skip the label
+        and the Merge Gate will stay red forever.
+        """
+        steps = _enable_automerge_steps()
+        assert steps[0]["name"] == "Add ready-to-merge label"
+
+    def test_label_step_adds_ready_to_merge(self) -> None:
+        """The label step should add the ``ready-to-merge`` label via ``gh pr edit``."""
+        steps = _enable_automerge_steps()
+        label_step = steps[0]
+        assert "--add-label ready-to-merge" in label_step["run"]
+
+    def test_second_step_is_enable_automerge(self) -> None:
+        """The auto-merge call runs second, after the label is already applied."""
+        steps = _enable_automerge_steps()
+        assert steps[1]["name"] == "Enable auto-merge (squash)"
+
+    def test_enable_automerge_step_has_id(self) -> None:
+        """The merge step needs ``id: automerge`` so the comment step can read its outcome."""
+        steps = _enable_automerge_steps()
+        assert steps[1].get("id") == "automerge"
+
+    def test_enable_automerge_step_uses_squash(self) -> None:
+        """The merge step should use the squash strategy with ``--auto``."""
+        steps = _enable_automerge_steps()
+        merge_step = steps[1]
+        assert "gh pr merge --auto --squash" in merge_step["run"]
+
+    def test_third_step_is_sticky_comment(self) -> None:
+        """The sticky status comment runs last."""
+        steps = _enable_automerge_steps()
+        assert steps[2]["name"] == "Post sticky status comment"
+
+
+class TestStickyCommentStep:
+    """The sticky comment step is outcome-aware and always runs."""
+
+    def test_sticky_comment_uses_always(self) -> None:
+        """``if: always()`` ensures the comment runs even when the merge step fails."""
+        steps = _enable_automerge_steps()
+        assert steps[2].get("if") == "always()"
+
+    def test_sticky_comment_uses_github_script(self) -> None:
+        """The sticky comment step should use ``actions/github-script``."""
+        steps = _enable_automerge_steps()
+        assert steps[2]["uses"] == "actions/github-script@v9"
+
+    def test_sticky_comment_exposes_automerge_outcome(self) -> None:
+        """The sticky comment step must expose ``AUTOMERGE_OUTCOME`` via ``env``."""
+        steps = _enable_automerge_steps()
+        env = steps[2].get("env", {})
+        assert env.get("AUTOMERGE_OUTCOME") == "${{ steps.automerge.outcome }}"
+
+    def test_sticky_comment_branches_on_outcome(self) -> None:
+        """The inline script should branch on ``AUTOMERGE_OUTCOME``.
+
+        Branching lets the script emit either the success copy or the
+        failure copy depending on whether the merge call succeeded.
+        """
+        steps = _enable_automerge_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "AUTOMERGE_OUTCOME" in script, (
+            "sticky comment script must reference AUTOMERGE_OUTCOME so it can "
+            "produce a success vs failure body"
+        )
+
+    def test_sticky_comment_retains_dedupe_marker(self) -> None:
+        """The sticky-comment dedupe marker must survive the refactor."""
+        steps = _enable_automerge_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "<!-- dependabot-automerge:status -->" in script
+
+    def test_sticky_comment_deletes_prior_bot_marker_comments(self) -> None:
+        """The dedupe logic (list + delete prior marker comments) must remain."""
+        steps = _enable_automerge_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "deleteComment" in script
+        assert "listComments" in script

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -19,7 +19,7 @@ WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "depend
 
 def _load_workflow() -> dict[str, Any]:
     """Load and parse the dependabot auto-merge workflow YAML."""
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
 def _enable_automerge_steps() -> list[dict[str, Any]]:


### PR DESCRIPTION
## Description

Fixes fragile step ordering in the `enable-automerge` job of `.github/workflows/dependabot-automerge.yml`. Previously, the job ran `gh pr merge --auto --squash` **before** applying the `ready-to-merge` label. When the merge call failed (observed on PR #419 because repo-level "Allow auto-merge" was disabled — `GraphQL: Pull request Auto merge is not allowed for this repository`), the subsequent label and sticky-comment steps were skipped entirely. The PR ended up with no `ready-to-merge` label, no diagnostic comment, and a permanently red Merge Gate check with no signal as to why.

The fix reorders the steps so the label — the durable signal that gates the Merge Gate — is applied unconditionally and first. Auto-merge is treated as a convenience side-effect on top of that. The sticky status comment now runs with `if: always()` and branches on `steps.automerge.outcome`, so it reports success or a label-applied-but-merge-call-failed state regardless of the merge outcome.

### Why reorder vs. `if: always()` vs. `continue-on-error`

Issue #423 listed three candidate fixes. Reordering was chosen because:

- **Reorder (chosen):** Aligns step order with intent — durable state (the label) first, convenience side-effect (auto-merge) second. Step-order is self-documenting; a reader doesn't need to track `if:` predicates across steps to understand the invariant.
- **`if: always()` only:** Would keep the existing step order and guard the label + comment steps. The label would still run after the failing merge call. It works, but the ordering would now *depend* on the `if:` guards rather than step position, which is easier to regress.
- **`continue-on-error`:** Would let the merge step fail soft and leave the label step running afterward. Same effect as reorder, but less explicit: the "I expect this to fail sometimes" signal is hidden inside a step attribute rather than visible in the job's shape.

The sticky-comment step still uses `if: always()` because it must post on both the success and label-only-failure branches. That's an `always()` use with a clear intent — unlike the label step, where `always()` would be papering over a known-bad step order.

### What the new order guarantees

1. `Add ready-to-merge label` — applied first, unconditionally for qualifying PRs.
2. `Enable auto-merge (squash)` — `id: automerge`; may fail without affecting the above.
3. `Post sticky status comment` — `if: always()`; branches on `AUTOMERGE_OUTCOME` to emit either the "auto-merge enabled" body or the "label applied, merge call failed — see logs, maintainer action required" body.

## Related Issue

Addresses #423

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `.github/workflows/dependabot-automerge.yml` — Reordered `enable-automerge` steps: label first, auto-merge second (with `id: automerge`), sticky comment third (`if: always()`, exposes `AUTOMERGE_OUTCOME`, branches success/failure body).
- `docs/development/dependabot-automerge.md` — Updated "Qualifying PRs receive" bullets to describe the new semantics: label is first and unconditional, auto-merge may fail independently, sticky comment covers both outcomes.
- `tests/test_dependabot_automerge_workflow.py` — New structural test module (18 tests) mirroring the `tests/test_benchmark_workflow.py` pattern. Asserts the three-step order inside `enable-automerge`, that the merge step carries `id: automerge`, that the sticky-comment step uses `if: always()`, exposes `AUTOMERGE_OUTCOME`, branches on it, and retains the `<!-- dependabot-automerge:status -->` dedupe marker + delete logic. Serves as a regression guard — if the steps are ever reordered again, these tests fail loudly.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (18 new structural tests, all passing)
- [x] `doit check` passes (format, lint, mypy, bandit, codespell, pytest)

Manual verification plan (post-merge):

- Next qualifying dependabot patch/minor PR: observe that the `ready-to-merge` label is applied even if the `Enable auto-merge (squash)` step fails, and that a sticky comment is posted reflecting the actual outcome.
- To force the failure branch for verification: temporarily disable "Allow auto-merge" at the repo level, let dependabot open a qualifying PR, then re-enable.

## Checklist

- [x] `doit check` passes.
- [x] Tests added (structural assertions on the workflow YAML).
- [x] Documentation updated (`docs/development/dependabot-automerge.md`).
- [x] No breaking changes — workflow-internal reorder; qualifying PRs receive the same label and comment, just more reliably.

## Additional Notes

**Supersedes #429** — #429 was blocked by CodeQL default setup silently refusing to analyze the PR, with no usable lever to force it. The same two commits (`fix: apply ready-to-merge label before gh pr merge …` and `fix: use utf-8 encoding when reading workflow yaml in test`) are cherry-picked here on a fresh branch so CodeQL gets a clean `refs/pull/N/*` to analyze. Issue #431 tracks the underlying CodeQL refactor to advanced setup so this doesn't recur.

**Out of scope (intentional):**

- **#424** (concurrency guard on `pull_request_target` re-evaluation) — separate issue; the label-first ordering is orthogonal to duplicate-run prevention and should ship independently.
- **#428** (swap `GITHUB_TOKEN` for a GitHub App token) — a token change would alter auth semantics repo-wide; rolling it into a targeted ordering fix would expand blast radius and muddy the bisect story.

**No ADR required:** Issue #423 does not carry the `needs-adr` label. A workflow-step-ordering bug fix does not constitute an architectural decision, and no existing ADR in `docs/decisions/` references the dependabot auto-merge workflow.

