### PR TITLE
fix: align release pipeline workflows with PEP440 tags and twine

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -384,7 +384,7 @@ This project uses **semantic versioning** derived automatically from git tags vi
 
 - **No manual version editing** - Version is determined by git tags
 - **Tag format:** `v<major>.<minor>.<patch>` (e.g., `v1.2.3`)
-- **Pre-release format:** `v<version>-<type><n>` (e.g., `v1.2.3-alpha0`, `v1.2.3-beta1`, `v1.2.3-rc0`)
+- **Pre-release format:** PEP440 `v<version><type><n>` (e.g., `v1.2.3a0`, `v1.2.3b1`, `v1.2.3rc0`, `v1.2.3.dev0`) — emitted by commitizen via `doit release --prerelease=...`
 
 Version bumping is handled by [commitizen](https://commitizen-tools.github.io/commitizen/) based on conventional commit history:
 
@@ -456,7 +456,7 @@ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://
 
 | Workflow | Trigger | Destination |
 |----------|---------|-------------|
-| `testpypi.yml` | Tag matching `v*-[a-zA-Z]*` (e.g., `v1.0.0-alpha0`) | TestPyPI only |
+| `testpypi.yml` | PEP440 pre-release tags: `v*a[0-9]*`, `v*b[0-9]*`, `v*rc[0-9]*`, `v*.dev[0-9]*` (e.g., `v1.0.0a0`) | TestPyPI only |
 | `release.yml` | Tag matching `v[0-9]+.[0-9]+.[0-9]+` (e.g., `v1.0.0`) | TestPyPI → PyPI |
 
 ### Setting Up Release Permissions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,24 @@ jobs:
       - name: Generate SBOM (XML)
         run: uv run cyclonedx-py environment --of XML -o dist/sbom.xml
 
+      # Split into two artifacts: ``dist`` for twine (wheels + sdist only)
+      # and ``sbom`` for the GitHub release. Mixing SBOM files into the
+      # publish artifact makes twine abort with InvalidDistribution. See
+      # issue #665.
       - uses: actions/upload-artifact@v7
         with:
           name: dist
-          path: dist
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: |
+            dist/sbom.json
+            dist/sbom.xml
           if-no-files-found: error
 
   publish-testpypi:
@@ -119,7 +133,7 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: dist
+          name: sbom
           path: dist
 
       - name: Upload SBOM assets to GitHub release

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -2,9 +2,14 @@ name: Publish to TestPyPI
 
 on:
   workflow_dispatch:
+  # PEP440 pre-release tag patterns. commitizen (used by doit release) emits
+  # these forms, not semver-style v*-alpha.* tags. See #659.
   push:
     tags:
-      - "v*-[a-zA-Z]*"
+      - "v*a[0-9]*"       # alpha: v0.1.0a0
+      - "v*b[0-9]*"       # beta: v0.1.0b1
+      - "v*rc[0-9]*"      # rc: v0.1.0rc0
+      - "v*.dev[0-9]*"    # dev: v0.1.0.dev2
 
 permissions:
   contents: read

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -42,10 +42,11 @@ v1.0.0         # Major release
 v1.1.0         # Minor release (new features)
 v1.1.1         # Patch release (bug fixes)
 
-# Pre-releases (for TestPyPI)
-v1.0.0-alpha.1   # Alpha release
-v1.0.0-beta.1    # Beta release
-v1.0.0-rc.1      # Release candidate
+# Pre-releases (for TestPyPI) — PEP440 format emitted by commitizen
+v1.0.0a0         # Alpha release
+v1.0.0b1         # Beta release
+v1.0.0rc0        # Release candidate
+v1.0.0.dev2      # Development release
 ```
 
 ### Checking Current Version
@@ -146,8 +147,9 @@ Pass `--prerelease=<type>` to `doit release` to open a pre-release PR:
 | `beta` | Feature-complete but not yet stable |
 | `rc` | Release candidate; only fixes expected before the final release |
 
-Pre-release tags (e.g. `v1.2.0a0`, `v1.2.0-rc.1`) trigger the TestPyPI publish
-workflow; production tags (e.g. `v1.2.0`) trigger TestPyPI followed by PyPI.
+Pre-release tags (e.g. `v1.2.0a0`, `v1.2.0b1`, `v1.2.0rc0`, `v1.2.0.dev2`)
+trigger the TestPyPI publish workflow; production tags (e.g. `v1.2.0`) trigger
+TestPyPI followed by PyPI.
 See the [Workflow Triggers](../../.github/CONTRIBUTING.md#workflow-triggers)
 table in `CONTRIBUTING.md` for the full mapping.
 
@@ -474,8 +476,8 @@ This produces two files in the `tmp/` directory:
 SBOMs are automatically generated and attached to every GitHub release:
 
 1. During the **build** job, `cyclonedx-py` generates both JSON and XML SBOMs
-2. The SBOM files are included in the `dist/` artifact alongside wheel and sdist packages
-3. After publishing to PyPI, the **github-release** job creates a GitHub release with auto-generated notes and attaches the SBOMs as release assets
+2. The SBOM files are uploaded as a separate `sbom` artifact (the `dist` artifact is wheels + sdist only, so twine in the publish jobs does not reject the SBOM files as `InvalidDistribution`)
+3. After publishing to PyPI, the **github-release** job downloads the `sbom` artifact and attaches both SBOMs to the GitHub release as downloadable assets
 
 Users can download the SBOM from the GitHub release page for any version.
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,76 @@
+"""Tests for the production Release publish workflow (issue #665).
+
+Structural asserts on `.github/workflows/release.yml`. The central regression
+guard is the artifact split: SBOM files (`sbom.json`, `sbom.xml`) must live
+in a separate `sbom` artifact from the wheels/sdist `dist` artifact, because
+twine (called by the publish jobs) inspects every file in `packages-dir` and
+rejects anything that isn't a `.whl` or `.tar.gz` with `InvalidDistribution`.
+
+These tests do not execute the workflow — they only verify its shape. Sibling
+file: `tests/test_testpypi_workflow.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "release.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the Release workflow YAML.
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is ``cp1252``.
+    """
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data: dict[Any, Any] = yaml.safe_load(content)
+    return data
+
+
+def _upload_steps_for_job(job_name: str) -> list[dict[Any, Any]]:
+    """Return all upload-artifact steps for the named job."""
+    wf = _load_workflow()
+    jobs = wf.get("jobs")
+    assert isinstance(jobs, dict), "workflow must have a 'jobs' mapping"
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"workflow must define job '{job_name}'"
+    steps = job.get("steps")
+    assert isinstance(steps, list), f"'{job_name}' must have a 'steps' list"
+    return [s for s in steps if isinstance(s, dict) and "upload-artifact" in str(s.get("uses", ""))]
+
+
+class TestBuildArtifactsSeparation:
+    """SBOMs must not be in the dist artifact (issue #665)."""
+
+    def test_dist_and_sbom_are_separate_uploads(self) -> None:
+        """build job must have two upload-artifact steps: 'dist' and 'sbom'."""
+        uploads = _upload_steps_for_job("build")
+        names = sorted(str(s.get("with", {}).get("name", "")) for s in uploads)
+        assert names == ["dist", "sbom"], (
+            f"build job must upload exactly 'dist' and 'sbom' artifacts; got {names}"
+        )
+
+    def test_dist_artifact_excludes_sbom(self) -> None:
+        """The 'dist' artifact's path must not include 'sbom' patterns.
+
+        Twine reads every file in dist/ and rejects sbom.json / sbom.xml
+        with InvalidDistribution, breaking publish-testpypi and publish.
+        """
+        uploads = _upload_steps_for_job("build")
+        dist_step = next(s for s in uploads if s.get("with", {}).get("name") == "dist")
+        path_value = str(dist_step["with"].get("path", ""))
+        assert "sbom" not in path_value.lower(), (
+            f"'dist' artifact path must not include sbom files; got {path_value!r}"
+        )
+
+    def test_sbom_artifact_includes_sbom_files(self) -> None:
+        """The 'sbom' artifact path must include sbom.json and sbom.xml."""
+        uploads = _upload_steps_for_job("build")
+        sbom_step = next(s for s in uploads if s.get("with", {}).get("name") == "sbom")
+        path_value = str(sbom_step["with"].get("path", ""))
+        assert "sbom.json" in path_value
+        assert "sbom.xml" in path_value

--- a/tests/test_testpypi_workflow.py
+++ b/tests/test_testpypi_workflow.py
@@ -1,0 +1,73 @@
+"""Tests for the TestPyPI publish workflow (issue #659).
+
+Structural asserts on `.github/workflows/testpypi.yml`. The central regression
+guard is the `on.push.tags` glob list: it must cover the four PEP440
+pre-release shapes that `commitizen` (used by `doit release --prerelease=...`)
+actually emits, and it must NOT use the old semver-only pattern that missed
+every PEP440 tag this project produces.
+
+These tests do not execute the workflow — they only verify its shape. See
+`tests/test_codeql_workflow.py` for the sibling pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "testpypi.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    """Load and parse the TestPyPI workflow YAML.
+
+    Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because PyYAML
+    parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
+
+    The explicit ``encoding="utf-8"`` is required for Windows, where the
+    default ``locale.getpreferredencoding()`` is ``cp1252`` and chokes on any
+    non-ASCII content — see the sibling test file for #430 context.
+    """
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data: dict[Any, Any] = yaml.safe_load(content)
+    return data
+
+
+class TestPushTagTriggers:
+    """The PEP440 pre-release tag patterns must be present; semver-only absent."""
+
+    def _tag_patterns(self) -> list[str]:
+        wf = _load_workflow()
+        # PyYAML parses bare 'on' as the boolean True.
+        on_section = wf.get("on") or wf.get(True)
+        assert isinstance(on_section, dict), "workflow must have an 'on' mapping"
+        push_section = on_section.get("push")
+        assert isinstance(push_section, dict), "workflow must have an 'on.push' mapping"
+        tags = push_section.get("tags")
+        assert isinstance(tags, list), "workflow must have an 'on.push.tags' list"
+        return [str(t) for t in tags]
+
+    def test_alpha_pattern_present(self) -> None:
+        """PEP440 alpha tags (e.g. v0.1.0a0) must trigger the workflow."""
+        assert "v*a[0-9]*" in self._tag_patterns()
+
+    def test_beta_pattern_present(self) -> None:
+        """PEP440 beta tags (e.g. v0.1.0b1) must trigger the workflow."""
+        assert "v*b[0-9]*" in self._tag_patterns()
+
+    def test_rc_pattern_present(self) -> None:
+        """PEP440 rc tags (e.g. v0.1.0rc0) must trigger the workflow."""
+        assert "v*rc[0-9]*" in self._tag_patterns()
+
+    def test_dev_pattern_present(self) -> None:
+        """PEP440 dev tags (e.g. v0.1.0.dev2) must trigger the workflow."""
+        assert "v*.dev[0-9]*" in self._tag_patterns()
+
+    def test_semver_only_pattern_absent(self) -> None:
+        """The old semver-style glob that missed all PEP440 tags must be gone."""
+        assert "v*-[a-zA-Z]*" not in self._tag_patterns(), (
+            "The old semver-only glob did not match commitizen's PEP440 pre-release "
+            "tags (e.g. v0.1.0a0) and must stay out to avoid regressing #659."
+        )


### PR DESCRIPTION
## Description

Two workflow-YAML defects in the release pipeline that block actual publish to PyPI/TestPyPI.

### `testpypi.yml`: PEP440 trigger globs

Replaces the semver-only `"v*-[a-zA-Z]*"` glob with four PEP440 globs covering alpha (`v*a[0-9]*`), beta (`v*b[0-9]*`), rc (`v*rc[0-9]*`), and dev (`v*.dev[0-9]*`). PEP440-only chosen because PyPI expects PEP440 natively and `commitizen` (the only tag source) emits PEP440 by default.

### `release.yml`: split SBOMs from `dist`

Build job now uploads two artifacts: `dist` (wheels + sdist only, consumed by `publish-testpypi` and `publish`) and `sbom` (consumed by `github-release`). twine no longer chokes on `sbom.json` / `sbom.xml` in `packages-dir`.

## Stacked PR

Stacked on #442 (the validators duo). Recommended order: #435 → #436 → #440 → #442 → this PR.

## Related Issue

Addresses #443.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- [x] All existing tests pass (`doit check` green)
- [x] Added new tests (6 structural YAML asserts across two new test files)

## Verified downstream

Both fixes shipped to `endavis/pynetappfoundry`:
- #659 (PR #660): testpypi.yml PEP440 trigger globs — alpha publish to TestPyPI worked first run after this landed.
- #665 (PR #666): release.yml split SBOMs — production v0.1.0 published cleanly to PyPI after this landed.

Cross-repo port — original PRs: endavis/pynetappfoundry#660 and #666.
