### PR TITLE
fix: refuse doit release --prerelease on tagless repos

### DIFF
--- a/tests/test_doit_release.py
+++ b/tests/test_doit_release.py
@@ -27,10 +27,13 @@ from tools.doit.release import (
     _build_cz_get_next_cmd,
     _extract_next_version_from_cz_output,
     _extract_version_from_release_pr,
+    _repo_has_version_tags,
     validate_merge_commits,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from _pytest.monkeypatch import MonkeyPatch
 
 
@@ -598,6 +601,54 @@ class TestExtractNextVersionFromCzOutput:
         """
         stdout = "0.0.1\n0.0.2\n0.0.3\n"
         assert _extract_next_version_from_cz_output(stdout) == "0.0.3"
+
+
+class TestRepoHasVersionTags:
+    """Tests for ``_repo_has_version_tags`` (issue #448).
+
+    The helper shells out to ``git tag --list v*``. These tests monkeypatch
+    ``subprocess.run`` inside ``tools.doit.release`` so the git call returns
+    canned stdout.
+    """
+
+    @staticmethod
+    def _fake_tag_list(
+        stdout: str, returncode: int = 0
+    ) -> Callable[..., subprocess.CompletedProcess[str]]:
+        def fake(
+            cmd: list[str],
+            *_args: object,
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            assert cmd[:3] == ["git", "tag", "--list"]
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode, stdout=stdout, stderr=""
+            )
+
+        return fake
+
+    def test_no_tags_returns_false(self, monkeypatch: MonkeyPatch) -> None:
+        """Empty ``git tag --list v*`` output → no tags → ``False``."""
+        monkeypatch.setattr("tools.doit.release.subprocess.run", self._fake_tag_list(""))
+        assert _repo_has_version_tags() is False
+
+    def test_whitespace_only_returns_false(self, monkeypatch: MonkeyPatch) -> None:
+        """Whitespace-only output counts as no tags."""
+        monkeypatch.setattr("tools.doit.release.subprocess.run", self._fake_tag_list("\n\n  \n"))
+        assert _repo_has_version_tags() is False
+
+    def test_one_tag_returns_true(self, monkeypatch: MonkeyPatch) -> None:
+        """A single ``v*`` tag present → ``True``."""
+        monkeypatch.setattr("tools.doit.release.subprocess.run", self._fake_tag_list("v0.0.0\n"))
+        assert _repo_has_version_tags() is True
+
+    def test_multiple_tags_returns_true(self, monkeypatch: MonkeyPatch) -> None:
+        """Multiple ``v*`` tags present → ``True``."""
+        monkeypatch.setattr(
+            "tools.doit.release.subprocess.run",
+            self._fake_tag_list("v0.0.0\nv0.1.0a0\nv0.1.0\n"),
+        )
+        assert _repo_has_version_tags() is True
 
 
 class TestTaskReleaseActionSignature:

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -209,6 +209,24 @@ def _build_cz_get_next_cmd(increment: str, prerelease: str) -> list[str]:
     return cmd
 
 
+def _repo_has_version_tags() -> bool:
+    """Return ``True`` if the repo has at least one ``v*`` tag.
+
+    Used by ``task_release`` to refuse the ``--prerelease`` combination on
+    a fresh repo: without an anchor tag, ``cz bump --get-next --yes
+    --prerelease alpha`` silently returns the production first-version
+    (``0.1.0``) and drops the ``--prerelease`` flag, producing a
+    production PR when a pre-release was requested (issue #448).
+    """
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "tag", "--list", "v*"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
 def _extract_next_version_from_cz_output(stdout: str) -> str | None:
     """Extract the next version from ``cz bump --get-next`` stdout.
 
@@ -287,6 +305,26 @@ def task_release() -> dict[str, Any]:
             console.print(
                 "[bold red]❌ Error: --prerelease and --increment "
                 "are mutually exclusive.[/bold red]"
+            )
+            sys.exit(1)
+
+        # prerelease on a tagless repo silently produces a production version
+        # because cz has no anchor to bump from. Refuse loudly instead.
+        if prerelease and not _repo_has_version_tags():
+            console.print(
+                "[bold red]❌ Error: --prerelease requested but this repo has "
+                "no version tags yet.[/bold red]"
+            )
+            console.print(
+                "[yellow]cz bump cannot compute a pre-release without an anchor "
+                "tag. Pick one of:[/yellow]\n"
+                "  [cyan]1.[/cyan] Seed a baseline tag and retry:\n"
+                "     [dim]git tag v0.0.0 <commit>[/dim]\n"
+                "     [dim]git push origin v0.0.0[/dim]\n"
+                "     [dim]doit release --prerelease=" + prerelease + "[/dim]\n"
+                "  [cyan]2.[/cyan] Drop --prerelease to cut a production first "
+                "release (v0.1.0):\n"
+                "     [dim]doit release[/dim]"
             )
             sys.exit(1)
 


### PR DESCRIPTION
## Description

Ports the tagless-repo `--prerelease` guard from `pynetappfoundry#645` (commit `c168318e`). Missed in the initial release-chain port batch (#435, #436, #438, #440, #442, #444, #446) — filing it now as a standalone 8th PR since all prerequisites are already merged.

On a tagless repo, `doit release --prerelease=alpha` silently produces a production `v0.1.0` PR because `cz bump --get-next --yes --prerelease alpha` has no anchor tag and falls back to its first-version default, ignoring `--prerelease`. If the user doesn't notice, `release_tag` would then push straight to PyPI instead of TestPyPI.

## Related Issue

Addresses #448

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`tools/doit/release.py`** — new `_repo_has_version_tags()` helper shells out to `git tag --list v*`; `task_release` checks it before the `cz bump --get-next` call and exits 1 with a red banner + two-option guidance (seed `v0.0.0` and retry, or drop `--prerelease` for a `v0.1.0` production first release) when `--prerelease` is set on a tagless repo.
- **`tests/test_doit_release.py`** — new `TestRepoHasVersionTags` class with four tests (empty output, whitespace-only, single tag, multiple tags) using the subprocess-monkeypatch pattern established in `TestValidateMergeCommits` (#437).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes (downstream verification on pynetappfoundry)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (docs unchanged — guard is an internal CLI behavior change; user-facing docs for the papercut remediation live in #447)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Self-contained +89 lines across 2 files. No dependencies on other in-flight work — all referenced helpers (`TestValidateMergeCommits`, `task_release`) are already merged via #436 / #438.

Unblocks #447 (auto-seed `v0.0.0` at bootstrap) — the papercut #447 remediates only exists once this guard lands.
