### PR TITLE
fix: auto-remove template management suite from spawned projects

### DIFF
--- a/docs/template/index.md
+++ b/docs/template/index.md
@@ -31,6 +31,12 @@ This interactive menu provides access to all template operations - creating proj
 - **Automated setup** (recommended): One command creates and configures everything
 - **Manual setup**: Clone the template and configure it yourself
 
+> **Note:** The automated setup removes the template management suite
+> (`tools/pyproject_template/`, `docs/template/`, `bootstrap.py`) from your
+> spawned project by default. Consumers who want ongoing template sync can
+> reinstall the suite with `bootstrap.py --sync` — see
+> **[Keeping Up to Date](updates.md)**.
+
 ### Have an Existing Project?
 
 **[Migration Guide](migration.md)** - Bring your existing Python project into this template.

--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -43,7 +43,11 @@ The bootstrap script (`setup_repo.py`) automates the entire setup:
 4. **Replicates labels** from the template repository
 5. **Runs placeholder replacement** (`configure.py`)
 6. **Clones the repository** locally
-7. **Prints next steps** checklist
+7. **Removes the template management suite** (`tools/pyproject_template/`,
+   `docs/template/`, `bootstrap.py`) so your consumer project owns a clean
+   tree. If you later want ongoing template sync, reinstall the suite with
+   `bootstrap.py --sync` (see [Keeping Up to Date](updates.md)).
+8. **Prints next steps** checklist
 
 ### Requirements
 
@@ -77,6 +81,15 @@ After the script completes, you'll need to:
    instructions. See the
    [release automation guide](../development/release-and-automation.md#github-environments-trusted-publishing)
    for background.
+
+   > **Note:** The template management suite (`tools/pyproject_template/`,
+   > `docs/template/`, `bootstrap.py`) was auto-removed during setup so your
+   > project owns a clean tree. If you later want ongoing template sync,
+   > reinstall the suite by running:
+   > ```bash
+   > curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \
+   >     | python3 - --sync
+   > ```
 
 2. **Add Codecov token** (optional, for coverage reports):
    - Sign up at [codecov.io](https://codecov.io)

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -18,6 +18,17 @@ Stay in sync with improvements to the pyproject-template.
 > ```
 > Select option **[3] Check for template updates** to compare your project against the latest template, then **[5] Mark as synced** after applying changes.
 
+> **Don't have the template management suite?** The automated
+> [New Project Setup](new-project.md) removes the suite by default so your
+> consumer project starts with a clean tree. Reinstall it at any time with:
+> ```bash
+> curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \
+>     | python3 - --sync
+> ```
+> This installs `tools/pyproject_template/` back into your project so you
+> can use `manage.py`, `check_template_updates.py`, and the rest of the
+> sync tooling described below.
+
 ## When to Update
 
 Consider checking for template updates when:

--- a/tests/pyproject_template/test_setup_repo.py
+++ b/tests/pyproject_template/test_setup_repo.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -151,3 +153,296 @@ class TestRepositorySetup:
             assert setup.config["author_name"] == "Test User"
             assert setup.config["author_email"] == "test@example.com"
             assert setup.config["repo_owner"] == "testuser"
+
+
+class TestCleanupTemplateSuite:
+    """Tests for RepositorySetup.cleanup_template_suite().
+
+    These tests cover the auto-removal of the template management suite
+    from spawned consumer projects (issue #465). They mock
+    ``cleanup_template_files`` and ``subprocess.run`` so no real filesystem
+    or git effects occur.
+    """
+
+    def _make_cleanup_result(
+        self,
+        *,
+        deleted_files: list[Path] | None = None,
+        deleted_dirs: list[Path] | None = None,
+    ) -> MagicMock:
+        """Build a CleanupResult-compatible mock.
+
+        ``cleanup_template_files`` returns a ``CleanupResult`` (NamedTuple).
+        Only ``deleted_files`` and ``deleted_dirs`` are consulted by
+        ``cleanup_template_suite``; supplying a MagicMock with those
+        attributes is sufficient.
+        """
+        result = MagicMock()
+        result.deleted_files = deleted_files or []
+        result.deleted_dirs = deleted_dirs or []
+        result.failed = []
+        result.mkdocs_updated = False
+        return result
+
+    def test_cleanup_invokes_cleanup_template_files_with_all_mode(self) -> None:
+        """cleanup_template_suite() passes CleanupMode.ALL to cleanup_template_files."""
+        from tools.pyproject_template.setup_repo import CleanupMode, RepositorySetup
+
+        setup = RepositorySetup()
+
+        # Simulate at least one deleted file so the git path is exercised.
+        fake_result = self._make_cleanup_result(deleted_files=[Path("bootstrap.py")])
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ) as mock_cleanup,
+            patch("tools.pyproject_template.setup_repo.subprocess.run"),
+        ):
+            setup.cleanup_template_suite()
+
+        # Assert it was called exactly once with CleanupMode.ALL.
+        mock_cleanup.assert_called_once()
+        _, kwargs = mock_cleanup.call_args
+        args = mock_cleanup.call_args.args
+        assert args[0] == CleanupMode.ALL
+        # root is passed as a keyword argument.
+        assert "root" in kwargs
+
+    def test_cleanup_uses_current_working_directory_as_root(self) -> None:
+        """cleanup_template_suite() passes Path.cwd() as the root."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        fake_result = self._make_cleanup_result(deleted_files=[Path("bootstrap.py")])
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ) as mock_cleanup,
+            patch("tools.pyproject_template.setup_repo.subprocess.run"),
+        ):
+            setup.cleanup_template_suite()
+
+        _, kwargs = mock_cleanup.call_args
+        assert kwargs["root"] == Path.cwd()
+
+    def test_cleanup_commits_and_pushes_after_successful_cleanup(self) -> None:
+        """After deletions, cleanup_template_suite() stages, commits, and pushes."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        fake_result = self._make_cleanup_result(
+            deleted_files=[Path("bootstrap.py")],
+            deleted_dirs=[Path("tools/pyproject_template")],
+        )
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+        ):
+            setup.cleanup_template_suite()
+
+        # Collect the first positional argument (the command list) for each call.
+        commands = [call.args[0] for call in mock_run.call_args_list]
+
+        # Verify add -A was called.
+        assert any(cmd[:2] == ["git", "add"] and "-A" in cmd for cmd in commands), (
+            f"Expected 'git add -A' in commands, got: {commands}"
+        )
+
+        # Verify commit --no-verify was called with the expected subject.
+        commit_calls = [
+            cmd for cmd in commands if len(cmd) >= 3 and cmd[0] == "git" and cmd[1] == "commit"
+        ]
+        assert commit_calls, f"Expected 'git commit' call, got: {commands}"
+        commit_cmd = commit_calls[0]
+        assert "--no-verify" in commit_cmd
+        # The commit message is the argument after -m.
+        assert "-m" in commit_cmd
+        msg_index = commit_cmd.index("-m") + 1
+        assert "chore: remove template management suite" in commit_cmd[msg_index]
+
+        # Verify push was called.
+        assert ["git", "push"] in commands, f"Expected 'git push' in commands, got: {commands}"
+
+    def test_cleanup_skips_commit_when_nothing_was_deleted(self) -> None:
+        """cleanup_template_suite() does not commit when no files were deleted.
+
+        Guards against an empty git commit when a consumer re-runs setup on a
+        project that has already been cleaned.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        # No deletions performed.
+        fake_result = self._make_cleanup_result()
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+        ):
+            setup.cleanup_template_suite()
+
+        # No git subprocess calls should have been made.
+        assert mock_run.call_count == 0
+
+    def test_cleanup_logs_warning_and_does_not_raise_on_failure(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """cleanup_template_suite() swallows exceptions rather than re-raising.
+
+        A cleanup failure must not block the user from using their freshly
+        spawned repository, so the method must log a warning and return
+        normally.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                side_effect=OSError("permission denied"),
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run"),
+        ):
+            # Must not raise.
+            setup.cleanup_template_suite()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Warning text should surface the exception.
+        assert "Template suite cleanup failed" in combined
+        assert "permission denied" in combined
+
+    def test_cleanup_logs_warning_when_git_commit_fails(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """cleanup_template_suite() handles subprocess failures defensively."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        fake_result = self._make_cleanup_result(deleted_files=[Path("bootstrap.py")])
+
+        def mock_run(cmd: list[str], **_kwargs: object) -> object:
+            if len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "commit":
+                raise subprocess.CalledProcessError(1, cmd, b"", b"hook rejected")
+            return MagicMock(returncode=0)
+
+        with (
+            patch(
+                "tools.pyproject_template.setup_repo.cleanup_template_files",
+                return_value=fake_result,
+            ),
+            patch("tools.pyproject_template.setup_repo.subprocess.run", side_effect=mock_run),
+        ):
+            # Must not raise.
+            setup.cleanup_template_suite()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Template suite cleanup failed" in combined
+
+
+class TestRunOrder:
+    """Tests for RepositorySetup.run() ordering.
+
+    The critical ordering requirement introduced by issue #465 is that
+    ``cleanup_template_suite`` must run AFTER the development environment
+    is set up (so ``doit check`` still has the template tests available)
+    and BEFORE the manual steps are printed (so the printed summary
+    reflects the cleaned tree).
+    """
+
+    def test_run_invokes_cleanup_between_env_setup_and_manual_steps(self) -> None:
+        """run() calls cleanup_template_suite() between env-setup and manual-steps."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        # Track the order that the orchestration methods are called.
+        call_order: list[str] = []
+
+        def make_tracker(name: str) -> object:
+            def _tracked(*_args: object, **_kwargs: object) -> None:
+                call_order.append(name)
+
+            return _tracked
+
+        # Patch every orchestration step on the instance. We use
+        # ``patch.object`` so each MagicMock records on the ``setup``
+        # instance without polluting other tests.
+        with (
+            patch.object(setup, "print_banner", side_effect=make_tracker("print_banner")),
+            patch.object(
+                setup, "check_requirements", side_effect=make_tracker("check_requirements")
+            ),
+            patch.object(setup, "gather_inputs", side_effect=make_tracker("gather_inputs")),
+            patch.object(
+                setup,
+                "create_github_repository",
+                side_effect=make_tracker("create_github_repository"),
+            ),
+            patch.object(
+                setup,
+                "configure_repository_settings",
+                side_effect=make_tracker("configure_repository_settings"),
+            ),
+            patch.object(
+                setup,
+                "configure_branch_protection",
+                side_effect=make_tracker("configure_branch_protection"),
+            ),
+            patch.object(setup, "replicate_labels", side_effect=make_tracker("replicate_labels")),
+            patch.object(
+                setup, "enable_github_pages", side_effect=make_tracker("enable_github_pages")
+            ),
+            patch.object(setup, "clone_repository", side_effect=make_tracker("clone_repository")),
+            patch.object(
+                setup,
+                "configure_placeholders",
+                side_effect=make_tracker("configure_placeholders"),
+            ),
+            patch.object(
+                setup,
+                "setup_development_environment",
+                side_effect=make_tracker("setup_development_environment"),
+            ),
+            patch.object(
+                setup,
+                "cleanup_template_suite",
+                side_effect=make_tracker("cleanup_template_suite"),
+            ),
+            patch.object(
+                setup, "print_manual_steps", side_effect=make_tracker("print_manual_steps")
+            ),
+        ):
+            setup.run()
+
+        # cleanup_template_suite must appear after setup_development_environment
+        # and before print_manual_steps.
+        assert "setup_development_environment" in call_order
+        assert "cleanup_template_suite" in call_order
+        assert "print_manual_steps" in call_order
+
+        env_idx = call_order.index("setup_development_environment")
+        cleanup_idx = call_order.index("cleanup_template_suite")
+        manual_idx = call_order.index("print_manual_steps")
+
+        assert env_idx < cleanup_idx < manual_idx, (
+            f"Expected setup_development_environment < cleanup_template_suite < "
+            f"print_manual_steps, got order: {call_order}"
+        )

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -33,6 +33,13 @@ if str(_script_dir) not in sys.path:
     sys.path.insert(0, str(_script_dir))
 
 # isort: off
+# Import cleanup helpers (used after development environment setup to
+# remove the template management suite from the spawned consumer project).
+from cleanup import (  # noqa: E402
+    CleanupMode,
+    cleanup_template_files,
+)
+
 # Import repo settings functions (aliased to avoid shadowing class methods)
 from repo_settings import (  # noqa: E402
     configure_branch_protection as _configure_branch_protection,
@@ -586,6 +593,75 @@ chore: apply code formatting
             print("  uv run doit check")
             print()
 
+    def cleanup_template_suite(self) -> None:
+        """Remove the template management suite from the spawned consumer project.
+
+        Consumer projects do not use or maintain the template's own tooling
+        (``tools/pyproject_template/``, ``docs/template/``, ``bootstrap.py``).
+        This step invokes :func:`cleanup_template_files` with
+        :attr:`CleanupMode.ALL` to delete the suite, then stages, commits, and
+        pushes the deletions so the consumer's default branch reflects a clean
+        tree.
+
+        Consumers who later want the template-sync suite back can re-install
+        it with ``curl -sSL .../bootstrap.py | python3 - --sync``.
+
+        This method is defensive: any failure is logged as a warning and
+        execution continues, so a cleanup failure does not block the user from
+        using their freshly-spawned repository.
+        """
+        Logger.step("Removing template management suite from spawned project...")
+
+        try:
+            result = cleanup_template_files(CleanupMode.ALL, root=Path.cwd())
+
+            # If nothing was deleted, there's nothing to commit.
+            if not result.deleted_files and not result.deleted_dirs:
+                Logger.info("No template files found to clean up")
+                return
+
+            # Stage deletions, commit, and push. --no-verify mirrors the
+            # pattern used in configure_placeholders(); the no-commit-to-main
+            # pre-commit hook would otherwise reject the commit on a freshly
+            # spawned repo whose only branch is main.
+            subprocess.run(["git", "add", "-A"], check=True, capture_output=True)
+            commit_msg = """
+chore: remove template management suite
+
+Auto-removed by setup_repo.py to keep the consumer project free of
+template-only tooling:
+
+- tools/pyproject_template/ (manage.py, setup_repo.py, configure.py,
+  cleanup.py, check_template_updates.py, migrate_existing_project.py,
+  settings.py, repo_settings.py, utils.py, __init__.py)
+- docs/template/
+- bootstrap.py
+- Template nav section in mkdocs.yml
+
+To reinstall the template-sync suite later, run:
+  curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py \\
+      | python3 - --sync
+
+🤖 Generated with setup-repo.py"""
+
+            subprocess.run(
+                ["git", "commit", "-m", commit_msg, "--no-verify"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(["git", "push"], check=True, capture_output=True)
+            Logger.success("Template management suite removed, committed, and pushed")
+
+        except Exception as e:
+            Logger.warning(f"Template suite cleanup failed: {e}")
+            Logger.info(
+                "You can remove the template suite manually later by running "
+                "`python tools/pyproject_template/cleanup.py --all` from the project root."
+            )
+            import traceback
+
+            traceback.print_exc()
+
     def configure_repository_settings(self) -> None:
         """Configure repository settings to match template."""
         _configure_repository_settings(
@@ -656,11 +732,12 @@ chore: apply code formatting
         print(f"      https://github.com/{self.config['repo_full']}/settings/access")
         print()
 
-        Logger.step("Cleanup Recommendations:")
-        print("  You can safely remove the following setup scripts:")
-        print("  - bootstrap.py")
-        print("  - tools/pyproject_template/configure.py")
-        print("  - tools/pyproject_template/setup_repo.py")
+        Logger.info(
+            "Template tooling was auto-removed. To reinstall the template-sync "
+            "suite later, run: curl -sSL "
+            "https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py "
+            "| python3 - --sync"
+        )
         print()
 
         Logger.step("You're all set!")
@@ -688,6 +765,7 @@ chore: apply code formatting
         2. Configure all GitHub settings (before cloning to avoid partial setup)
         3. Clone repository locally
         4. Configure local files and development environment
+        5. Remove template management suite from the consumer project
         """
         self.print_banner()
         self.check_requirements()
@@ -708,6 +786,11 @@ chore: apply code formatting
         self.clone_repository()
         self.configure_placeholders()
         self.setup_development_environment()
+
+        # Remove the template management suite from the spawned project.
+        # Consumers don't use or maintain the template's own tooling; they
+        # can re-install it later with `bootstrap.py --sync` if desired.
+        self.cleanup_template_suite()
 
         self.print_manual_steps()
 


### PR DESCRIPTION
## Description

Every consumer project spawned from this template inherited `tools/pyproject_template/` — the template's own management suite (~500KB of Python) — because `setup_repo.py` stopped at `setup_development_environment()` without invoking the cleanup helpers that already existed in `tools/pyproject_template/cleanup.py`. `bootstrap.py`'s own module docstring documents a two-flow design (default spawn → clean tree; `bootstrap.py --sync` → re-install the suite), but the default spawn was missing the cleanup step.

This PR wires the missing step in. `RepositorySetup.run()` now invokes `cleanup_template_files(CleanupMode.ALL, root=Path.cwd())` at the tail of the orchestration (after `setup_development_environment()`, before `print_manual_steps()`), then stages, commits, and pushes the deletions so the consumer's default branch reflects the clean tree.

## Related Issue

Addresses #465

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

Two commits:

1. **`feat(spawn): auto-remove template management suite from spawned projects`** (`tools/pyproject_template/setup_repo.py`, `tests/pyproject_template/test_setup_repo.py`)
   - New method `RepositorySetup.cleanup_template_suite()`:
     - Invokes `cleanup_template_files(CleanupMode.ALL, root=Path.cwd())`.
     - If the returned `CleanupResult` has no deletions, logs an info line and returns (avoids an empty commit when a consumer re-runs setup on an already-cleaned project).
     - Otherwise stages with `git add -A`, commits with `--no-verify` (mirroring the pattern already used in `configure_placeholders()` — the no-commit-to-main pre-commit hook would otherwise reject the commit on a freshly spawned repo whose only branch is `main`), and pushes.
     - Wraps the whole flow in a defensive `try/except` that logs a warning and returns normally on failure. A cleanup hiccup must not block the user from using the freshly spawned repository.
   - Wired into `run()` between `setup_development_environment()` and `print_manual_steps()` and added to the ordered-steps docstring.
   - Removed the obsolete "Cleanup Recommendations" manual-steps block from `print_manual_steps()` and replaced it with a one-line note pointing to `bootstrap.py --sync` for re-installation.

2. **`docs: describe auto-cleanup of template suite and --sync re-install path`** (`docs/template/index.md`, `docs/template/new-project.md`, `docs/template/updates.md`)
   - `docs/template/new-project.md`: added step 7 ("Removes the template management suite") to "What It Does" and a post-setup note pointing to `bootstrap.py --sync`.
   - `docs/template/index.md`: cross-reference to the new default behavior and the updates guide.
   - `docs/template/updates.md`: callout for consumers who want the template-sync suite back, documenting the `bootstrap.py --sync` command.

## Testing

Seven new tests, organized in two classes:

- `TestCleanupTemplateSuite`:
  - `test_cleanup_invokes_cleanup_template_files_with_all_mode` — `CleanupMode.ALL` is the mode passed.
  - `test_cleanup_uses_current_working_directory_as_root` — `root=Path.cwd()`.
  - `test_cleanup_commits_and_pushes_after_successful_cleanup` — asserts `git add -A`, `git commit --no-verify` with the expected subject, and `git push`.
  - `test_cleanup_skips_commit_when_nothing_was_deleted` — no subprocess calls when `CleanupResult` is empty.
  - `test_cleanup_logs_warning_and_does_not_raise_on_failure` — `OSError` from the cleanup helper is swallowed with a warning.
  - `test_cleanup_logs_warning_when_git_commit_fails` — `subprocess.CalledProcessError` during commit is swallowed with a warning.
- `TestRunOrder`:
  - `test_run_invokes_cleanup_between_env_setup_and_manual_steps` — patches every orchestration step, runs `run()`, asserts `setup_development_environment < cleanup_template_suite < print_manual_steps`.

All tests mock `cleanup_template_files` and `subprocess.run` so no real filesystem or git effects occur.

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes (deferred until the sibling issues #463/#464 also land — see Out of Scope)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A (generated by commitizen at release time from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

**No ADR required.** Issue #465 does not carry the `needs-adr` label. This PR implements a design already documented in `bootstrap.py`'s own module docstring (the "default spawn = clean tree / `--sync` = install suite" two-flow split). Verified the bootstrap.py docstring is still consistent with the new default behavior — no change needed there.

**Out of scope** (tracked separately):
- Sibling issues **#463** (spawn-flow `conftest.py` / test-file cleanup) and **#464** (`package_name` over-replacement). They share the same spawn-flow root cause; fix order is #465 → #463 → #464.
- Migration helpers for already-spawned projects that still have the suite shipped. `manage.py action 6` already handles that case interactively; no new tool is needed.

**Pyright diagnostics (not errors, intentionally not silenced):**
- `setup_repo.py:38-39` — `CleanupMode` / `cleanup_template_files` flagged "not accessed". False positive: both are used at line 616. Pyright can't resolve the sys.path-imported `cleanup` sibling module cleanly. Left as-is to match the existing convention for the other sys.path-imported siblings (`repo_settings`, `utils`) in this file.
- `test_setup_repo.py:116, 123, 340, 380` — underscore-prefix parameters flagged unused. Lines 116 / 123 are pre-existing (commit 9f19484c, 2026-01-19); 340 / 380 are new but follow the same existing style convention.
