### PR TITLE
refactor: normalize "doc" to "docs" across tooling, tests, and docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -673,12 +673,12 @@ Every code change must be linked to a GitHub Issue. This ensures:
 doit issue --type=feature    # For new features
 doit issue --type=bug        # For bugs and defects
 doit issue --type=refactor   # For code refactoring
-doit issue --type=doc        # For documentation
+doit issue --type=docs       # For documentation
 doit issue --type=chore      # For maintenance tasks
 
 # Non-interactive: For AI agents or scripts
 doit issue --type=feature --title="Add export" --body-file=issue.md
-doit issue --type=doc --title="Add guide" --body="## Description\n..."
+doit issue --type=docs --title="Add guide" --body="## Description\n..."
 ```
 
 **Or use gh CLI directly:**
@@ -690,7 +690,7 @@ gh issue create --title "<description>" --label "enhancement" --body "..."
 - `feature` → `enhancement, needs-triage`
 - `bug` → `bug, needs-triage`
 - `refactor` → `refactor, needs-triage`
-- `doc` → `documentation, needs-triage`
+- `docs` → `documentation, needs-triage`
 - `chore` → `chore, needs-triage`
 
 **Required fields ensure complete information** - Fill all fields to provide context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,7 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 - **Releases:** Never run `doit release` without explicit command.
 - **PRs:** Use `doit pr` to create PRs and `doit pr_merge` to merge with proper commit format. Issues are not automatically closed. Ask the user if they would like the related issue closed — pass `--auto-close` to `doit pr_merge` to close linked issues in one step.
 - **The Merge Gate action:** is a manual action for the user to add to a PR. It requires the ready-to-merge label and should never be added by automation. Exception: the dependabot auto-merge workflow (`.github/workflows/dependabot-automerge.yml`) applies the `ready-to-merge` label to qualifying dependabot PRs only.
-- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, doc, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
+- **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, docs, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 
 ## Workflow Commands (for AI agents)
@@ -361,7 +361,7 @@ doit issue --type=refactor --title="refactor: extract validation" \
   --body="## Current Code Issue\nDuplicated logic\n\n## Proposed Improvement\nExtract to mixin"
 
 # Documentation (requires: Description)
-doit issue --type=doc --title="doc: add provider guide" \
+doit issue --type=docs --title="docs: add provider guide" \
   --body="## Description\nAdd guide for creating custom providers"
 
 # Chore (requires: Description)

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -35,7 +35,7 @@ If you are not sure what state you are in, run `/where-am-i` at any time. It ins
 
 ### 2. Pick an issue
 
-Every change starts from an issue. Either list the open backlog with `gh issue list` and pick one, or create a new issue with `doit issue --type=<type>` (types are `feature`, `bug`, `refactor`, `doc`, `chore`). The template enforces Issue → Branch → Commit → PR → Merge; there is no supported path that skips the issue.
+Every change starts from an issue. Either list the open backlog with `gh issue list` and pick one, or create a new issue with `doit issue --type=<type>` (types are `feature`, `bug`, `refactor`, `docs`, `chore`). The template enforces Issue → Branch → Commit → PR → Merge; there is no supported path that skips the issue.
 
 For the rest of this walkthrough assume you have picked issue number `42`.
 

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -614,7 +614,7 @@ doit issue --type=bug --title="Fix bug" --body-file=issue.md
 - `feature` - New feature request
 - `bug` - Bug report
 - `refactor` - Code refactoring
-- `doc` - Documentation improvement
+- `docs` - Documentation improvement
 - `chore` - Maintenance task
 
 **Options:**

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -37,7 +37,7 @@ class TestIssueTypeMapping:
 
     def test_all_issue_types_have_mapping(self) -> None:
         """All expected issue types should have file mappings."""
-        expected_types = {"feature", "bug", "refactor", "doc", "chore"}
+        expected_types = {"feature", "bug", "refactor", "docs", "chore"}
         assert set(ISSUE_TYPE_TO_FILE.keys()) == expected_types
 
     def test_mapping_files_exist(self) -> None:
@@ -51,7 +51,7 @@ class TestIssueTypeMapping:
 class TestGetIssueTemplate:
     """Test get_issue_template function."""
 
-    @pytest.mark.parametrize("issue_type", ["feature", "bug", "refactor", "doc", "chore"])
+    @pytest.mark.parametrize("issue_type", ["feature", "bug", "refactor", "docs", "chore"])
     def test_get_template_for_valid_types(self, issue_type: str) -> None:
         """Should return IssueTemplate for all valid types."""
         result = get_issue_template(issue_type)
@@ -81,10 +81,15 @@ class TestGetIssueTemplate:
         result = get_issue_template("refactor")
         assert "refactor" in result.labels
 
-    def test_doc_template_has_expected_labels(self) -> None:
-        """Doc template should have documentation label."""
-        result = get_issue_template("doc")
+    def test_docs_template_has_expected_labels(self) -> None:
+        """Docs template should have documentation label."""
+        result = get_issue_template("docs")
         assert "documentation" in result.labels
+
+    def test_legacy_doc_type_raises_value_error(self) -> None:
+        """Legacy 'doc' type should raise ValueError after rename to 'docs'."""
+        with pytest.raises(ValueError, match="Invalid issue type"):
+            get_issue_template("doc")
 
     def test_chore_template_has_expected_labels(self) -> None:
         """Chore template should have chore label."""
@@ -126,9 +131,9 @@ class TestGetRequiredSections:
         assert "Current Code Issue" in sections
         assert "Proposed Improvement" in sections
 
-    def test_doc_required_sections(self) -> None:
-        """Doc type should require type and description."""
-        sections = get_required_sections("doc")
+    def test_docs_required_sections(self) -> None:
+        """Docs type should require type and description."""
+        sections = get_required_sections("docs")
         assert "Documentation Type" in sections
         assert "Description" in sections
 
@@ -148,7 +153,7 @@ class TestGetIssueLabels:
             ("feature", "enhancement"),
             ("bug", "bug"),
             ("refactor", "refactor"),
-            ("doc", "documentation"),
+            ("docs", "documentation"),
             ("chore", "chore"),
         ],
     )

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -129,7 +129,7 @@ def _validate_issue_content(
 
     Args:
         sections: Parsed markdown sections
-        issue_type: Type of issue (feature, bug, refactor, doc, chore)
+        issue_type: Type of issue (feature, bug, refactor, docs, chore)
         console: Rich console for output
 
     Returns:
@@ -194,7 +194,7 @@ def _read_body_file(file_path: str, console: "ConsoleType") -> str | None:
 
 
 def task_issue() -> dict[str, Any]:
-    """Create issue from .github/ISSUE_TEMPLATE/<type>.yml (feature/bug/refactor/doc/chore).
+    """Create issue from .github/ISSUE_TEMPLATE/<type>.yml (feature/bug/refactor/docs/chore).
 
     Labels are automatically applied based on the issue type.
 
@@ -205,7 +205,7 @@ def task_issue() -> dict[str, Any]:
 
     Examples:
         Interactive:  doit issue --type=feature
-        From file:    doit issue --type=doc --title="Add guide" --body-file=issue.md
+        From file:    doit issue --type=docs --title="Add guide" --body-file=issue.md
         Direct:       doit issue --type=chore --title="Update CI" --body="## Description\\n..."
     """
 
@@ -313,7 +313,7 @@ def task_issue() -> dict[str, Any]:
                 "short": "t",
                 "long": "type",
                 "default": "feature",
-                "help": "Issue type: feature, bug, refactor, doc, chore",
+                "help": "Issue type: feature, bug, refactor, docs, chore",
             },
             {"name": "title", "long": "title", "default": None, "help": "Issue title"},
             {"name": "body", "long": "body", "default": None, "help": "Issue body (markdown)"},

--- a/tools/doit/templates.py
+++ b/tools/doit/templates.py
@@ -36,7 +36,7 @@ ISSUE_TYPE_TO_FILE = {
     "feature": "feature_request.yml",
     "bug": "bug_report.yml",
     "refactor": "refactor.yml",
-    "doc": "documentation.yml",
+    "docs": "documentation.yml",
     "chore": "chore.yml",
 }
 
@@ -158,7 +158,7 @@ def get_issue_template(issue_type: str) -> IssueTemplate:
     """Get the issue template for a given type.
 
     Args:
-        issue_type: One of 'feature', 'bug', 'refactor', 'doc', 'chore'
+        issue_type: One of 'feature', 'bug', 'refactor', 'docs', 'chore'
 
     Returns:
         IssueTemplate with editor content and metadata
@@ -228,7 +228,7 @@ def get_issue_labels(issue_type: str) -> str:
     """Get the labels for a given issue type.
 
     Args:
-        issue_type: One of 'feature', 'bug', 'refactor', 'doc', 'chore'
+        issue_type: One of 'feature', 'bug', 'refactor', 'docs', 'chore'
 
     Returns:
         Comma-separated string of labels
@@ -241,7 +241,7 @@ def get_required_sections(issue_type: str) -> list[str]:
     """Get the required sections for a given issue type.
 
     Args:
-        issue_type: One of 'feature', 'bug', 'refactor', 'doc', 'chore'
+        issue_type: One of 'feature', 'bug', 'refactor', 'docs', 'chore'
 
     Returns:
         List of required section names


### PR DESCRIPTION
## Description

Normalizes the documentation issue-type identifier from `doc` to `docs` across the tooling, tests, and documentation so a single spelling is used everywhere the word acts as a type identifier or Conventional Commits prefix. Also fixes an active bug in `AGENTS.md` where the documentation issue example used `--title="doc: add provider guide"` — that title would fail the PR-title validator.

## Related Issue

Addresses #455

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [x] Documentation update

## BREAKING CHANGE

**`doit issue --type=doc` no longer works. Use `doit issue --type=docs` instead.**

The `ISSUE_TYPE_TO_FILE` mapping key changed from `"doc"` to `"docs"`, so the CLI now raises `ValueError: Invalid issue type` for the old flag value. Any local scripts, shell aliases, editor snippets, or automation that invoke `doit issue --type=doc` must be updated to `--type=docs`.

### Migration

```bash
# Before
doit issue --type=doc --title="..." --body="..."

# After
doit issue --type=docs --title="..." --body="..."
```

### Rationale for clean break

This is a template repository with no external API consumers. The issue (#455) explicitly accepted a clean break over a deprecation window because:
- The PR-title validator and release-notes matcher already require the `docs:` Conventional Commits prefix (plural), so the singular `doc` identifier was inconsistent with every other touchpoint.
- Accepting both spellings would entrench the inconsistency and add code with no long-term owner.

A regression test (`test_legacy_doc_type_raises_value_error`) is included to assert the old value now errors, preventing accidental re-introduction.

## Changes Made

- **`tools/doit/templates.py`** — `ISSUE_TYPE_TO_FILE` dict key `doc` → `docs`; updated 3 docstrings listing the accepted issue types.
- **`tools/doit/github.py`** — Updated 4 sites: 2 docstrings, 1 example line in `task_issue` docstring, 1 `--type` help-text string.
- **`tests/test_templates.py`** — Flipped 5 literal `"doc"` sites to `"docs"`; renamed 2 tests (`test_doc_*` → `test_docs_*`); added `test_legacy_doc_type_raises_value_error` as a regression guard for the old key.
- **`AGENTS.md`** — Updated issue-type list (line 342) and fixed the documentation example title (line 364) that was using the invalid `doc:` prefix.
- **`.github/CONTRIBUTING.md`** — Updated 3 sites: interactive example, non-interactive example, label-auto-apply map.
- **`docs/development/ai/first-5-minutes.md`** — Updated the issue-type list on line 38.
- **`docs/development/doit-tasks-reference.md`** — Updated the issue-type list on line 617.

Out of scope intentionally:
- `.github/ISSUE_TEMPLATE/documentation.yml` filename stays as-is. It is user-visible only in the GitHub "New Issue" picker, where the full word is appropriate.
- The internal YAML field id `doc-type` (in `documentation.yml` and `FIELD_ID_TO_SECTION`) is unrelated to the CLI flag and stays as-is.

## Testing

- [x] All existing tests pass
- [x] Added new test for new functionality (`test_legacy_doc_type_raises_value_error` regression guard)
- [x] Manually tested the changes

Validation:
- `doit check` passes locally (format, lint, type-check, security, spell-check, full test suite).
- The new regression test asserts `get_issue_template("doc")` raises `ValueError: Invalid issue type`.
- Renamed tests (`test_docs_template_has_expected_labels`, `test_docs_required_sections`) confirm the `docs` key resolves the `documentation.yml` template and applies the `documentation` label.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — not applicable; CHANGELOG.md is auto-generated from conventional commits during the release workflow. The `BREAKING CHANGE:` footer on the commit will flag this correctly for the next release.
- [x] My changes generate no new warnings

## Additional Notes

Issue #455 has labels `refactor` and `needs-triage` (no `needs-adr`). Per `AGENTS.md`, refactors only need an ADR when they encode a significant architectural decision. This is a naming-consistency fix with no architectural implication, so no ADR is added. No existing ADR in `docs/decisions/` references the `doc` issue-type flag.
