### PR TITLE
fix: tolerate single-# plan headers in /implement grep

### DIFF
--- a/.claude/agents/implement-worker.md
+++ b/.claude/agents/implement-worker.md
@@ -28,10 +28,10 @@ The parent prompt will provide:
 
 ### 2. Fetch the implementation plan
 
-Retrieve all comments and find the one containing `## Implementation Plan for`:
+Retrieve all comments and find the one whose body has a heading line starting with `Implementation Plan for`:
 
 ```bash
-gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[] | select(.body | contains("## Implementation Plan for")) | .body'
+gh api repos/{owner}/{repo}/issues/<issue-number>/comments --jq '.[] | select(.body | test("^#+ Implementation Plan for"; "m")) | .body'
 ```
 
 - If multiple plan comments exist, use the most recent one.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -19,7 +19,7 @@ The implementation is delegated to a sub-agent (Task tool) so raw tool output st
 2. **Verify a plan comment exists:**
    Fetch all comments and search for the plan header:
    ```bash
-   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep "## Implementation Plan for"
+   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
    ```
    - If no plan comment is found, tell the user:
      > "No implementation plan found for issue #$ARGUMENTS. Run `/plan-issue $ARGUMENTS` first."

--- a/.claude/commands/plan-both.md
+++ b/.claude/commands/plan-both.md
@@ -18,7 +18,7 @@ gh issue view $ARGUMENTS --json number,title,state,labels
 ### Step 2: Check for existing plans
 
 ```bash
-gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -l "## Implementation Plan for"
+gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
 ```
 
 - If plan comments already exist, warn the user:

--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -19,7 +19,7 @@ This command runs in the main conversation context (NOT in a subagent) so the us
 
 2. **Check for an existing plan comment:**
    ```bash
-   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -l "## Implementation Plan for"
+   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
    ```
    - If a plan comment already exists, warn the user:
      > "Issue #$ARGUMENTS already has an implementation plan comment. Continuing will post a new one. Proceed?"

--- a/.claude/commands/where-am-i.md
+++ b/.claude/commands/where-am-i.md
@@ -30,7 +30,7 @@ Based on the branch name, determine the workflow state:
    ```
 3. Check for a plan comment:
    ```bash
-   gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[].body' | grep "## Implementation Plan for"
+   gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
    ```
 4. Check for uncommitted changes:
    ```bash


### PR DESCRIPTION
## Description

Relax the plan-comment detection patterns used by `/plan-issue`, `/plan-both`, `/implement`, `/where-am-i`, and the `implement-worker` agent so they accept both `# Implementation Plan for ...` and `## Implementation Plan for ...` as valid plan sentinels. This unblocks consumers when a plan comment was posted with a single `#` (e.g. if the heading was collapsed by an editor or by a future planner variant).

No planner or template files were touched — the canonical emitted form remains `##`. Only the consumer side was loosened.

## Related Issue

Addresses #457

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

| File | Before | After |
| :--- | :--- | :--- |
| `.claude/commands/implement.md` | `grep "## Implementation Plan for"` | `grep -E "^#+ Implementation Plan for"` |
| `.claude/commands/plan-both.md` | `grep -l "## Implementation Plan for"` | `grep -lE "^#+ Implementation Plan for"` |
| `.claude/commands/plan-issue.md` | `grep -l "## Implementation Plan for"` | `grep -lE "^#+ Implementation Plan for"` |
| `.claude/commands/where-am-i.md` | `grep "## Implementation Plan for"` | `grep -E "^#+ Implementation Plan for"` |
| `.claude/agents/implement-worker.md` | `jq '... contains("## Implementation Plan for") ...'` | `jq '... test("^#+ Implementation Plan for"; "m") ...'` |

## Testing

- [x] `doit check` passes (all existing tests pass, lint/type/security/spell clean)
- [x] Behavioral verification performed during implementation against real plan comments on issues #455 (single-`#`) and #430 (double-`##`) and a negative prose string. No new test file — these are prompt-file one-liners with no Python surface to cover.
- [ ] No new functionality requiring new tests

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A; prompt-file change with behavioral verification
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — no updates needed; `docs/development/ai/slash-commands.md` and `first-5-minutes.md` describe the planner's emitted form (`##`), which is unchanged
- [ ] I have updated the CHANGELOG.md — N/A (generated from conventional commits at release)
- [x] My changes generate no new warnings
