### PR TITLE
docs: document allow_auto_merge as a required repository setting

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,3 +1,7 @@
+# Requires the `allow_auto_merge` repository setting to be enabled.
+# See docs/development/github-repository-settings.md for the full list
+# of required repository settings, and docs/development/dependabot-automerge.md
+# for how this workflow uses it.
 name: Dependabot Auto-merge
 
 on:

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -39,8 +39,9 @@ Qualifying PRs receive:
   This happens first and is **unconditional** for qualifying PRs.
 - GitHub's native auto-merge attempted with the **squash** strategy. This step
   can fail for reasons outside the workflow (e.g. the repository does not have
-  `allow_auto_merge` enabled), in which case the run is marked as a failure but
-  the label above is already applied.
+  [`allow_auto_merge`](github-repository-settings.md#repository-settings) enabled),
+  in which case the run is marked as a failure but the label above is already
+  applied.
 - A sticky status comment describing the outcome. If auto-merge was enabled, it
   confirms that; if the auto-merge step failed, it notes that the label was
   applied anyway and points at the workflow logs so a maintainer can investigate

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -36,6 +36,7 @@ These are the general repository-level settings applied by
 | **Allow squash merge** | Yes | Only merge strategy allowed (linear history) |
 | **Allow merge commit** | No | Enforces squash-only policy |
 | **Allow rebase merge** | No | Enforces squash-only policy |
+| **Allow auto-merge** | Yes | Required by the [Dependabot Auto-merge](dependabot-automerge.md) workflow so it can call `gh pr merge --auto` |
 | **Delete branch on merge** | Yes | Cleans up feature branches automatically |
 | **Visibility** | Public | Template default; private repos may lack some security features |
 


### PR DESCRIPTION
## Description

Documents `allow_auto_merge` as a required repository setting. Previously the setting was copied implicitly by `configure_repository_settings()` but absent from the settings table, so operators discovered the requirement via a workflow failure (`Pull request Auto merge is not allowed for this repository`) rather than the docs — see bugs #419 and #423.

## Related Issue

Addresses #427

## Type of Change

- [x] Documentation update

## Changes Made

- `docs/development/github-repository-settings.md`: added `Allow auto-merge | Yes` row to the Repository Settings table, linking to the Dependabot Auto-merge doc.
- `docs/development/dependabot-automerge.md`: turned the inline `allow_auto_merge` reference into a link back to the settings table (bidirectional cross-link).
- `.github/workflows/dependabot-automerge.yml`: added a header comment pointing readers of the YAML at the setting requirement and both docs.

## Testing

- [x] `doit check` passes (no code changed; existing tests still green)
- [x] `doit docs_build` succeeds; no new broken-link warnings from the new anchor

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly

## Additional Notes

Doc-only change. No `needs-adr` label on the issue; per `AGENTS.md`, doc issues do not require an ADR. No existing ADR in `docs/decisions/` references auto-merge.
