### PR TITLE
feat: auto-seed v0.0.0 baseline tag in template bootstrap

### DIFF
--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -780,6 +780,10 @@ doit release --prerelease=rc
 - Must be on `main` branch
 - No uncommitted changes
 - All checks must pass
+- `--prerelease` additionally requires a baseline `v*` tag so commitizen
+  has an anchor to bump from. Existing projects that predate the bootstrap
+  auto-seed should seed one manually — see
+  [Before your first pre-release](release-and-automation.md#before-your-first-pre-release).
 
 See [Release Automation](release-and-automation.md) for the full flow.
 

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -82,6 +82,34 @@ uv run doit release_tag
 Both commands must be run from `main` with a clean working tree.
 `--prerelease` and `--increment` are mutually exclusive on `doit release`.
 
+### Before your first pre-release
+
+`doit release --prerelease=alpha|beta|rc` requires a baseline `v*` tag so
+commitizen has an anchor version to bump from. Without one the task refuses
+and prints guidance (see [issue #448](https://github.com/endavis/pyproject-template/issues/448)).
+
+**New projects (bootstrap flow).** `tools/pyproject_template/configure.py`
+auto-seeds a `v0.0.0` tag on the root commit, so nothing else is required —
+only push it when you're ready:
+
+```bash
+git push origin v0.0.0
+```
+
+**Existing projects (synced from the template before the auto-seed
+landed).** Seed the baseline tag manually, once per project:
+
+```bash
+# From the project root:
+git tag v0.0.0 "$(git rev-list --max-parents=0 HEAD | head -1)"
+git push origin v0.0.0
+```
+
+After that, `doit release --prerelease=alpha` produces the expected
+`v0.1.0a0` PR. Skip this step entirely if your first release is a
+production release (`doit release` without `--prerelease` works on a
+tagless repo — commitizen defaults to `v0.1.0`).
+
 ### Step 1: Create the release PR (`doit release`)
 
 `doit release` determines the next version, creates a `release/vX.Y.Z`

--- a/tests/pyproject_template/test_pyproject_template_main.py
+++ b/tests/pyproject_template/test_pyproject_template_main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -731,6 +733,118 @@ class TestConfigureModule:
             assert not tool_tests_dir.exists()
             # But tests directory itself should still exist
             assert (tmp_path / "tests").exists()
+        finally:
+            os.chdir(old_cwd)
+
+
+class TestSeedBaselineTag:
+    """Tests for ``seed_baseline_tag`` (issue #447).
+
+    Exercises the auto-seed of ``v0.0.0`` on the bootstrap root commit. The
+    function powers the fix for the papercut introduced by the ``--prerelease``
+    guard from issue #448: without a baseline tag, cz bump refuses to compute
+    a pre-release on a fresh repo.
+    """
+
+    @staticmethod
+    def _init_repo(repo: Path) -> str:
+        """Initialize a git repo in ``repo`` with one empty root commit.
+
+        Returns the SHA of the root commit.
+        """
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "root", "--no-verify"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    @staticmethod
+    def _list_tags(repo: Path) -> list[str]:
+        result = subprocess.run(
+            ["git", "tag", "--list"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def test_no_tags_creates_v0_0_0_on_root_commit(self, tmp_path: Path) -> None:
+        """With no existing v* tags, seed_baseline_tag creates v0.0.0 on the root commit."""
+        from tools.pyproject_template.configure import seed_baseline_tag
+
+        root_sha = self._init_repo(tmp_path)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            seed_baseline_tag()
+
+            assert self._list_tags(tmp_path) == ["v0.0.0"]
+
+            # Verify the tag points at the root commit
+            tagged_sha = subprocess.run(
+                ["git", "rev-list", "-n", "1", "v0.0.0"],
+                cwd=tmp_path,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            assert tagged_sha == root_sha
+        finally:
+            os.chdir(old_cwd)
+
+    def test_existing_version_tag_is_preserved(self, tmp_path: Path) -> None:
+        """When a v* tag already exists, seed_baseline_tag is a no-op (idempotent)."""
+        from tools.pyproject_template.configure import seed_baseline_tag
+
+        self._init_repo(tmp_path)
+        subprocess.run(
+            ["git", "tag", "v0.1.0"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            seed_baseline_tag()
+
+            # v0.1.0 preserved, v0.0.0 NOT added.
+            assert self._list_tags(tmp_path) == ["v0.1.0"]
+        finally:
+            os.chdir(old_cwd)
+
+    def test_not_a_git_repo_is_safe_no_op(self, tmp_path: Path) -> None:
+        """Outside a git repo, seed_baseline_tag skips without raising."""
+        from tools.pyproject_template.configure import seed_baseline_tag
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            seed_baseline_tag()  # Must not raise.
+            # No .git, no tags, nothing to observe — just reaching this line
+            # proves the function returned cleanly.
+            assert not (tmp_path / ".git").exists()
         finally:
             os.chdir(old_cwd)
 

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -9,6 +9,7 @@ Optional: skip final confirmation with --yes.
 
 import argparse
 import shutil
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
@@ -157,6 +158,78 @@ def require(value: str, label: str) -> str:
     raise SystemExit(
         f"❌ Missing required value for {label} (supply in pyproject.toml or via prompt)."
     )
+
+
+def _git_has_version_tag() -> bool:
+    """Return ``True`` if the current repo has at least one ``v*`` tag."""
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "tag", "--list", "v*"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
+def _git_root_commit() -> str | None:
+    """Return the root commit SHA of the current repo, or ``None`` if unavailable.
+
+    Returns ``None`` if not inside a git repo, the repo has no commits, or the
+    ``git rev-list`` call fails for any other reason.
+    """
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "rev-list", "--max-parents=0", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return lines[0] if lines else None
+
+
+def seed_baseline_tag() -> None:
+    """Seed a ``v0.0.0`` tag on the root commit if no ``v*`` tag exists.
+
+    Gives commitizen an anchor to compute pre-release versions against. Without
+    it, ``doit release --prerelease=alpha`` refuses on a tagless repo (guard
+    from issue #448). Idempotent: skips if any ``v*`` tag already exists. Skips
+    silently (with a visible message) if not inside a git repo or if there are
+    no commits yet, so the user can run ``git init && git commit`` first and
+    seed manually with ``git tag v0.0.0 <root-commit>``.
+    """
+    if not Path(".git").exists():
+        Logger.info(
+            "Skipping v0.0.0 baseline tag: not a git repo yet (run `git init` "
+            "and commit first, then seed manually: "
+            "`git tag v0.0.0 <root-commit>`)"
+        )
+        return
+
+    if _git_has_version_tag():
+        Logger.info("Skipping v0.0.0 baseline tag: a v* tag already exists")
+        return
+
+    root = _git_root_commit()
+    if root is None:
+        Logger.info(
+            "Skipping v0.0.0 baseline tag: no commits yet "
+            "(seed manually after your first commit: `git tag v0.0.0 <root-commit>`)"
+        )
+        return
+
+    result = subprocess.run(  # nosec B603 B607
+        ["git", "tag", "v0.0.0", root],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        print(f"  ✓ Seeded baseline tag v0.0.0 on root commit {root[:7]}")
+        Logger.info("   → push with `git push origin v0.0.0` when ready")
+    else:
+        Logger.warning(f"Could not create v0.0.0 tag: {result.stderr.strip() or 'unknown error'}")
 
 
 def run_configure(
@@ -367,6 +440,11 @@ def run_configure(
     if enable_dependabot and dependabot_example.exists():
         print("  ✓ Enabling Dependabot")
         shutil.copy(dependabot_example, dependabot_config)
+
+    # Seed v0.0.0 baseline tag so `doit release --prerelease=alpha` works on the
+    # first release (see issue #447). Idempotent and skipped gracefully when
+    # there is no git repo or no commits yet.
+    seed_baseline_tag()
 
     Logger.success("Configuration complete!")
     Logger.header("Next Steps")


### PR DESCRIPTION
## Description

Closes the papercut introduced by the `--prerelease` guard from #448. On a tagless repo, `doit release --prerelease=alpha|beta|rc` correctly refuses (no anchor tag → no meaningful pre-release version), but that puts a one-time manual step in front of anyone bootstrapping a new project that wants a pre-release before their first production release.

The fix is two-layer so both new and existing projects are covered:

1. **Template bootstrap auto-seeds `v0.0.0`.** `tools/pyproject_template/configure.py` now creates `v0.0.0` on the root commit at configure time. Idempotent (skips if any `v*` tag already exists) and graceful (skips with a visible Logger message if there's no git repo or no commits yet).
2. **Docs.** A new "Before your first pre-release" subsection in `release-and-automation.md` documents the manual seeding commands for existing projects that predate the auto-seed. The `release` entry in `doit-tasks-reference.md` cross-links there under Requirements.

## Related Issue

Addresses #447

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`tools/pyproject_template/configure.py`** — added `subprocess` import; new helpers `_git_has_version_tag()` and `_git_root_commit()`; new `seed_baseline_tag()` function (idempotent + safe-no-op for non-repo / no-commit cases); wired into `run_configure()` right before the "Configuration complete" message.
- **`tests/pyproject_template/test_pyproject_template_main.py`** — new `TestSeedBaselineTag` class with three tests covering "no tags, create", "tag exists, skip", and "not a git repo, no-op". Uses real `tmp_path` git repos with env-seeded author/committer so no user git config is assumed.
- **`docs/development/release-and-automation.md`** — new `### Before your first pre-release` subsection between "Release Flow" and "Step 1", covering both the auto-seed path for new projects and the manual-seed path for existing projects.
- **`docs/development/doit-tasks-reference.md`** — added a Requirements bullet on the `release` entry cross-linking to the new subsection.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (3 tests in `TestSeedBaselineTag`)
- [x] Manually verified via `doit check` (all 7 gates green)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (`release-and-automation.md` + `doit-tasks-reference.md`)
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Scope: +224 lines across 4 files. No behavior change for existing projects with a `v*` tag already present; safe-no-op for bootstraps run outside a git repo.

Downstream origin: `pynetappfoundry#646`. Same release-chain family as #425 / #426 / #437 / #439 / #441 / #443 / #445 / #448.
