### PR TITLE
refactor: convert CodeQL from default setup to advanced workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+name: CodeQL
+
+# Advanced CodeQL setup (replaces GitHub's "default setup").
+#
+# The summary job below is named exactly `CodeQL` (case-sensitive): that
+# string is the required check-run that branch protection on main expects.
+# If this job is renamed, PRs will stop merging until the ruleset is updated.
+# See issue #431 for the migration from default setup to this workflow.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan, Monday 04:27 UTC. Offset from mutation.yml (Sun 00:00) and
+    # dependabot-automerge.yml (every 6h) so they don't contend for runners.
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  CodeQL:
+    # Summary job -- this is the check-run required by the `main` ruleset.
+    # The name MUST be exactly `CodeQL` (case-sensitive) to match branch
+    # protection; renaming it will break merges.
+    name: CodeQL
+    needs: [analyze]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix result
+        env:
+          ANALYZE_RESULT: ${{ needs.analyze.result }}
+        run: |
+          echo "analyze job result: $ANALYZE_RESULT"
+          if [[ "$ANALYZE_RESULT" != "success" ]]; then
+            echo "CodeQL analysis did not succeed for all languages"
+            exit 1
+          fi
+          echo "CodeQL analysis succeeded for all matrix languages"

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -67,7 +67,7 @@ to the default branch.
 | | Allowed merge methods: squash only |
 | **Required status checks** | `require-label` (from the Merge Gate workflow) |
 | | Strict policy: Yes (branch must be up to date) |
-| **Code scanning** | CodeQL -- errors threshold, high-or-higher security alerts |
+| **Required status checks** | `CodeQL` check-run emitted by `.github/workflows/codeql.yml` |
 | **Code quality** | Errors severity threshold |
 | **Bypass actors** | Repository admin role (always) |
 
@@ -132,6 +132,7 @@ each workflow, its trigger, and required permissions.
 | Workflow | File | Trigger | Permissions |
 | :--- | :--- | :--- | :--- |
 | **CI** | `ci.yml` | PR to `main` (opened, synchronize, reopened, labeled), `workflow_dispatch`, `workflow_call` | `contents: read` |
+| **CodeQL** | `codeql.yml` | Push to `main`, PR to `main`, Scheduled (Monday 04:27 UTC) | `contents: read`, `security-events: write`, `actions: read` |
 | **Merge Gate** | `merge-gate.yml` | PR to `main` (opened, labeled, unlabeled, synchronize, reopened) | `contents: read` |
 | **PR Validation** | `pr-checks.yml` | PR (opened, edited, synchronize) | Default |
 | **Breaking Change Detection** | `breaking-change-detection.yml` | PR (opened, synchronize, edited) | `contents: read`, `issues: write`, `pull-requests: write` |
@@ -199,14 +200,16 @@ Security features are configured by `_configure_security_settings()` in
 | **Secret scanning** | Enabled | Detects accidentally committed secrets |
 | **Secret scanning push protection** | Enabled | Blocks pushes containing secrets |
 | **Dependabot security updates** | Enabled | Automatic PRs for vulnerable dependencies |
-| **CodeQL analysis** | Configured | Static analysis for security vulnerabilities |
+| **CodeQL analysis** | Workflow-driven | Runs from `.github/workflows/codeql.yml` on every push to `main`, PR to `main`, and weekly schedule |
 
 !!! note
     Secret scanning and push protection are available for free on public
     repositories. Private repositories require GitHub Advanced Security (GHAS).
 
-**Automated:** Yes, security settings are copied from the template. CodeQL is
-configured separately by `configure_codeql()`.
+**Automated:** Yes, security settings are copied from the template. CodeQL
+runs as a committed GitHub Actions workflow (`.github/workflows/codeql.yml`)
+and is replicated automatically when the template generator copies workflow
+files into a new repository — no extra API call is required.
 
 ## Dependabot
 
@@ -307,6 +310,5 @@ configuration:
 3. **Secrets** -- Add `CODECOV_TOKEN` and optional release app credentials
 4. **CODEOWNERS** -- Replace `@username` with the actual owner
 5. **Dependabot** -- Verify Dependabot is enabled in repository settings
-6. **CodeQL** -- Verify CodeQL is active after initial setup
 
 For the full post-setup checklist, see the [New Project Setup](../template/new-project.md) guide.

--- a/docs/template/manage.md
+++ b/docs/template/manage.md
@@ -71,7 +71,12 @@ Configures GitHub repository settings:
 - Branch protection rulesets
 - Labels
 - GitHub Pages
-- CodeQL code scanning
+
+CodeQL code scanning is configured via the committed workflow file
+`.github/workflows/codeql.yml` rather than an API call, so it replicates
+automatically when the template generator copies workflow files into a new
+repository. No explicit "update repository settings" step is required to
+enable it.
 
 **When to use:** You want to update GitHub settings to match the latest template configuration.
 

--- a/docs/template/tools-reference.md
+++ b/docs/template/tools-reference.md
@@ -368,8 +368,15 @@ Internal module providing functions to configure GitHub repository settings. Use
 | `configure_branch_protection()` | Set up branch protection rulesets |
 | `replicate_labels()` | Copy labels from template repository |
 | `enable_github_pages()` | Enable GitHub Pages for documentation |
-| `configure_codeql()` | Configure CodeQL code scanning |
 | `update_all_repo_settings()` | Convenience function to run all configuration steps |
+
+!!! note "CodeQL scanning is workflow-driven"
+    CodeQL code scanning is configured via the committed
+    `.github/workflows/codeql.yml` workflow rather than an API call. It is
+    replicated automatically when the template generator copies workflow
+    files into a new repository, so no dedicated function (or manual setup
+    step) is required. See issue #431 for the migration from default setup
+    to this advanced workflow file.
 
 ### Usage
 

--- a/tests/pyproject_template/test_repo_settings.py
+++ b/tests/pyproject_template/test_repo_settings.py
@@ -200,42 +200,14 @@ class TestEnableGithubPages:
             assert result is False
 
 
-class TestConfigureCodeql:
-    """Tests for configure_codeql function."""
-
-    def test_configure_codeql_success(self) -> None:
-        """Test successful CodeQL configuration."""
-        from tools.pyproject_template.repo_settings import configure_codeql
-
-        mock_template_codeql = {
-            "state": "configured",
-            "query_suite": "extended",
-            "languages": ["python"],
-        }
-
-        with patch(
-            "tools.pyproject_template.repo_settings.GitHubCLI.api",
-            side_effect=[mock_template_codeql, None],
-        ):
-            result = configure_codeql(repo_full="user/repo")
-            assert result is True
-
-    def test_configure_codeql_not_configured(self) -> None:
-        """Test CodeQL when template doesn't have it configured."""
-        from tools.pyproject_template.repo_settings import configure_codeql
-
-        mock_template_codeql = {"state": "not-configured"}
-
-        with patch(
-            "tools.pyproject_template.repo_settings.GitHubCLI.api",
-            return_value=mock_template_codeql,
-        ):
-            result = configure_codeql(repo_full="user/repo")
-            assert result is True  # Not configured is not a failure
-
-
 class TestUpdateAllRepoSettings:
-    """Tests for update_all_repo_settings convenience function."""
+    """Tests for update_all_repo_settings convenience function.
+
+    CodeQL scanning is intentionally NOT part of this orchestration: it runs
+    from the committed ``.github/workflows/codeql.yml`` workflow file that
+    the template generator copies into every new repository. See issue #431
+    for the migration from the default-setup API to the workflow file.
+    """
 
     def test_update_all_repo_settings_success(self) -> None:
         """Test that update_all_repo_settings calls all configuration functions."""
@@ -258,10 +230,6 @@ class TestUpdateAllRepoSettings:
                 "tools.pyproject_template.repo_settings.enable_github_pages",
                 return_value=True,
             ) as mock_pages,
-            patch(
-                "tools.pyproject_template.repo_settings.configure_codeql",
-                return_value=True,
-            ) as mock_codeql,
         ):
             result = update_all_repo_settings(
                 repo_full="user/repo",
@@ -273,7 +241,6 @@ class TestUpdateAllRepoSettings:
             mock_branch.assert_called_once()
             mock_labels.assert_called_once()
             mock_pages.assert_called_once()
-            mock_codeql.assert_called_once()
 
     def test_update_all_repo_settings_partial_failure(self) -> None:
         """Test that update_all_repo_settings returns False if any step fails."""
@@ -294,10 +261,6 @@ class TestUpdateAllRepoSettings:
             ),
             patch(
                 "tools.pyproject_template.repo_settings.enable_github_pages",
-                return_value=True,
-            ),
-            patch(
-                "tools.pyproject_template.repo_settings.configure_codeql",
                 return_value=True,
             ),
         ):

--- a/tests/test_codeql_workflow.py
+++ b/tests/test_codeql_workflow.py
@@ -1,0 +1,277 @@
+"""Tests for the CodeQL GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape. The central regression guard is the
+summary job name: it must be exactly ``CodeQL`` (case-sensitive) because the
+main-branch ruleset requires a check-run named ``CodeQL``. Renaming that job
+will stop PRs from merging. See issue #431 for context (the migration from
+GitHub's "default setup" to this advanced workflow file).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "codeql.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the CodeQL workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from issue #430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _analyze_steps() -> list[dict[str, Any]]:
+    """Return the list of steps in the ``analyze`` job."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["analyze"]
+    steps: list[dict[str, Any]] = job["steps"]
+    return steps
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The CodeQL workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name_is_codeql(self) -> None:
+        """Top-level workflow name should be ``CodeQL``."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "CodeQL"
+
+
+class TestTriggers:
+    """Triggers: push to main, PR to main, and a weekly schedule."""
+
+    def test_push_triggers_on_main(self) -> None:
+        """Workflow should trigger on push to ``main``.
+
+        PyYAML parses the YAML boolean key ``on`` as ``True``, so we access
+        the triggers via the ``True`` key (or ``"on"`` if quoted). Support
+        both so the test is resilient to how the file was written.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        push = triggers["push"]
+        assert push["branches"] == ["main"]
+
+    def test_pull_request_triggers_on_main(self) -> None:
+        """Workflow should trigger on pull_request targeting ``main``."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        pr = triggers["pull_request"]
+        assert pr["branches"] == ["main"]
+
+    def test_has_weekly_schedule(self) -> None:
+        """Workflow should run on a weekly cron schedule."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        schedule = triggers["schedule"]
+        assert isinstance(schedule, list) and len(schedule) >= 1
+        # Just assert there is a cron entry -- the exact minute/hour is
+        # operational detail and can shift if it collides with other workflows.
+        assert "cron" in schedule[0]
+        assert isinstance(schedule[0]["cron"], str)
+
+
+class TestPermissions:
+    """Top-level permissions match CodeQL's documented minimum."""
+
+    def test_permissions_contents_read(self) -> None:
+        """``contents: read`` is the baseline read permission."""
+        workflow = _load_workflow()
+        permissions = workflow["permissions"]
+        assert permissions["contents"] == "read"
+
+    def test_permissions_security_events_write(self) -> None:
+        """``security-events: write`` lets CodeQL upload SARIF results."""
+        workflow = _load_workflow()
+        permissions = workflow["permissions"]
+        assert permissions["security-events"] == "write"
+
+    def test_permissions_actions_read(self) -> None:
+        """``actions: read`` is required for the Actions language scanner."""
+        workflow = _load_workflow()
+        permissions = workflow["permissions"]
+        assert permissions["actions"] == "read"
+
+
+class TestConcurrency:
+    """Concurrency group cancels stale PR pushes."""
+
+    def test_concurrency_group_keyed_on_ref(self) -> None:
+        """Group should include ``github.head_ref || github.ref`` so each PR
+        and each branch has its own lane."""
+        workflow = _load_workflow()
+        concurrency = workflow["concurrency"]
+        group = concurrency["group"]
+        assert "github.head_ref" in group
+        assert "github.ref" in group
+
+    def test_concurrency_cancel_in_progress(self) -> None:
+        """``cancel-in-progress: true`` so stale runs are superseded."""
+        workflow = _load_workflow()
+        concurrency = workflow["concurrency"]
+        assert concurrency["cancel-in-progress"] is True
+
+
+class TestAnalyzeJob:
+    """The ``analyze`` job runs the actual CodeQL scan."""
+
+    def test_analyze_job_exists(self) -> None:
+        """Workflow should define the ``analyze`` job."""
+        workflow = _load_workflow()
+        assert "analyze" in workflow["jobs"]
+
+    def test_analyze_matrix_languages_exact(self) -> None:
+        """Matrix languages must be exactly ``actions`` and ``python``.
+
+        Expanding the language set is out of scope for #431 and requires a
+        separate decision -- this test guards against accidental drift.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["analyze"]
+        matrix = job["strategy"]["matrix"]
+        assert sorted(matrix["language"]) == ["actions", "python"]
+
+    def test_analyze_matrix_fail_fast_false(self) -> None:
+        """fail-fast: false so one language failing doesn't mask the other."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["analyze"]
+        assert job["strategy"]["fail-fast"] is False
+
+    def test_analyze_uses_checkout_v6(self) -> None:
+        """``actions/checkout`` should be pinned to ``@v6`` (repo convention)."""
+        steps = _analyze_steps()
+        checkout_steps = [s for s in steps if s.get("uses", "").startswith("actions/checkout@")]
+        assert checkout_steps, "expected an actions/checkout step"
+        assert checkout_steps[0]["uses"] == "actions/checkout@v6"
+
+    def test_analyze_uses_codeql_init_v3(self) -> None:
+        """``github/codeql-action/init`` should be pinned to ``@v3``."""
+        steps = _analyze_steps()
+        init_steps = [
+            s for s in steps if s.get("uses", "").startswith("github/codeql-action/init@")
+        ]
+        assert init_steps, "expected a github/codeql-action/init step"
+        assert init_steps[0]["uses"] == "github/codeql-action/init@v3"
+
+    def test_analyze_uses_codeql_analyze_v3(self) -> None:
+        """``github/codeql-action/analyze`` should be pinned to ``@v3``."""
+        steps = _analyze_steps()
+        analyze_steps = [
+            s for s in steps if s.get("uses", "").startswith("github/codeql-action/analyze@")
+        ]
+        assert analyze_steps, "expected a github/codeql-action/analyze step"
+        assert analyze_steps[0]["uses"] == "github/codeql-action/analyze@v3"
+
+    def test_analyze_init_passes_matrix_language(self) -> None:
+        """The init step must receive the matrix language via ``with.languages``."""
+        steps = _analyze_steps()
+        init_step = next(
+            s for s in steps if s.get("uses", "").startswith("github/codeql-action/init@")
+        )
+        assert init_step["with"]["languages"] == "${{ matrix.language }}"
+
+
+class TestSummaryJob:
+    """The ``CodeQL`` summary job is the check-run the ruleset requires.
+
+    This section is the core regression guard for issue #431: the name of the
+    summary job must be exactly ``CodeQL``, case-sensitive, or branch
+    protection will no longer match a required status check and PRs will be
+    permanently blocked.
+    """
+
+    def test_summary_job_key_is_codeql_exact(self) -> None:
+        """The summary job key must be the exact string ``CodeQL``.
+
+        This is the contract with the main-branch ruleset. Do NOT rename.
+        """
+        workflow = _load_workflow()
+        assert "CodeQL" in workflow["jobs"], (
+            "summary job must be named exactly 'CodeQL' (case-sensitive) -- "
+            "this is the required check-run name in the main-branch ruleset"
+        )
+
+    def test_summary_job_explicit_name_is_codeql(self) -> None:
+        """The job's explicit ``name:`` field should also be ``CodeQL``.
+
+        GitHub uses the ``name`` field for the displayed check-run when set,
+        so both the job key and its ``name`` must align.
+        """
+        workflow = _load_workflow()
+        summary = workflow["jobs"]["CodeQL"]
+        assert summary.get("name") == "CodeQL"
+
+    def test_summary_job_needs_analyze(self) -> None:
+        """Summary job must depend on ``analyze`` so it reflects the real result."""
+        workflow = _load_workflow()
+        summary = workflow["jobs"]["CodeQL"]
+        assert summary["needs"] == ["analyze"]
+
+    def test_summary_job_if_always(self) -> None:
+        """``if: always()`` ensures the summary job runs and emits a check-run
+        even when the analyze matrix fails -- otherwise a failed scan would
+        leave the required check in a ``waiting`` state forever."""
+        workflow = _load_workflow()
+        summary = workflow["jobs"]["CodeQL"]
+        assert summary.get("if") == "always()"
+
+    def test_summary_job_fails_when_analyze_fails(self) -> None:
+        """The summary step must exit non-zero when any matrix language failed.
+
+        The guard we care about is that the step inspects
+        ``needs.analyze.result`` somewhere in its definition and exits
+        non-zero on a non-success result. The idiomatic secure pattern is to
+        surface the expression via ``env:`` (so the shell never interpolates
+        ``${{ ... }}`` directly) and read it as a plain shell variable in
+        ``run:``. Accept either location so the test enforces the contract
+        without locking in one scripting style.
+        """
+        workflow = _load_workflow()
+        summary = workflow["jobs"]["CodeQL"]
+        steps = summary["steps"]
+
+        # Combine everything we might want to inspect: env values and run bodies.
+        run_bodies = [step.get("run", "") for step in steps]
+        env_values: list[str] = []
+        for step in steps:
+            env_map = step.get("env", {})
+            if isinstance(env_map, dict):
+                env_values.extend(str(v) for v in env_map.values())
+
+        searchable = "\n".join(run_bodies + env_values)
+
+        assert "needs.analyze.result" in searchable, (
+            "summary job must reference needs.analyze.result (directly in run "
+            "or via env) so it exits non-zero when the matrix fails"
+        )
+
+        combined_runs = "\n".join(run_bodies)
+        assert "exit 1" in combined_runs, (
+            "summary job must explicitly exit non-zero on failure so the "
+            "check-run turns red instead of green"
+        )

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -430,11 +430,12 @@ def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool 
             )
             subprocess.run(["git", "push"], cwd=project_dir, check=True)
 
-        # Now configure branch protection and other GitHub settings
+        # Now configure branch protection and other GitHub settings.
+        # CodeQL scanning is NOT set up here: it runs from the committed
+        # .github/workflows/codeql.yml workflow that was cloned with the repo.
         setup.configure_branch_protection()
         setup.replicate_labels()
         setup.enable_github_pages()
-        setup.configure_codeql()
 
         setup.print_manual_steps()
 
@@ -524,7 +525,6 @@ def action_repo_settings(manager: SettingsManager, dry_run: bool) -> int:
         Logger.info("  - Branch protection rulesets")
         Logger.info("  - Labels")
         Logger.info("  - GitHub Pages")
-        Logger.info("  - CodeQL code scanning")
         return 0
 
     # Import repo_settings module for repository configuration

--- a/tools/pyproject_template/repo_settings.py
+++ b/tools/pyproject_template/repo_settings.py
@@ -3,8 +3,13 @@
 repo_settings.py - GitHub repository settings configuration.
 
 This module provides functions to configure GitHub repository settings,
-branch protection, labels, GitHub Pages, and CodeQL. It can be used
-independently of the full setup process.
+branch protection, labels, and GitHub Pages. It can be used independently
+of the full setup process.
+
+CodeQL scanning is configured via the committed workflow file at
+``.github/workflows/codeql.yml`` (advanced setup) -- no API call is
+required, because the workflow is replicated by the template generator
+along with all other workflow files. See issue #431.
 
 These functions are used by both setup_repo.py (initial setup) and
 manage.py (updating existing repositories).
@@ -395,58 +400,6 @@ def enable_github_pages(repo_full: str) -> bool:
         return False
 
 
-def configure_codeql(
-    repo_full: str,
-    template_repo: str = TEMPLATE_REPO,
-) -> bool:
-    """Configure CodeQL code scanning to match template.
-
-    Args:
-        repo_full: Full repository name (owner/repo)
-        template_repo: Template repository to copy CodeQL config from
-
-    Returns:
-        True if successful, False otherwise
-    """
-    Logger.step("Configuring CodeQL code scanning...")
-
-    try:
-        # Get CodeQL setup from template
-        template_codeql = GitHubCLI.api(f"repos/{template_repo}/code-scanning/default-setup")
-
-        if template_codeql.get("state") != "configured":
-            Logger.info("CodeQL not configured in template, skipping")
-            return True  # Not a failure, just nothing to do
-
-        # Replicate CodeQL configuration
-        codeql_data: dict[str, Any] = {
-            "state": "configured",
-            "query_suite": template_codeql.get("query_suite", "default"),
-        }
-
-        # Add languages if specified (will auto-detect if not provided)
-        if template_codeql.get("languages"):
-            codeql_data["languages"] = template_codeql["languages"]
-
-        GitHubCLI.api(
-            f"repos/{repo_full}/code-scanning/default-setup",
-            method="PATCH",
-            data=codeql_data,
-        )
-        Logger.success(
-            f"CodeQL configured with {template_codeql.get('query_suite', 'default')} query suite"
-        )
-        return True
-
-    except subprocess.CalledProcessError as e:
-        Logger.warning("CodeQL configuration failed")
-        if e.stderr:
-            print(f"  Error: {e.stderr.strip()}")
-        Logger.info("You can configure CodeQL manually at:")
-        Logger.info(f"  https://github.com/{repo_full}/security/code-scanning")
-        return False
-
-
 def update_all_repo_settings(
     repo_full: str,
     description: str,
@@ -456,6 +409,11 @@ def update_all_repo_settings(
     """Update all repository settings to match template.
 
     This is a convenience function that runs all configuration steps.
+
+    Note: CodeQL scanning is NOT configured here -- it is driven by the
+    committed ``.github/workflows/codeql.yml`` workflow file, which the
+    template generator copies into new repositories alongside every other
+    workflow. No API call is required. See issue #431.
 
     Args:
         repo_full: Full repository name (owner/repo)
@@ -471,6 +429,5 @@ def update_all_repo_settings(
         configure_branch_protection(repo_full, template_repo),
         replicate_labels(repo_full, template_repo),
         enable_github_pages(repo_full),
-        configure_codeql(repo_full, template_repo),
     ]
     return all(results)

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -36,7 +36,6 @@ if str(_script_dir) not in sys.path:
 # Import repo settings functions (aliased to avoid shadowing class methods)
 from repo_settings import (  # noqa: E402
     configure_branch_protection as _configure_branch_protection,
-    configure_codeql as _configure_codeql,
     configure_repository_settings as _configure_repository_settings,
     enable_github_pages as _enable_github_pages,
     replicate_labels as _replicate_labels,
@@ -614,13 +613,6 @@ chore: apply code formatting
         """Enable GitHub Pages."""
         _enable_github_pages(repo_full=self.config["repo_full"])
 
-    def configure_codeql(self) -> None:
-        """Configure CodeQL code scanning to match template."""
-        _configure_codeql(
-            repo_full=self.config["repo_full"],
-            template_repo=self.TEMPLATE_FULL,
-        )
-
     def print_manual_steps(self) -> None:
         """Print manual steps that need to be completed."""
         print()
@@ -702,13 +694,15 @@ chore: apply code formatting
         self.gather_inputs()
 
         # Create repository on GitHub and configure all GitHub settings
-        # BEFORE cloning to avoid partial setup if GitHub operations fail
+        # BEFORE cloning to avoid partial setup if GitHub operations fail.
+        # CodeQL scanning is NOT set up here: it runs from the committed
+        # .github/workflows/codeql.yml workflow that the template generator
+        # copies into the new repo automatically.
         self.create_github_repository()
         self.configure_repository_settings()
         self.configure_branch_protection()
         self.replicate_labels()
         self.enable_github_pages()
-        self.configure_codeql()
 
         # Now clone and configure locally
         self.clone_repository()


### PR DESCRIPTION
## Description

Replace GitHub's CodeQL "default setup" with an advanced-setup workflow
committed at `.github/workflows/codeql.yml`. The workflow scans `actions`
and `python` on every push to `main`, every PR to `main`, and on a weekly
cron, and exposes a summary job literally named `CodeQL` so the existing
branch-protection required check continues to match without any ruleset
edit.

### Why

Default setup is opaque about PR handling. When a PR has no changes CodeQL
considers actionable, the check-run can be skipped, reported
`action_required`, or left pending indefinitely -- each looks different in
the merge gate and none of them can be satisfied by pushing more commits.
This bit us on PR #429 and again on PR #432, where the required CodeQL
check refused to resolve and #432 ultimately had to be admin-merged.

Advanced setup puts the workflow definition in-repo: behavior is now
visible, versioned, and reviewable; the check-run always emits a result;
and PR pass/fail is a function of the workflow, not a black-box default
that varies with the change content.

### What

- New `.github/workflows/codeql.yml`
  - Matrix over `[actions, python]` using
    `github/codeql-action/init@v3` + `github/codeql-action/analyze@v3`.
  - Triggers: push to `main`, PR to `main`, weekly cron
    (`27 4 * * 1`, chosen to avoid collision with `mutation.yml` and
    `dependabot-automerge.yml`).
  - Permissions: `contents: read`, `security-events: write`,
    `actions: read` (CodeQL's documented minimum for the Actions scanner).
  - Concurrency:
    `${{ github.workflow }}-${{ github.head_ref || github.ref }}` with
    `cancel-in-progress: true`, so new pushes supersede stale runs.
  - Summary job keyed exactly `CodeQL` (case-sensitive) with
    `if: always()` so the required check-run always materializes, even if
    the matrix fails. This name is the contract with the existing
    main-branch ruleset required check -- **do not rename without
    updating the ruleset first**.

- Removed `configure_codeql()` and every call site
  - `tools/pyproject_template/repo_settings.py`: function deleted;
    `update_all_repo_settings()` no longer calls it. Docstring now
    explains that CodeQL is workflow-driven.
  - `tools/pyproject_template/setup_repo.py`: `SetupRepo.configure_codeql`
    method removed; the `setup()`/`run()` orchestration no longer invokes
    it. Inline comment explains that CodeQL replicates via the workflow
    file copy.
  - `tools/pyproject_template/manage.py`: `setup.configure_codeql()`
    removed from the `create` flow; the "CodeQL code scanning" line
    removed from the dry-run message for `action_repo_settings`.

- Tests
  - `tests/pyproject_template/test_repo_settings.py`: `TestConfigureCodeql`
    class deleted; CodeQL mocks removed from the
    `update_all_repo_settings` integration tests.
  - `tests/test_codeql_workflow.py` (new): 23 structural YAML asserts
    mirroring the `test_dependabot_automerge_workflow.py` pattern, with
    explicit `encoding="utf-8"` on `Path.read_text` (Windows fix from
    issue #430). Central regression guard: the summary job key and its
    `name:` field must both be literally `CodeQL`.

- Documentation
  - `docs/development/github-repository-settings.md`: ruleset row reframed
    as a required status check, new CodeQL row added to the Workflows
    table, Security Settings row flipped from "Configured" to
    "Workflow-driven", manual-steps "Verify CodeQL is active" item
    removed.
  - `docs/template/manage.md`: CodeQL bullet removed from the repo-settings
    list; added a note that CodeQL replicates via the workflow file copy.
  - `docs/template/tools-reference.md`: `configure_codeql()` row removed;
    admonition added explaining the migration.

### Scope

- `configure_codeql()` and all call sites are removed.
- Downstream template consumers get the advanced-setup workflow
  automatically on their next project generation -- the template
  generator already copies every `.github/workflows/*.yml`.
- No change to `.github/workflows/ci.yml`, `merge-gate.yml`, or any other
  workflow.
- No change to the ruleset. The new summary job is intentionally named to
  match the existing required check.

### Explicitly out of scope

These are related but separate issues and are not addressed here:

- Issue #424 -- standardizing `concurrency:` groups across all workflows.
- Issue #428 -- replacing `GITHUB_TOKEN` with a GitHub App token in
  automation workflows.
- Issue #430 -- auditing `Path.read_text` call sites for the missing
  `encoding="utf-8"` latent bug. (The new test file does use
  `encoding="utf-8"`; a broader audit is #430's job.)

## Related Issue

Addresses #431

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `.github/workflows/codeql.yml` (advanced setup, matrix on
  `[actions, python]`, summary job named exactly `CodeQL`).
- Deleted `configure_codeql()` from
  `tools/pyproject_template/repo_settings.py` and removed it from
  `update_all_repo_settings()`.
- Removed `SetupRepo.configure_codeql()` and its call from
  `tools/pyproject_template/setup_repo.py` (`setup()` / `run()`).
- Removed `setup.configure_codeql()` call and the dry-run "CodeQL" line
  from `tools/pyproject_template/manage.py`.
- Removed `TestConfigureCodeql` from
  `tests/pyproject_template/test_repo_settings.py`; dropped CodeQL mocks
  from the `update_all_repo_settings` tests.
- Added `tests/test_codeql_workflow.py` with 23 structural tests.
- Updated `docs/development/github-repository-settings.md`,
  `docs/template/manage.md`, and `docs/template/tools-reference.md` to
  describe the workflow-driven model and remove references to
  `configure_codeql()` and "Verify CodeQL is active".

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Local validation: `doit check` passes (tests + lint + format + type-check
+ security + spell-check). The new workflow itself is GitHub-Actions-only
and is not executed locally; the 23 structural tests in
`tests/test_codeql_workflow.py` are the local regression guard. The
existing `test_repo_settings.py` tests were updated to reflect the
removed function and still pass.

## Post-merge actions

Two admin steps are required after this PR merges. Neither is something
CI can do on our behalf:

1. **Disable CodeQL default setup** to end the dual-scanner window and
   leave the committed workflow as the single source of truth:
   ```bash
   gh api -X PATCH repos/endavis/pyproject-template/code-scanning/default-setup \
     -F state=not-configured
   ```
2. **Confirm the new workflow emits a green `CodeQL` check on the next
   PR.** Until that happens we don't have independent evidence that
   branch protection's required check is resolving against the new
   workflow.

## PR #431 itself may require admin-merge

This PR will likely hit the same merge block that PR #432 did. The
existing default-setup `CodeQL` required check is already broken on PRs
in this repository (that's the whole reason #431 exists), and the new
workflow in this PR cannot retroactively satisfy it -- the new workflow
only becomes the canonical emitter of the `CodeQL` check-run **after**
this PR merges and default setup is disabled in step 1 above.

Expect to admin-merge this PR, then immediately run step 1, then verify
on the next PR that the `CodeQL` check is emitted by the new workflow
file.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Issue #431 is not labeled `needs-adr`. A workflow-file migration is
tooling, not an architectural decision, and no existing ADR in
`docs/decisions/` is invalidated by this change (the directory currently
contains only `adr-template.md` and `README.md`). No ADR is created.
