### PR TITLE
refactor: dedupe dependabot workflow runs via concurrency and label-split

### DIFF
--- a/.github/workflows/ci-full-matrix.yml
+++ b/.github/workflows/ci-full-matrix.yml
@@ -1,0 +1,18 @@
+name: CI (full matrix)
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch full-matrix CI
+    if: github.event.label.name == 'full-matrix'
+    uses: ./.github/workflows/ci.yml
+    with:
+      full_matrix: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,25 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   workflow_call:
+    inputs:
+      full_matrix:
+        description: 'Run the full Python-version matrix (middle versions) instead of the bookend versions.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
-    # Skip CI if triggered by a label event that isn't 'full-matrix'
-    if: github.event.action != 'labeled' || github.event.label.name == 'full-matrix'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -42,7 +50,7 @@ jobs:
           oldest_minor=${oldest#3.}
           newest_minor=${newest#3.}
 
-          if [[ "${{ github.event.label.name }}" == "full-matrix" ]]; then
+          if [[ "${{ inputs.full_matrix }}" == "true" ]]; then
             # Middle versions only (bookends already tested)
             versions=""
             for ((i=oldest_minor+1; i<newest_minor; i++)); do
@@ -167,8 +175,7 @@ jobs:
         run: uv run doit docs_build
 
   ci-complete:
-    # Always run unless this is a non-full-matrix label event
-    if: always() && (github.event.action != 'labeled' || github.event.label.name == 'full-matrix')
+    if: always()
     needs: [setup, test, docs]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,7 +2,7 @@ name: Dependabot Auto-merge
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review]
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
@@ -11,14 +11,17 @@ permissions:
   pull-requests: write
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   evaluate:
     name: Evaluate dependabot PR
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.actor == 'dependabot[bot]' &&
-      github.event.action != 'labeled'
+      github.actor == 'dependabot[bot]'
     outputs:
       qualifies: ${{ steps.decide.outputs.qualifies }}
       reason: ${{ steps.decide.outputs.reason }}
@@ -178,58 +181,6 @@ jobs:
             const body =
               marker +
               `\n⏸️ **Auto-merge skipped:** ${reason}. Human review required.`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
-            for (const c of comments) {
-              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: c.id,
-                });
-              }
-            }
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body,
-            });
-
-  handle-blocked-label:
-    name: Handle blocking label
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.action == 'labeled' &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      (github.event.label.name == 'automerge-blocked' || github.event.label.name == 'do-not-merge')
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      LABEL_NAME: ${{ github.event.label.name }}
-    steps:
-      - name: Disable auto-merge
-        run: gh pr merge --disable-auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" || true
-
-      - name: Remove ready-to-merge label
-        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label ready-to-merge || true
-
-      - name: Post sticky blocked comment
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const prNumber = Number(process.env.PR_NUMBER);
-            const label = process.env.LABEL_NAME;
-            const marker = '<!-- dependabot-automerge:status -->';
-            const body =
-              marker +
-              `\n🛑 **Auto-merge disabled** by \`${label}\` label.`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/dependabot-blocked-label.yml
+++ b/.github/workflows/dependabot-blocked-label.yml
@@ -1,0 +1,62 @@
+name: Dependabot Blocked Label
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  handle-blocked-label:
+    name: Handle blocking label
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      (github.event.label.name == 'automerge-blocked' || github.event.label.name == 'do-not-merge')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      LABEL_NAME: ${{ github.event.label.name }}
+    steps:
+      - name: Disable auto-merge
+        run: gh pr merge --disable-auto "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" || true
+
+      - name: Remove ready-to-merge label
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label ready-to-merge || true
+
+      - name: Post sticky blocked comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const label = process.env.LABEL_NAME;
+            const marker = '<!-- dependabot-automerge:status -->';
+            const body =
+              marker +
+              `\n🛑 **Auto-merge disabled** by \`${label}\` label.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            for (const c of comments) {
+              if (c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -586,6 +586,13 @@ Use this label to trigger comprehensive compatibility testing across all support
 gh pr edit <PR-NUMBER> --add-label "full-matrix"
 ```
 
+Adding the label triggers the dedicated `.github/workflows/ci-full-matrix.yml`
+workflow. That workflow is a thin dispatcher: it fires only on the `labeled`
+event, confirms the label name is `full-matrix`, and then calls `ci.yml` via
+`workflow_call` with `full_matrix: true`. The main `ci.yml` no longer fires on
+label events itself, which keeps the per-push `CI` check from being duplicated
+every time a label is added to a PR.
+
 ### Branch Protection Integration
 
 Configure branch protection rules to require the merge gate:

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -17,6 +17,13 @@ dependabot PR and enables GitHub's native auto-merge for PRs that meet the
 project's safety criteria. Qualifying PRs are merged automatically once the
 required CI checks pass.
 
+The label-driven opt-out path lives in a sibling workflow,
+`.github/workflows/dependabot-blocked-label.yml`, which fires only on
+`pull_request_target: labeled` events. Splitting label handling out of the
+main workflow keeps the `Dependabot Auto-merge` check clean (it runs once per
+PR open/sync, not once per auto-applied label) and lets the main workflow use
+`concurrency: cancel-in-progress: true` safely.
+
 ## What gets auto-merged
 
 A dependabot PR qualifies when **all** of the following are true:
@@ -53,12 +60,16 @@ Skipped PRs require a human reviewer to merge them using the normal workflow.
 ## The `automerge-blocked` opt-out
 
 To stop auto-merge on a PR that already qualified, add the label
-`automerge-blocked` (or `do-not-merge`). The workflow reacts to the `labeled`
-event:
+`automerge-blocked` (or `do-not-merge`). The `dependabot-blocked-label.yml`
+workflow reacts to the `labeled` event:
 
 - Disables GitHub's auto-merge on the PR.
 - Removes the `ready-to-merge` label.
 - Posts a sticky comment recording the block.
+
+Both workflows share the same `<!-- dependabot-automerge:status -->` sticky
+comment marker, so toggling the block updates the existing comment instead of
+producing a thread of status messages.
 
 ## Configuration
 
@@ -96,4 +107,5 @@ does not spam the bot while a rebase is in progress.
 
 - `AGENTS.md` section [Dependabot PRs](../../AGENTS.md#dependabot-prs)
 - `.github/workflows/dependabot-automerge.yml`
+- `.github/workflows/dependabot-blocked-label.yml`
 - `.github/automerge-config.json`

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -99,7 +99,7 @@ To add a label: edit `.github/labels.yml`, run `doit labels_sync --dry-run` to p
 | `documentation` | `#0075ca` | Improvements or additions to documentation | Issue template, release notes |
 | `duplicate` | `#cfd3d7` | This issue or pull request already exists | Manual triage |
 | `enhancement` | `#a2eeef` | New feature or request | Issue template, release notes |
-| `full-matrix` | `#1D76DB` | Run CI on all supported Python versions | CI workflow (triggers full matrix) |
+| `full-matrix` | `#1D76DB` | Run CI on all supported Python versions | `CI (full matrix)` workflow (dispatches `ci.yml` with `full_matrix: true`) |
 | `github_actions` | `#000000` | Pull requests that update GitHub Actions code | Dependabot PRs |
 | `good first issue` | `#7057ff` | Good for newcomers | Manual triage |
 | `help wanted` | `#008672` | Extra attention is needed | Manual triage |
@@ -131,7 +131,8 @@ each workflow, its trigger, and required permissions.
 
 | Workflow | File | Trigger | Permissions |
 | :--- | :--- | :--- | :--- |
-| **CI** | `ci.yml` | PR to `main` (opened, synchronize, reopened, labeled), `workflow_dispatch`, `workflow_call` | `contents: read` |
+| **CI** | `ci.yml` | PR to `main` (opened, synchronize, reopened), `workflow_dispatch`, `workflow_call` | `contents: read` |
+| **CI (full matrix)** | `ci-full-matrix.yml` | PR to `main` (labeled with `full-matrix`) -- dispatches `ci.yml` with `full_matrix: true` | `contents: read` |
 | **CodeQL** | `codeql.yml` | Push to `main`, PR to `main`, Scheduled (Monday 04:27 UTC) | `contents: read`, `security-events: write`, `actions: read` |
 | **Merge Gate** | `merge-gate.yml` | PR to `main` (opened, labeled, unlabeled, synchronize, reopened) | `contents: read` |
 | **PR Validation** | `pr-checks.yml` | PR (opened, edited, synchronize) | Default |
@@ -144,8 +145,10 @@ each workflow, its trigger, and required permissions.
 ### Key workflow details
 
 - **CI** uses a matrix strategy with Python versions from
-  `.github/python-versions.json`. Adding the `full-matrix` label to a PR runs
-  all versions; otherwise, only the bookend versions are tested.
+  `.github/python-versions.json`; only the bookend versions are tested on
+  every push. Adding the `full-matrix` label to a PR triggers the dedicated
+  `CI (full matrix)` workflow, which calls `ci.yml` with
+  `full_matrix: true` to cover the middle versions.
 - **Merge Gate** requires the `ready-to-merge` label on a PR before the
   `require-label` status check passes. This is a manual gate added by a reviewer.
 - **Release** publishes to TestPyPI first, then PyPI, then creates a GitHub

--- a/tests/test_ci_full_matrix_workflow.py
+++ b/tests/test_ci_full_matrix_workflow.py
@@ -1,0 +1,140 @@
+"""Tests for the CI (full matrix) dispatch workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape.
+
+This workflow exists to preserve the ``full-matrix`` label UX (adding the
+label on a PR triggers a run across the middle Python versions) while keeping
+the ``labeled`` event off the main ``ci.yml`` trigger list (see issue #424).
+The dispatch job is a thin wrapper: a single ``if:`` guard checks the label
+name, then delegates to ``ci.yml`` via ``workflow_call`` with
+``full_matrix: true``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "ci-full-matrix.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the CI full-matrix workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from issue #430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The CI full-matrix workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name(self) -> None:
+        """The workflow name is the user-facing check-run label."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "CI (full matrix)"
+
+
+class TestTriggers:
+    """Trigger configuration: pull_request ``labeled`` only."""
+
+    def test_only_trigger_is_pull_request(self) -> None:
+        """The workflow should have exactly one trigger: ``pull_request``.
+
+        Adding other triggers would break the isolation that issue #424
+        establishes between label-driven runs and push-driven runs.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        assert list(triggers.keys()) == ["pull_request"], (
+            "workflow should trigger on pull_request only so label-driven "
+            "full-matrix runs stay isolated (issue #424)"
+        )
+
+    def test_pull_request_types_is_labeled_only(self) -> None:
+        """The only event type should be ``labeled``.
+
+        This is the core regression guard for issue #424: the whole point
+        of this workflow is to absorb the ``labeled`` trigger so the main
+        ``ci.yml`` no longer fires on every label event.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request"]["types"]
+        assert types == ["labeled"], f"expected types: [labeled], got {types}"
+
+    def test_pull_request_branches_is_main(self) -> None:
+        """The workflow targets PRs to ``main``, matching ``ci.yml``'s scope."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        branches = triggers["pull_request"]["branches"]
+        assert branches == ["main"]
+
+
+class TestDispatchJob:
+    """The ``dispatch`` job delegates to ``ci.yml`` via ``workflow_call``."""
+
+    def test_dispatch_job_exists(self) -> None:
+        """Workflow should define the ``dispatch`` job."""
+        workflow = _load_workflow()
+        assert "dispatch" in workflow["jobs"]
+
+    def test_dispatch_if_filters_on_full_matrix_label(self) -> None:
+        """The job's ``if:`` must filter on the ``full-matrix`` label.
+
+        Without this guard, *any* label applied to a PR would dispatch a
+        full-matrix CI run -- a massive waste of minutes.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job["if"] == "github.event.label.name == 'full-matrix'"
+
+    def test_dispatch_uses_local_ci_workflow(self) -> None:
+        """The job must call ``./.github/workflows/ci.yml`` via ``workflow_call``.
+
+        The local path (``./...``) is important: using a remote reference
+        would run a possibly-different version of the reusable workflow.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job["uses"] == "./.github/workflows/ci.yml"
+
+    def test_dispatch_passes_full_matrix_true(self) -> None:
+        """The job must pass ``full_matrix: true`` to the reusable workflow.
+
+        This is what actually flips the matrix from bookend versions to
+        middle versions. If the input is omitted or passed as ``false``,
+        the full-matrix label will silently not do anything.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job["with"]["full_matrix"] is True
+
+    def test_dispatch_inherits_secrets(self) -> None:
+        """``secrets: inherit`` so the reusable workflow can reach secrets
+        like ``CODECOV_TOKEN``."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["dispatch"]
+        assert job.get("secrets") == "inherit"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,166 @@
+"""Tests for the CI GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape.
+
+Scope is intentionally minimal: we guard the three invariants that matter for
+issue #424:
+
+1. ``labeled`` is NOT in the ``pull_request`` event type list. Keeping it
+   there would cause every auto-applied label on a dependabot PR to spawn a
+   duplicate CI run (the motivation for the split introduced in #424).
+2. A workflow-level ``concurrency`` block exists with ``cancel-in-progress:
+   true`` and a key that includes ``github.head_ref || github.ref``. This
+   ensures a new push to a PR cancels the in-flight run on the prior commit.
+3. The ``workflow_call`` trigger exposes a ``full_matrix`` boolean input
+   (default ``false``) so the sibling ``ci-full-matrix.yml`` workflow can
+   dispatch the full-matrix run via ``uses: ./.github/workflows/ci.yml``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "ci.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the CI workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from issue #430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The CI workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name(self) -> None:
+        """The workflow name is ``CI`` -- the required check-run in branch
+        protection and the name referenced by ``ci-full-matrix.yml``."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "CI"
+
+
+class TestPullRequestTriggerHasNoLabeledType:
+    """The main CI workflow should no longer fire on label events (issue #424).
+
+    Label-driven full-matrix runs are handled by ``ci-full-matrix.yml``, which
+    calls this workflow via ``workflow_call``. Leaving ``labeled`` in the
+    trigger list here would re-introduce the duplicate-run problem.
+    """
+
+    def test_labeled_not_in_pull_request_types(self) -> None:
+        """The ``labeled`` event type must NOT appear in ``pull_request.types``."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        pr = triggers["pull_request"]
+        types = pr["types"]
+        assert "labeled" not in types, (
+            f"'labeled' must not be in pull_request.types; got {types}. "
+            "Label-driven runs are handled by ci-full-matrix.yml (issue #424)."
+        )
+
+    def test_pull_request_types_cover_core_lifecycle(self) -> None:
+        """The PR trigger must still cover the core lifecycle events.
+
+        We keep ``opened``, ``synchronize``, and ``reopened`` so that CI runs
+        on every push and on reopened PRs. Removing any of these would leave
+        a PR without CI coverage.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request"]["types"]
+        for required in ("opened", "synchronize", "reopened"):
+            assert required in types, f"pull_request.types missing '{required}': {types}"
+
+
+class TestConcurrency:
+    """Workflow-level concurrency block cancels stale runs on new pushes."""
+
+    def test_concurrency_block_exists(self) -> None:
+        """The workflow must declare a top-level ``concurrency`` block."""
+        workflow = _load_workflow()
+        assert "concurrency" in workflow, "workflow must declare a concurrency block"
+
+    def test_concurrency_group_keyed_on_ref(self) -> None:
+        """The group key must reference ``head_ref || ref``.
+
+        ``head_ref`` is only set for PR events and points at the PR's source
+        branch; ``ref`` is the fallback for push/schedule/dispatch events.
+        Using the pair gives each PR its own concurrency lane while still
+        scoping main-branch runs to ``refs/heads/main``.
+        """
+        workflow = _load_workflow()
+        group: str = workflow["concurrency"]["group"]
+        assert "github.head_ref" in group
+        assert "github.ref" in group
+
+    def test_concurrency_cancel_in_progress(self) -> None:
+        """``cancel-in-progress: true`` supersedes stale runs on a new push."""
+        workflow = _load_workflow()
+        assert workflow["concurrency"]["cancel-in-progress"] is True
+
+
+class TestWorkflowCallInputs:
+    """``workflow_call`` exposes a ``full_matrix`` boolean input."""
+
+    def test_workflow_call_present(self) -> None:
+        """The workflow must be callable as a reusable workflow.
+
+        ``ci-full-matrix.yml`` invokes this workflow via
+        ``uses: ./.github/workflows/ci.yml``; removing ``workflow_call``
+        here breaks the full-matrix dispatch path.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        assert "workflow_call" in triggers
+
+    def test_workflow_call_has_full_matrix_input(self) -> None:
+        """``workflow_call.inputs.full_matrix`` must be declared."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        wc = triggers["workflow_call"]
+        assert wc is not None, "workflow_call must declare an inputs block"
+        assert "inputs" in wc
+        assert "full_matrix" in wc["inputs"]
+
+    def test_full_matrix_input_is_boolean(self) -> None:
+        """The ``full_matrix`` input must be declared as a boolean."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        fm = triggers["workflow_call"]["inputs"]["full_matrix"]
+        assert fm["type"] == "boolean"
+
+    def test_full_matrix_input_defaults_false(self) -> None:
+        """The default must be ``false`` so plain ``workflow_call`` runs
+        the bookend matrix, matching the pre-#424 behavior."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        fm = triggers["workflow_call"]["inputs"]["full_matrix"]
+        assert fm["default"] is False

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -5,6 +5,11 @@ workflow — they only verify its shape. The most important guarantee here is th
 step ordering inside the ``enable-automerge`` job (see issue #423): the
 ``ready-to-merge`` label must be applied *before* ``gh pr merge --auto`` is
 invoked so that a failure of the merge call cannot skip the label.
+
+Issue #424 split the blocked-label handler out into a sibling workflow
+(``dependabot-blocked-label.yml``) so this workflow no longer fires on
+``labeled`` events. The ``TestOnTriggers`` and ``TestConcurrency`` classes
+below guard that split.
 """
 
 from __future__ import annotations
@@ -17,8 +22,12 @@ import yaml
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "dependabot-automerge.yml"
 
 
-def _load_workflow() -> dict[str, Any]:
-    """Load and parse the dependabot auto-merge workflow YAML."""
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the dependabot auto-merge workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+    """
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
@@ -160,3 +169,79 @@ class TestStickyCommentStep:
         script: str = steps[2]["with"]["script"]
         assert "deleteComment" in script
         assert "listComments" in script
+
+
+class TestOnTriggers:
+    """Trigger configuration: the ``labeled`` event is handled elsewhere.
+
+    Issue #424 moved label-driven handling to ``dependabot-blocked-label.yml``.
+    Leaving ``labeled`` in the trigger list here would re-introduce the
+    duplicate-run problem on dependabot PRs (each auto-applied label fires a
+    separate workflow run).
+    """
+
+    def test_labeled_not_in_pull_request_target_types(self) -> None:
+        """The ``labeled`` event type must NOT appear in ``pull_request_target.types``.
+
+        This is the core regression guard for issue #424.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        types = triggers["pull_request_target"]["types"]
+        assert "labeled" not in types, (
+            f"'labeled' must not be in pull_request_target.types; got {types}. "
+            "Label-driven handling is in dependabot-blocked-label.yml (issue #424)."
+        )
+
+    def test_pull_request_target_types_cover_core_lifecycle(self) -> None:
+        """The PR trigger must still cover the core lifecycle events so the
+        main evaluate/enable-automerge flow still runs on every open/sync."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request_target"]["types"]
+        for required in ("opened", "reopened", "synchronize", "ready_for_review"):
+            assert required in types, f"pull_request_target.types missing '{required}': {types}"
+
+    def test_schedule_and_workflow_dispatch_retained(self) -> None:
+        """``schedule`` and ``workflow_dispatch`` drive the rebase-requester job,
+        so they must remain triggers on this workflow."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        assert "schedule" in triggers
+        assert "workflow_dispatch" in triggers
+
+
+class TestConcurrency:
+    """Workflow-level concurrency block dedupes in-flight runs per PR.
+
+    The concurrency block is only safe to add after the ``labeled`` trigger
+    split in issue #424: prior to the split, a labeled event arriving shortly
+    after an ``opened`` event would cancel the in-flight ``evaluate`` job
+    mid-run. With label events routed to ``dependabot-blocked-label.yml``,
+    cancelling stale runs on this workflow is safe.
+    """
+
+    def test_concurrency_block_exists(self) -> None:
+        """The workflow must declare a top-level ``concurrency`` block."""
+        workflow = _load_workflow()
+        assert "concurrency" in workflow, "workflow must declare a concurrency block"
+
+    def test_concurrency_group_keyed_on_pr_number_or_ref(self) -> None:
+        """The group key must reference ``pull_request.number`` and ``github.ref``.
+
+        ``pull_request.number`` isolates PR runs from each other;
+        ``github.ref`` is the fallback for schedule/workflow_dispatch runs
+        that have no PR context.
+        """
+        workflow = _load_workflow()
+        group: str = workflow["concurrency"]["group"]
+        assert "pull_request.number" in group or "github.event.pull_request.number" in group
+        assert "github.ref" in group
+
+    def test_concurrency_cancel_in_progress(self) -> None:
+        """``cancel-in-progress: true`` supersedes stale runs on a new PR push."""
+        workflow = _load_workflow()
+        assert workflow["concurrency"]["cancel-in-progress"] is True

--- a/tests/test_dependabot_blocked_label_workflow.py
+++ b/tests/test_dependabot_blocked_label_workflow.py
@@ -1,0 +1,208 @@
+"""Tests for the dependabot blocked-label GitHub Actions workflow configuration.
+
+These tests are structural asserts on the parsed YAML. They do not execute the
+workflow -- they only verify its shape. This workflow was split out from
+``dependabot-automerge.yml`` in issue #424 so that the ``labeled`` trigger no
+longer fires the main auto-merge workflow on every auto-applied dependabot
+label (see the Context section of that issue's plan for the motivation).
+
+The central regression guards here are:
+
+1. The workflow triggers on ``pull_request_target: labeled`` only -- no other
+   event types. Adding ``opened`` or ``synchronize`` would defeat the whole
+   purpose of the split.
+2. The ``handle-blocked-label`` job preserves the exact ``if:`` conditions and
+   step sequence from the original job (disable auto-merge -> remove
+   ``ready-to-merge`` label -> post sticky comment). The sticky-comment marker
+   must survive intact so that the dedupe logic in ``dependabot-automerge.yml``
+   and this workflow share a single comment slot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).parent.parent / ".github" / "workflows" / "dependabot-blocked-label.yml"
+)
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the dependabot blocked-label workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
+    PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
+    non-ASCII content in the workflow file (lesson from issue #430).
+    """
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _handle_blocked_label_steps() -> list[dict[str, Any]]:
+    """Return the list of steps in the ``handle-blocked-label`` job."""
+    workflow = _load_workflow()
+    job = workflow["jobs"]["handle-blocked-label"]
+    steps: list[dict[str, Any]] = job["steps"]
+    return steps
+
+
+class TestWorkflowFile:
+    """The workflow file exists and parses as YAML."""
+
+    def test_workflow_file_exists(self) -> None:
+        """The dependabot blocked-label workflow YAML file should exist."""
+        assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        """The workflow file should be valid YAML with a jobs dict."""
+        workflow = _load_workflow()
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+        assert isinstance(workflow["jobs"], dict)
+
+    def test_workflow_name(self) -> None:
+        """The workflow name is the user-facing check-run label."""
+        workflow = _load_workflow()
+        assert workflow.get("name") == "Dependabot Blocked Label"
+
+
+class TestTriggers:
+    """Trigger configuration: ``labeled`` only, no other event types."""
+
+    def test_only_trigger_is_pull_request_target(self) -> None:
+        """The workflow should have exactly one trigger: ``pull_request_target``."""
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None, "workflow has no triggers block"
+        assert list(triggers.keys()) == ["pull_request_target"], (
+            "workflow should trigger on pull_request_target only; other triggers "
+            "would defeat the split from dependabot-automerge.yml (issue #424)"
+        )
+
+    def test_pull_request_target_types_is_labeled_only(self) -> None:
+        """The only event type should be ``labeled``.
+
+        This is the core regression guard for issue #424: the whole point of
+        this workflow is to absorb the ``labeled`` event so the main
+        auto-merge workflow no longer runs on every auto-applied label.
+        """
+        workflow = _load_workflow()
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers is not None
+        types = triggers["pull_request_target"]["types"]
+        assert types == ["labeled"], f"expected types: [labeled], got {types}"
+
+
+class TestPermissions:
+    """Top-level permissions follow the principle of least privilege."""
+
+    def test_permissions_pull_requests_write(self) -> None:
+        """The job edits labels and toggles auto-merge, so it needs PR write access."""
+        workflow = _load_workflow()
+        assert workflow["permissions"]["pull-requests"] == "write"
+
+    def test_permissions_contents_read(self) -> None:
+        """``contents: read`` is the baseline; this workflow does not write to the repo.
+
+        Notably we do NOT copy ``contents: write`` from the parent
+        ``dependabot-automerge.yml``. That permission was there for the
+        ``request-rebase`` job, which stays in the parent workflow. This
+        workflow only needs to edit PR labels and comments.
+        """
+        workflow = _load_workflow()
+        assert workflow["permissions"]["contents"] == "read"
+
+
+class TestHandleBlockedLabelJob:
+    """The ``handle-blocked-label`` job preserves the shape of the original job."""
+
+    def test_job_exists(self) -> None:
+        """Workflow should define the ``handle-blocked-label`` job."""
+        workflow = _load_workflow()
+        assert "handle-blocked-label" in workflow["jobs"]
+
+    def test_job_name(self) -> None:
+        """The user-facing job name should be ``Handle blocking label``."""
+        workflow = _load_workflow()
+        job = workflow["jobs"]["handle-blocked-label"]
+        assert job["name"] == "Handle blocking label"
+
+    def test_job_if_guards_dependabot_and_blocking_labels(self) -> None:
+        """The ``if:`` guard must match the original from ``dependabot-automerge.yml``.
+
+        The guard has four parts:
+
+        1. ``github.event_name == 'pull_request_target'`` -- sanity check.
+        2. ``github.event.action == 'labeled'`` -- explicit action filter.
+        3. ``github.event.pull_request.user.login == 'dependabot[bot]'`` --
+           only act on dependabot PRs.
+        4. label name is ``automerge-blocked`` or ``do-not-merge``.
+
+        Any of these going missing is a behavior change the test must catch.
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["handle-blocked-label"]
+        guard: str = job["if"]
+        assert "github.event_name == 'pull_request_target'" in guard
+        assert "github.event.action == 'labeled'" in guard
+        assert "github.event.pull_request.user.login == 'dependabot[bot]'" in guard
+        assert "github.event.label.name == 'automerge-blocked'" in guard
+        assert "github.event.label.name == 'do-not-merge'" in guard
+
+    def test_job_env_exposes_pr_number_and_label_name(self) -> None:
+        """The job exposes ``PR_NUMBER`` and ``LABEL_NAME`` via ``env`` so the
+        subsequent steps can read them as shell variables (the secure pattern
+        that avoids direct ``${{ ... }}`` interpolation in ``run``).
+        """
+        workflow = _load_workflow()
+        job = workflow["jobs"]["handle-blocked-label"]
+        env = job["env"]
+        assert env["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
+        assert env["LABEL_NAME"] == "${{ github.event.label.name }}"
+        assert env["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+
+
+class TestHandleBlockedLabelSteps:
+    """Step ordering mirrors the original job: disable -> unlabel -> comment."""
+
+    def test_has_three_steps(self) -> None:
+        """The job should have exactly three steps, matching the original."""
+        steps = _handle_blocked_label_steps()
+        assert len(steps) == 3, f"expected 3 steps, got {len(steps)}: {steps}"
+
+    def test_first_step_disables_auto_merge(self) -> None:
+        """Step 1 disables GitHub auto-merge via ``gh pr merge --disable-auto``."""
+        steps = _handle_blocked_label_steps()
+        assert steps[0]["name"] == "Disable auto-merge"
+        assert "gh pr merge --disable-auto" in steps[0]["run"]
+
+    def test_second_step_removes_ready_to_merge_label(self) -> None:
+        """Step 2 removes the ``ready-to-merge`` label so the Merge Gate blocks the PR."""
+        steps = _handle_blocked_label_steps()
+        assert steps[1]["name"] == "Remove ready-to-merge label"
+        assert "--remove-label ready-to-merge" in steps[1]["run"]
+
+    def test_third_step_posts_sticky_blocked_comment(self) -> None:
+        """Step 3 posts the sticky blocked comment via ``actions/github-script``."""
+        steps = _handle_blocked_label_steps()
+        assert steps[2]["name"] == "Post sticky blocked comment"
+        assert steps[2]["uses"] == "actions/github-script@v9"
+
+    def test_sticky_comment_retains_dedupe_marker(self) -> None:
+        """The sticky-comment dedupe marker must match the parent workflow's marker
+        so both workflows share a single comment slot on the PR."""
+        steps = _handle_blocked_label_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "<!-- dependabot-automerge:status -->" in script
+
+    def test_sticky_comment_deletes_prior_bot_marker_comments(self) -> None:
+        """The dedupe logic (list + delete prior marker comments) must remain."""
+        steps = _handle_blocked_label_steps()
+        script: str = steps[2]["with"]["script"]
+        assert "deleteComment" in script
+        assert "listComments" in script


### PR DESCRIPTION
## Description

Split the label-driven paths out of `dependabot-automerge.yml` and `ci.yml` so we
can safely add workflow-level concurrency groups that dedupe the duplicate
workflow runs dependabot triggers. When dependabot opens a PR, GitHub fires one
`opened` event plus one `labeled` event per auto-applied label (`dependencies`,
`automated`, sometimes more), which previously spawned 3-4 runs each of
`Dependabot Auto-merge` and `CI`. A plain `concurrency: cancel-in-progress: true`
on the existing workflows would have cancelled the in-flight evaluation job
whenever a follow-up label event arrived, so the fix is structural: move the
label-handling jobs to their own workflows and let the main workflows run once
per PR open/sync.

## Related Issue

Addresses #424

## Type of Change

- [x] Code refactoring

## Changes Made

- `.github/workflows/dependabot-automerge.yml`: removed `labeled` from
  `pull_request_target.types`, deleted the `handle-blocked-label` job (moved to
  new workflow), and added a workflow-level `concurrency` block keyed on
  `pull_request.number || ref` with `cancel-in-progress: true`.
- `.github/workflows/dependabot-blocked-label.yml` (new): single-purpose workflow
  reacting to `pull_request_target: labeled`. Holds the `handle-blocked-label`
  job verbatim from the old auto-merge workflow (disable auto-merge, remove
  `ready-to-merge`, post sticky block comment). No concurrency block - the job
  is idempotent and running it per label change is correct.
- `.github/workflows/ci.yml`: removed `labeled` from `pull_request.types`, added
  `workflow_call.inputs.full_matrix` boolean, added workflow-level `concurrency`
  keyed on `head_ref || ref`, replaced the `github.event.label.name ==
  'full-matrix'` check with `inputs.full_matrix`, and simplified
  `ci-complete.if:` to `always()` since the label guard is no longer needed.
- `.github/workflows/ci-full-matrix.yml` (new): thin dispatcher on
  `pull_request: labeled`. Confirms the label is `full-matrix` and then calls
  `ci.yml` via `workflow_call` with `full_matrix: true`. Preserves the existing
  user-facing UX (add the label to trigger the middle-versions matrix).
- `tests/test_dependabot_automerge_workflow.py`: added `TestOnTriggers` and
  `TestConcurrency` classes asserting `labeled` is absent and the concurrency
  block is present. Removed tests that referenced the deleted
  `handle-blocked-label` job (they now live in the new test file).
- `tests/test_dependabot_blocked_label_workflow.py` (new): asserts trigger types
  is exactly `[labeled]`, the `handle-blocked-label` job exists with the
  expected dependabot-bot + blocking-label `if:` guards, and the three steps
  (disable auto-merge, remove ready-to-merge, sticky comment) are present.
- `tests/test_ci_workflow.py` (new): asserts `labeled` is not in
  `pull_request.types`, the concurrency block exists with `cancel-in-progress:
  true` keyed on `head_ref || ref`, and the `workflow_call.inputs.full_matrix`
  boolean input is declared with `default: false`.
- `tests/test_ci_full_matrix_workflow.py` (new): asserts trigger types is
  `[labeled]`, the dispatch job `uses: ./.github/workflows/ci.yml` with
  `full_matrix: true`, and the job `if:` checks the label name.
- `docs/development/dependabot-automerge.md`: one-paragraph note about the
  split, plus updated cross-references so the `automerge-blocked` opt-out
  section points at the sibling workflow.
- `docs/development/ci-cd-testing.md`: `full-matrix` label description updated
  to point at `ci-full-matrix.yml` as the entry point.
- `docs/development/github-repository-settings.md`: label table entry for
  `full-matrix` now names the dedicated workflow; workflow table updated with
  the `CI (full matrix)` row; key-workflow-details bullet reworded to match the
  new dispatcher structure; `CI` trigger row no longer lists `labeled`.

## Testing

- [x] All existing tests pass (`doit check` passes locally)
- [x] Added new tests for new functionality (three new structural YAML test
      files; existing auto-merge test file updated to match the new shape)
- [x] Manually reviewed each modified workflow for valid YAML structure

### Self-test on this PR

- [ ] `Dependabot Auto-merge` does NOT appear as a check on this PR (this PR is
      not from dependabot).
- [ ] `CI` fires exactly once per push - no SKIPPED label-event duplicates.
- [ ] `CI (full matrix)` does NOT fire unless a reviewer manually adds the
      `full-matrix` label.

### Post-merge verification (on the next real dependabot PR)

- [ ] Exactly one run of `Dependabot Auto-merge` per PR open/sync (no SKIPPED
      label-event duplicates).
- [ ] `Dependabot Blocked Label` fires under its own workflow name on label
      changes, keeping the main auto-merge check clean.
- [ ] `CI` runs once per open/sync; `CI (full matrix)` runs only when the
      `full-matrix` label is added.
- [ ] Manually adding `automerge-blocked` to a qualifying dependabot PR
      triggers `dependabot-blocked-label.yml` and disables auto-merge (regression
      guard for the original caveat in #424).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (N/A - CHANGELOG is auto-generated from
      conventional commits at release time)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required. Issue #424 is labeled `refactor`, not `needs-adr`. This is a
  mechanical change to workflow structure; the scanning/testing goals and
  coverage are unchanged. Only the event-trigger mechanism moves.
- Concurrency groups were intentionally *not* added to `merge-gate.yml`,
  `benchmark.yml`, `mutation.yml`, or the release workflows. They do not share
  the duplicate-label-run problem (no `labeled` triggers driving full job runs).
  Can be addressed in a follow-up if it becomes necessary.
- The `full-matrix` user-facing UX is preserved: add the label, the full matrix
  runs. The mechanism (dedicated dispatcher workflow vs. `if:` on a matrix job)
  is the only thing that changed.
