### PR TITLE
fix: complete release task wiring (cz --yes, action params, gh search)

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -25,6 +25,7 @@ from rich.console import Console
 from tools.doit.base import run_streamed, run_teed
 from tools.doit.release import (
     _build_cz_get_next_cmd,
+    _extract_next_version_from_cz_output,
     _extract_version_from_release_pr,
     validate_merge_commits,
 )
@@ -382,36 +383,36 @@ class TestBuildCzGetNextCmd:
         ("increment", "prerelease", "expected"),
         [
             # No flags: base command only.
-            ("", "", ["uv", "run", "cz", "bump", "--get-next"]),
+            ("", "", ["uv", "run", "cz", "bump", "--get-next", "--yes"]),
             # Increment alone (lowercase input is uppercased).
             (
                 "minor",
                 "",
-                ["uv", "run", "cz", "bump", "--get-next", "--increment", "MINOR"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--increment", "MINOR"],
             ),
             # Increment alone (already uppercase stays uppercase).
             (
                 "PATCH",
                 "",
-                ["uv", "run", "cz", "bump", "--get-next", "--increment", "PATCH"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--increment", "PATCH"],
             ),
             # Prerelease alone: alpha.
             (
                 "",
                 "alpha",
-                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "alpha"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "alpha"],
             ),
             # Prerelease alone: beta.
             (
                 "",
                 "beta",
-                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "beta"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "beta"],
             ),
             # Prerelease alone: rc.
             (
                 "",
                 "rc",
-                ["uv", "run", "cz", "bump", "--get-next", "--prerelease", "rc"],
+                ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "rc"],
             ),
             # Both set: helper does NOT validate; the task is responsible for
             # rejecting this combination. Helper just emits both flags in
@@ -425,6 +426,7 @@ class TestBuildCzGetNextCmd:
                     "cz",
                     "bump",
                     "--get-next",
+                    "--yes",
                     "--increment",
                     "MINOR",
                     "--prerelease",
@@ -532,3 +534,141 @@ class TestValidateMergeCommits:
         monkeypatch.setattr("tools.doit.release.subprocess.run", fake)
 
         assert validate_merge_commits(self._silent_console()) is False
+
+
+class TestExtractNextVersionFromCzOutput:
+    """Tests for ``_extract_next_version_from_cz_output`` (issue #641).
+
+    Scans the captured stdout of ``cz bump --get-next --yes`` and returns
+    the last line that matches a semver-ish version pattern. Must tolerate
+    leading diagnostic noise (on a tagless repo, cz prints a multi-line
+    "No tag matching configuration could be found" block before emitting
+    the version) and reject strings that merely contain a version substring.
+    """
+
+    @pytest.mark.parametrize(
+        ("stdout", "expected"),
+        [
+            # Clean production-release output.
+            ("1.2.3\n", "1.2.3"),
+            # Clean pre-release output (PEP440).
+            ("0.1.0a0\n", "0.1.0a0"),
+            ("0.1.0b1\n", "0.1.0b1"),
+            ("0.1.0rc0\n", "0.1.0rc0"),
+            # Clean pre-release output (semver style).
+            ("0.1.0-alpha.0\n", "0.1.0-alpha.0"),
+            # Leading 'v' accepted and stripped.
+            ("v0.2.0\n", "0.2.0"),
+            # Tagless-repo case: diagnostic noise precedes the version.
+            # Regression case that this helper exists to fix.
+            (
+                "No tag matching configuration could be found.\n"
+                "Possible causes:\n"
+                "- version in configuration is not the current version\n"
+                "- tag_format or legacy_tag_formats is missing\n"
+                "\n"
+                "0.1.0a0\n",
+                "0.1.0a0",
+            ),
+            # Trailing blank lines are ignored; the version is still found.
+            ("0.1.0\n\n\n", "0.1.0"),
+        ],
+    )
+    def test_returns_trailing_version_line(self, stdout: str, expected: str) -> None:
+        assert _extract_next_version_from_cz_output(stdout) == expected
+
+    def test_returns_none_when_no_version_line(self) -> None:
+        """Output with zero version-shaped lines returns ``None``."""
+        assert _extract_next_version_from_cz_output("totally unrelated output\n") is None
+
+    def test_rejects_line_that_only_contains_a_version_substring(self) -> None:
+        """The pattern is anchored to the whole line.
+
+        A diagnostic line like ``"error at 1.2.3 somewhere"`` must not
+        be mistaken for the version output.
+        """
+        stdout = "something broke near 1.2.3 in the build\n"
+        assert _extract_next_version_from_cz_output(stdout) is None
+
+    def test_returns_last_version_when_multiple(self) -> None:
+        """When multiple version-shaped lines are present, take the last.
+
+        cz may print intermediate version hints in diagnostic output; the
+        trailing line is the authoritative one.
+        """
+        stdout = "0.0.1\n0.0.2\n0.0.3\n"
+        assert _extract_next_version_from_cz_output(stdout) == "0.0.3"
+
+
+class TestTaskReleaseActionSignature:
+    """Regression tests for ``task_release`` CLI-param wiring (issue #650).
+
+    doit's ``params`` parsing populates values for the **action function**,
+    not the outer task-creator function. If the action doesn't accept the
+    param names as kwargs, doit silently drops the CLI values and the action
+    runs with closure-captured defaults. These tests pin the action signature
+    so a future refactor can't re-introduce the silent drop.
+    """
+
+    def test_action_accepts_params(self) -> None:
+        """The first action must accept ``increment`` and ``prerelease`` kwargs."""
+        import inspect
+
+        from tools.doit.release import task_release
+
+        result = task_release()
+        actions = result["actions"]
+        assert actions, "task_release must return at least one action"
+        action = actions[0]
+        sig = inspect.signature(action)
+        assert "increment" in sig.parameters, (
+            "create_release_pr must accept 'increment' for --increment CLI flag to reach it"
+        )
+        assert "prerelease" in sig.parameters, (
+            "create_release_pr must accept 'prerelease' for --prerelease CLI flag to reach it"
+        )
+
+    def test_params_names_match_action_signature(self) -> None:
+        """Every ``params[n]['name']`` must be a parameter of the action function.
+
+        Without this match, doit's parsed CLI values can't reach the action.
+        """
+        import inspect
+
+        from tools.doit.release import task_release
+
+        result = task_release()
+        action = result["actions"][0]
+        sig_params = set(inspect.signature(action).parameters)
+        cli_param_names = {p["name"] for p in result["params"]}
+        missing = cli_param_names - sig_params
+        assert not missing, (
+            f"params names {missing} have no matching kwarg in the action signature; "
+            "doit will silently drop their CLI values"
+        )
+
+
+class TestReleaseTagGhSearch:
+    """Regression test for ``task_release_tag``'s gh pr list search (issue #657).
+
+    GitHub's search parses ``release: v in:title`` with the colon as a
+    qualifier separator (like ``head:``, ``author:``), returning zero results
+    for literal title substrings containing colons. ``head:release/`` is
+    GitHub's intended syntax and matches the head-branch naming convention
+    ``doit release`` uses for release branches.
+    """
+
+    def test_gh_search_uses_head_prefix_not_title_colon_substring(self) -> None:
+        """Source must use head:release/ and not the broken title-colon search."""
+        import pathlib
+
+        # Windows read_text() defaults to cp1252 which can't decode non-ASCII
+        # characters like ❌ in release.py's error banners — always specify utf-8.
+        src = pathlib.Path("tools/doit/release.py").read_text(encoding="utf-8")
+        assert "release: v in:title" not in src, (
+            "The broken colon-in-search pattern returns zero results from gh "
+            "pr list and must not recur"
+        )
+        assert '"head:release/"' in src, (
+            "task_release_tag must use head:release/ to find merged release PRs"
+        )

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -196,7 +196,10 @@ def _build_cz_get_next_cmd(increment: str, prerelease: str) -> list[str]:
     Returns:
         The command list ready to hand to ``subprocess.run``.
     """
-    cmd = ["uv", "run", "cz", "bump", "--get-next"]
+    # --yes auto-answers cz's interactive prompts (e.g. "Is this the first
+    # tag created?" on a tagless repo). Without it, cz hangs or prints
+    # "Cancelled by user" into the stdout we capture for version parsing.
+    cmd = ["uv", "run", "cz", "bump", "--get-next", "--yes"]
     if increment:
         cmd.extend(["--increment", increment.upper()])
     if prerelease:
@@ -204,7 +207,35 @@ def _build_cz_get_next_cmd(increment: str, prerelease: str) -> list[str]:
     return cmd
 
 
-def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
+def _extract_next_version_from_cz_output(stdout: str) -> str | None:
+    """Extract the next version from ``cz bump --get-next`` stdout.
+
+    On a tagless repo, cz emits diagnostic lines before the version (e.g.
+    ``"No tag matching configuration could be found."``). Scan from the
+    last line backward and return the first line that matches
+    ``_VERSION_PATTERN``. The match must cover the entire line so noisy
+    diagnostics that happen to contain a version substring don't fool it.
+
+    Args:
+        stdout: The captured stdout from ``cz bump --get-next``.
+
+    Returns:
+        The bare version string (no leading ``v``) from the last
+        version-looking line, or ``None`` if no line matches.
+    """
+    # Anchor the pattern so it must span the whole (stripped) line.
+    whole_line = re.compile(rf"^{_VERSION_PATTERN}$")
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = whole_line.match(stripped)
+        if match:
+            return match.group(1)
+    return None
+
+
+def task_release() -> dict[str, Any]:
     """Create a release PR with changelog updates (PR-based release flow).
 
     This is the single supported release entry point. It creates a release
@@ -212,13 +243,14 @@ def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
     reviewer merges the PR, run ``doit release_tag`` to tag ``main`` and
     trigger the publish workflow.
 
-    Args:
-        increment (str): Force version increment type (MAJOR, MINOR, PATCH). Auto-detects if empty.
-        prerelease (str): Pre-release type (alpha, beta, rc). Empty for a production release.
-            Mutually exclusive with ``increment``.
+    CLI params (see the ``params`` entry in the returned dict): ``--increment``
+    forces a version increment type; ``--prerelease`` produces a pre-release
+    (alpha/beta/rc). The action function ``create_release_pr`` accepts these
+    as keyword arguments so doit's param parsing reaches them — see #650 for
+    why the closure approach was wrong.
     """
 
-    def create_release_pr() -> None:
+    def create_release_pr(increment: str = "", prerelease: str = "") -> None:
         console = Console()
         console.print("=" * 70)
         console.print("[bold green]Starting PR-based release process...[/bold green]")
@@ -319,7 +351,15 @@ def task_release(increment: str = "", prerelease: str = "") -> dict[str, Any]:
                 capture_output=True,
                 text=True,
             )
-            next_version = result.stdout.strip()
+            next_version = _extract_next_version_from_cz_output(result.stdout)
+            if next_version is None:
+                console.print(
+                    "[bold red]❌ Could not extract a version from "
+                    "cz bump --get-next output.[/bold red]"
+                )
+                console.print(f"[red]Stdout: {result.stdout}[/red]")
+                console.print(f"[red]Stderr: {result.stderr}[/red]")
+                sys.exit(1)
             console.print(f"[green]✓ Next version: {next_version}[/green]")
         except subprocess.CalledProcessError as e:
             console.print("[bold red]❌ Failed to determine next version.[/bold red]")
@@ -501,6 +541,12 @@ def task_release_tag() -> dict[str, Any]:
         # Find the most recently merged release PR
         console.print("\n[cyan]Finding merged release PR...[/cyan]")
         try:
+            # Match PRs whose head branch starts with ``release/`` — the naming
+            # convention ``doit release`` uses. Do NOT use a title-substring
+            # search that includes the literal "release" prefix plus a colon
+            # and space: GitHub's search parses the colon as a qualifier
+            # separator (like ``head:``, ``author:``) and returns zero
+            # results. See #657.
             result = subprocess.run(
                 [
                     "gh",
@@ -509,7 +555,7 @@ def task_release_tag() -> dict[str, Any]:
                     "--state",
                     "merged",
                     "--search",
-                    "release: v in:title",
+                    "head:release/",
                     "--limit",
                     "1",
                     "--json",


### PR DESCRIPTION
## Description

Three task-internal wiring bugs in the PR-based release flow, all discovered downstream in sequence as end-to-end TestPyPI verification got further into the chain. Combined here as one upstream PR because each bug only became visible after the prior one was fixed.

1. **`cz bump --get-next` interactivity + version pollution.** Pass `--yes`; add a defensive `_extract_next_version_from_cz_output` helper that scans stdout from the last line backward.
2. **`--prerelease` and `--increment` CLI flags silently dropped.** doit's `params` parsing populates the action function's kwargs, not the outer task-creator's parameters. Move the kwargs onto `create_release_pr` matching `params[n]["name"]`.
3. **`release_tag` gh search uses colon qualifier syntax.** Swap to `head:release/`.

12 new test cases across `TestExtractNextVersionFromCzOutput` (9), `TestTaskReleaseActionSignature` (2), and `TestReleaseTagGhSearch` (1).

## Stacked PR

Stacked on top of #436 (the consolidated #426 port). Recommended order: #435 → #436 → this PR.

## Related Issue

Addresses #439.

## Type of Change

- [x] Bug fix

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added new tests for new functionality (12 across 3 classes)

## Verified downstream

All three fixes shipped to `endavis/pynetappfoundry`:
- #641 (PR #642): cz `--yes` + version extractor
- #650 (PR #651): wire CLI params to action function
- #657 (PR #658): release_tag head:release/ search

Combined, they make the PR-based pre-release flow actually work end-to-end against TestPyPI.

Cross-repo port — original PRs: endavis/pynetappfoundry#642, #651, #658.
