### PR TITLE
fix: scrub bootstrap.py refs and template docs during spawn cleanup

### DIFF
--- a/tests/template/test_cleanup.py
+++ b/tests/template/test_cleanup.py
@@ -340,3 +340,362 @@ class TestMain:
         with patch("sys.argv", ["cleanup.py", "--setup", "--all"]):
             result = main()
             assert result == 1
+
+
+class TestScrubTemplateReferences:
+    """Tests for ``scrub_template_references``.
+
+    Verifies each of the three target files gets cleaned up correctly and
+    that the scrubber is idempotent. Addresses issue #469.
+    """
+
+    _PYPROJECT_WITH_STANZA = """\
+[tool.mypy]
+strict = true
+
+[[tool.mypy.overrides]]
+module = "doit.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Standalone scripts using sys.path manipulation; excluded from discovery
+# but still followed via imports from bootstrap.py
+module = "tools.pyproject_template.*"
+follow_imports = "skip"
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+"""
+
+    _PYPROJECT_WITHOUT_STANZA = """\
+[tool.mypy]
+strict = true
+
+[[tool.mypy.overrides]]
+module = "doit.*"
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+"""
+
+    _README_WITH_TEMPLATE_SECTIONS = """\
+# My Project
+
+Intro text.
+
+## Features
+
+- feature one
+
+## Quick Setup (Automated)
+
+Stuff about bootstrap.py.
+
+## Using This Template (Manual)
+
+Manual instructions about tools/pyproject_template/configure.py.
+
+## Development Setup
+
+Dev instructions.
+"""
+
+    _README_WITHOUT_TEMPLATE_SECTIONS = """\
+# My Project
+
+Intro text.
+
+## Features
+
+- feature one
+
+## Development Setup
+
+Dev instructions.
+"""
+
+    _DOIT_REF_WITH_TEMPLATE_CLEAN = """\
+# Doit Tasks Reference
+
+| Category | Commands | Purpose |
+| --- | --- | --- |
+| Setup | `install` | Install deps |
+| Maintenance | `cleanup`, `template_clean` | Project cleanup |
+
+## Testing Tasks
+
+### `test`
+
+Run tests.
+
+### `template_clean`
+
+Remove template-specific files after project setup.
+
+```bash
+doit template_clean --setup
+```
+
+**Setup mode (`--setup`)** removes:
+- `bootstrap.py`
+
+### `build`
+
+Build the package.
+"""
+
+    _DOIT_REF_WITHOUT_TEMPLATE_CLEAN = """\
+# Doit Tasks Reference
+
+| Category | Commands | Purpose |
+| --- | --- | --- |
+| Setup | `install` | Install deps |
+| Maintenance | `cleanup` | Project cleanup |
+
+## Testing Tasks
+
+### `test`
+
+Run tests.
+
+### `build`
+
+Build the package.
+"""
+
+    def test_scrubs_pyproject_when_stanza_present(self, tmp_path: Path) -> None:
+        """pyproject.toml stanza is removed when present."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        (tmp_path / "pyproject.toml").write_text(self._PYPROJECT_WITH_STANZA, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+        assert "tools.pyproject_template" not in new
+        # The unrelated doit.* override must survive.
+        assert 'module = "doit.*"' in new
+        assert tmp_path / "pyproject.toml" in changed
+
+    def test_pyproject_noop_when_stanza_absent(self, tmp_path: Path) -> None:
+        """Already-scrubbed pyproject.toml is left unchanged."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT_WITHOUT_STANZA, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        assert pyproject not in changed
+        assert pyproject.read_text(encoding="utf-8") == self._PYPROJECT_WITHOUT_STANZA
+
+    def test_scrubs_readme_when_sections_present(self, tmp_path: Path) -> None:
+        """Both template sections are removed; surrounding headings survive."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(self._README_WITH_TEMPLATE_SECTIONS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = readme.read_text(encoding="utf-8")
+        assert "## Quick Setup (Automated)" not in new
+        assert "## Using This Template (Manual)" not in new
+        # Surrounding headings intact.
+        assert "## Features" in new
+        assert "## Development Setup" in new
+        assert readme in changed
+
+    def test_readme_noop_when_sections_absent(self, tmp_path: Path) -> None:
+        """Already-scrubbed README.md is left unchanged."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(self._README_WITHOUT_TEMPLATE_SECTIONS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        assert readme not in changed
+        assert readme.read_text(encoding="utf-8") == self._README_WITHOUT_TEMPLATE_SECTIONS
+
+    def test_scrubs_doit_reference_section_and_toc(self, tmp_path: Path) -> None:
+        """doit-tasks-reference.md section removed and TOC row rewritten."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
+        doit_ref.parent.mkdir(parents=True)
+        doit_ref.write_text(self._DOIT_REF_WITH_TEMPLATE_CLEAN, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = doit_ref.read_text(encoding="utf-8")
+        assert "template_clean" not in new
+        # The TOC row is rewritten to list only ``cleanup``.
+        assert "| Maintenance | `cleanup` | Project cleanup |" in new
+        # The surrounding sections still exist.
+        assert "### `test`" in new
+        assert "### `build`" in new
+        assert doit_ref in changed
+
+    def test_doit_reference_noop_when_template_clean_absent(self, tmp_path: Path) -> None:
+        """Already-scrubbed doit-tasks-reference.md is left unchanged."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
+        doit_ref.parent.mkdir(parents=True)
+        doit_ref.write_text(self._DOIT_REF_WITHOUT_TEMPLATE_CLEAN, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        assert doit_ref not in changed
+        assert doit_ref.read_text(encoding="utf-8") == self._DOIT_REF_WITHOUT_TEMPLATE_CLEAN
+
+    def test_scrub_is_idempotent(self, tmp_path: Path) -> None:
+        """Running the scrubber twice must change nothing on the second pass."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        (tmp_path / "pyproject.toml").write_text(self._PYPROJECT_WITH_STANZA, encoding="utf-8")
+        (tmp_path / "README.md").write_text(self._README_WITH_TEMPLATE_SECTIONS, encoding="utf-8")
+        doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
+        doit_ref.parent.mkdir(parents=True)
+        doit_ref.write_text(self._DOIT_REF_WITH_TEMPLATE_CLEAN, encoding="utf-8")
+
+        # First pass: changes expected.
+        first_changed = scrub_template_references(tmp_path)
+        assert first_changed  # non-empty list
+
+        # Snapshot the post-first-pass file contents.
+        snapshots = {path: path.read_text(encoding="utf-8") for path in first_changed}
+
+        # Second pass: nothing should change.
+        second_changed = scrub_template_references(tmp_path)
+        assert second_changed == []
+
+        for path, original in snapshots.items():
+            assert path.read_text(encoding="utf-8") == original
+
+    def test_dry_run_does_not_write_files(self, tmp_path: Path) -> None:
+        """Under dry_run=True the files are not modified."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT_WITH_STANZA, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path, dry_run=True)
+
+        # File still has the stanza — nothing was written.
+        assert pyproject.read_text(encoding="utf-8") == self._PYPROJECT_WITH_STANZA
+        # But the change is still reported.
+        assert pyproject in changed
+
+    def test_no_target_files_returns_empty(self, tmp_path: Path) -> None:
+        """When none of the three target files exist, return an empty list."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        changed = scrub_template_references(tmp_path)
+        assert changed == []
+
+
+class TestCleanupAllDeletesTemplateCleanTask:
+    """Regression test for issue #469: ``tools/doit/template_clean.py`` goes away.
+
+    The doit task file imports the template cleanup module, which is deleted
+    under ``CleanupMode.ALL``. Leaving the task behind is misleading because
+    it would fail on invocation in a spawned repo.
+    """
+
+    def test_cleanup_all_deletes_template_clean_task(self, tmp_path: Path) -> None:
+        """template_clean.py is in ALL_TEMPLATE_FILES and gets deleted."""
+        from tools.pyproject_template.cleanup import (
+            ALL_TEMPLATE_FILES,
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        # Verify the constant itself lists the file (documents intent).
+        assert "tools/doit/template_clean.py" in ALL_TEMPLATE_FILES
+
+        # Create the file and run ALL-mode cleanup.
+        template_clean = tmp_path / "tools" / "doit" / "template_clean.py"
+        template_clean.parent.mkdir(parents=True)
+        template_clean.write_text("# placeholder", encoding="utf-8")
+
+        result = cleanup_template_files(CleanupMode.ALL, tmp_path)
+
+        assert not template_clean.exists()
+        # And the deleted_files list reflects the removal.
+        assert any(p.name == "template_clean.py" for p in result.deleted_files)
+
+    def test_cleanup_setup_only_leaves_template_clean_task(self, tmp_path: Path) -> None:
+        """Under SETUP_ONLY mode, template_clean.py survives (bug-#469 scope)."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        template_clean = tmp_path / "tools" / "doit" / "template_clean.py"
+        template_clean.parent.mkdir(parents=True)
+        template_clean.write_text("# placeholder", encoding="utf-8")
+
+        cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        assert template_clean.exists()
+
+
+class TestCleanupAllInvokesScrubber:
+    """``cleanup_template_files(CleanupMode.ALL)`` calls the scrubber."""
+
+    def test_all_mode_scrubs_pyproject(self, tmp_path: Path) -> None:
+        """ALL-mode cleanup removes the tools.pyproject_template mypy override."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        pyproject_content = (
+            "[tool.mypy]\n"
+            "strict = true\n"
+            "\n"
+            "[[tool.mypy.overrides]]\n"
+            "# Standalone scripts using sys.path manipulation; excluded from discovery\n"
+            "# but still followed via imports from bootstrap.py\n"
+            'module = "tools.pyproject_template.*"\n'
+            'follow_imports = "skip"\n'
+            "\n"
+            "[tool.pytest.ini_options]\n"
+            'minversion = "8.0"\n'
+        )
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(pyproject_content, encoding="utf-8")
+
+        # We need at least one deletable file so ALL-mode has work to do.
+        (tmp_path / "bootstrap.py").touch()
+
+        cleanup_template_files(CleanupMode.ALL, tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        assert "tools.pyproject_template" not in new
+
+    def test_setup_only_mode_does_not_scrub(self, tmp_path: Path) -> None:
+        """SETUP_ONLY mode leaves scrubber targets untouched."""
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        pyproject_content = (
+            "[[tool.mypy.overrides]]\n"
+            "# guarded\n"
+            'module = "tools.pyproject_template.*"\n'
+            'follow_imports = "skip"\n'
+            "\n"
+        )
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(pyproject_content, encoding="utf-8")
+        (tmp_path / "bootstrap.py").touch()
+
+        cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        # Scrubber must not run under SETUP_ONLY.
+        assert pyproject.read_text(encoding="utf-8") == pyproject_content

--- a/tests/template/test_doit_base.py
+++ b/tests/template/test_doit_base.py
@@ -1,0 +1,93 @@
+"""Tests for tools/doit/base.py helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.doit.base import optional_root_files
+
+
+def _touch(tmp_path: Path, rel: str) -> Path:
+    """Create ``rel`` under ``tmp_path`` and return the absolute path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+    return target
+
+
+class TestOptionalRootFiles:
+    """Tests for the ``optional_root_files`` helper."""
+
+    def test_empty_input_returns_empty_string(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No names -> empty string (safe to concatenate)."""
+        monkeypatch.chdir(tmp_path)
+        assert optional_root_files() == ""
+
+    def test_missing_file_returns_empty_string(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent candidate -> empty string."""
+        monkeypatch.chdir(tmp_path)
+        assert optional_root_files("bootstrap.py") == ""
+
+    def test_present_file_returns_space_prefixed_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Existing file -> ``' bootstrap.py'`` (single leading space)."""
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        result = optional_root_files("bootstrap.py")
+        assert result == " bootstrap.py"
+        # Exactly one leading space.
+        assert result.startswith(" ")
+        assert not result.startswith("  ")
+
+    def test_two_present_files_preserve_argument_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multiple present names -> argument order preserved, single space separators."""
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "a.py")
+        _touch(tmp_path, "b.py")
+
+        assert optional_root_files("a.py", "b.py") == " a.py b.py"
+        # Swapping the argument order swaps the output order too.
+        assert optional_root_files("b.py", "a.py") == " b.py a.py"
+
+    def test_mix_of_present_and_absent_filters_out_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the present names survive; missing ones are silently skipped."""
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "a.py")
+
+        assert optional_root_files("a.py", "missing.py") == " a.py"
+        assert optional_root_files("missing.py", "a.py") == " a.py"
+
+    def test_single_leading_space_and_separator(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Output uses exactly one leading space and one separator between names."""
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "x.py")
+        _touch(tmp_path, "y.py")
+
+        result = optional_root_files("x.py", "y.py")
+        # No double-spaces anywhere in the output.
+        assert "  " not in result
+        # Exactly two names separated by exactly one space.
+        assert result == " x.py y.py"
+
+    def test_directory_with_matching_name_is_not_treated_as_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A directory named ``bootstrap.py`` must not satisfy the is_file() guard."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "bootstrap.py").mkdir()
+
+        assert optional_root_files("bootstrap.py") == ""

--- a/tests/template/test_doit_docs.py
+++ b/tests/template/test_doit_docs.py
@@ -1,0 +1,53 @@
+"""Tests for tools/doit/docs.py ``task_spell_check`` wiring around ``bootstrap.py``.
+
+Verifies that the spell-check task (codespell) includes ``bootstrap.py`` when
+it exists at the cwd (template repo) and excludes it when it has been removed
+(spawned consumer project). Addresses issue #469.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.doit.docs import task_spell_check
+
+
+def _touch(tmp_path: Path, rel: str) -> Path:
+    """Create ``rel`` under ``tmp_path`` and return the absolute path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+    return target
+
+
+class TestTaskSpellCheck:
+    """``task_spell_check`` includes bootstrap.py iff it exists at cwd."""
+
+    def test_includes_bootstrap_py_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        task = task_spell_check()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert " bootstrap.py" in action
+        # README.md remains in the invocation regardless of bootstrap.py.
+        assert "README.md" in action
+
+    def test_excludes_bootstrap_py_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        task = task_spell_check()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert "bootstrap.py" not in action
+        # README.md is still present.
+        assert "README.md" in action
+        # No stray double-space where bootstrap.py used to sit.
+        assert "  " not in action

--- a/tests/template/test_doit_quality.py
+++ b/tests/template/test_doit_quality.py
@@ -1,0 +1,131 @@
+"""Tests for tools/doit/quality.py task wiring around ``bootstrap.py``.
+
+These tests verify that the code-quality tasks include ``bootstrap.py`` when
+it exists at the cwd (template repo) and exclude it when it has been removed
+(spawned consumer project). Addresses issue #469.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.doit.quality import (
+    task_format,
+    task_format_check,
+    task_lint,
+    task_type_check,
+)
+
+
+def _touch(tmp_path: Path, rel: str) -> Path:
+    """Create ``rel`` under ``tmp_path`` and return the absolute path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+    return target
+
+
+class TestTaskLint:
+    """``task_lint`` includes bootstrap.py iff it exists at cwd."""
+
+    def test_includes_bootstrap_py_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        task = task_lint()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert " bootstrap.py" in action
+
+    def test_excludes_bootstrap_py_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        task = task_lint()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert "bootstrap.py" not in action
+        # Sanity check: the ruff invocation is still present.
+        assert "ruff check" in action
+
+
+class TestTaskFormat:
+    """``task_format`` has two actions (format + check --fix); both must behave the same."""
+
+    def test_both_actions_include_bootstrap_py_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        task = task_format()
+        for action in task["actions"]:
+            assert isinstance(action, str)
+            assert " bootstrap.py" in action
+
+    def test_both_actions_exclude_bootstrap_py_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        task = task_format()
+        for action in task["actions"]:
+            assert isinstance(action, str)
+            assert "bootstrap.py" not in action
+
+
+class TestTaskFormatCheck:
+    """``task_format_check`` runs ``ruff format --check``."""
+
+    def test_includes_bootstrap_py_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        task = task_format_check()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert " bootstrap.py" in action
+
+    def test_excludes_bootstrap_py_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        task = task_format_check()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert "bootstrap.py" not in action
+        assert "ruff format --check" in action
+
+
+class TestTaskTypeCheck:
+    """``task_type_check`` runs ``mypy``."""
+
+    def test_includes_bootstrap_py_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        task = task_type_check()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert " bootstrap.py" in action
+
+    def test_excludes_bootstrap_py_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        task = task_type_check()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert "bootstrap.py" not in action
+        assert "mypy" in action

--- a/tests/template/test_doit_security.py
+++ b/tests/template/test_doit_security.py
@@ -1,0 +1,53 @@
+"""Tests for tools/doit/security.py ``task_security`` wiring around ``bootstrap.py``.
+
+Verifies that the security task (bandit) includes ``bootstrap.py`` when it
+exists at the cwd (template repo) and excludes it when it has been removed
+(spawned consumer project). Addresses issue #469.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.doit.security import task_security
+
+
+def _touch(tmp_path: Path, rel: str) -> Path:
+    """Create ``rel`` under ``tmp_path`` and return the absolute path."""
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+    return target
+
+
+class TestTaskSecurity:
+    """``task_security`` includes bootstrap.py iff it exists at cwd."""
+
+    def test_includes_bootstrap_py_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _touch(tmp_path, "bootstrap.py")
+
+        task = task_security()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert " bootstrap.py" in action
+        # The shell-level fallback messaging is still in place.
+        assert "bandit not installed" in action
+
+    def test_excludes_bootstrap_py_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        task = task_security()
+        action = task["actions"][0]
+        assert isinstance(action, str)
+        assert "bootstrap.py" not in action
+        # The bandit invocation is still present.
+        assert "bandit" in action
+        assert "src/" in action
+        assert "tools/" in action

--- a/tests/template/test_setup_repo.py
+++ b/tests/template/test_setup_repo.py
@@ -427,6 +427,11 @@ class TestRunOrder:
                 side_effect=make_tracker("cleanup_template_suite"),
             ),
             patch.object(
+                setup,
+                "verify_post_cleanup",
+                side_effect=make_tracker("verify_post_cleanup"),
+            ),
+            patch.object(
                 setup, "print_manual_steps", side_effect=make_tracker("print_manual_steps")
             ),
         ):
@@ -436,16 +441,127 @@ class TestRunOrder:
         # and before print_manual_steps.
         assert "setup_development_environment" in call_order
         assert "cleanup_template_suite" in call_order
+        assert "verify_post_cleanup" in call_order
         assert "print_manual_steps" in call_order
 
         env_idx = call_order.index("setup_development_environment")
         cleanup_idx = call_order.index("cleanup_template_suite")
+        verify_idx = call_order.index("verify_post_cleanup")
         manual_idx = call_order.index("print_manual_steps")
 
-        assert env_idx < cleanup_idx < manual_idx, (
+        assert env_idx < cleanup_idx < verify_idx < manual_idx, (
             f"Expected setup_development_environment < cleanup_template_suite < "
-            f"print_manual_steps, got order: {call_order}"
+            f"verify_post_cleanup < print_manual_steps, got order: {call_order}"
         )
+
+
+class TestVerifyPostCleanup:
+    """Tests for RepositorySetup.verify_post_cleanup().
+
+    Issue #469: after ``cleanup_template_suite`` removes ``bootstrap.py``
+    and the template management suite, any doit task that referenced those
+    files becomes broken. ``verify_post_cleanup`` re-runs ``doit check`` to
+    surface the failure in the spawned repo. It must be LENIENT — log a
+    diagnostic and return without raising or ``sys.exit`` — so the wizard
+    still reaches ``print_manual_steps`` and the user sees the final
+    instructions.
+    """
+
+    def test_runs_doit_check_in_current_directory(self) -> None:
+        """verify_post_cleanup invokes ``uv run doit check``."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            setup.verify_post_cleanup()
+
+        assert mock_run.call_count == 1
+        # Grab the command argument (first positional) from the call.
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["uv", "run", "doit", "check"]
+
+    def test_success_emits_success_message_and_does_not_raise(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When doit check returns 0, method returns silently with a success message."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            # Must not raise.
+            setup.verify_post_cleanup()
+
+        # Output should include the success marker but NOT the failure
+        # diagnostic.
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Post-cleanup validation checks passed" in combined
+        assert "Validation failed *after* cleanup" not in combined
+
+    def test_failure_logs_diagnostic_and_does_not_raise(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When doit check returns non-zero, method logs diagnostic and returns.
+
+        The diagnostic marker ``Validation failed *after* cleanup`` must
+        appear in the output so the user can correlate the failure with
+        the post-cleanup phase.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            # Must not raise — no SystemExit, no other exception.
+            setup.verify_post_cleanup()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        # Specific diagnostic marker we can assert on.
+        assert "Validation failed *after* cleanup" in combined
+
+    def test_failure_does_not_call_sys_exit(self) -> None:
+        """verify_post_cleanup must not sys.exit on failure.
+
+        Issue #469 explicitly requires lenient handling because the GitHub
+        repo has already been created and partially configured — forcing
+        an exit would leave the user stranded with no path to the manual
+        steps summary.
+        """
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+            patch("tools.pyproject_template.setup_repo.sys.exit") as mock_exit,
+        ):
+            mock_run.return_value = MagicMock(returncode=1)
+            setup.verify_post_cleanup()
+
+        mock_exit.assert_not_called()
+
+    def test_filenotfounderror_handled_gracefully(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """If ``uv`` is missing from PATH, surface a diagnostic but do not raise."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with patch(
+            "tools.pyproject_template.setup_repo.subprocess.run",
+            side_effect=FileNotFoundError("uv not found"),
+        ):
+            # Must not raise.
+            setup.verify_post_cleanup()
+
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "Validation failed *after* cleanup" in combined
 
 
 class TestConfigurePlaceholdersTemplateTestsRemoval:

--- a/tools/doit/base.py
+++ b/tools/doit/base.py
@@ -4,6 +4,7 @@ import os
 import subprocess  # nosec B404 - subprocess is required to run doit sub-tasks
 import sys
 from collections.abc import Mapping
+from pathlib import Path
 
 from rich.console import Console
 from rich.panel import Panel
@@ -30,6 +31,32 @@ def success_message() -> None:
         )
     )
     console.print()
+
+
+def optional_root_files(*names: str) -> str:
+    """Return a shell-ready, space-prefixed suffix of existing root-level files.
+
+    Builds a string such as ``" bootstrap.py"`` (leading space, space-separated)
+    containing only the names that exist as files at the current working
+    directory. Missing names are silently skipped; argument order is preserved
+    for the names that survive.
+
+    Designed for safe concatenation onto an existing command string used in a
+    ``doit`` task action, so tasks can reference root-level files (e.g.
+    ``bootstrap.py``) that are present in the template but deleted by the
+    consumer-project cleanup step. Empty input or no surviving names yields
+    ``""``, making concatenation a no-op.
+
+    Args:
+        *names: Candidate filenames at the current working directory.
+
+    Returns:
+        ``""`` when no names survive, otherwise ``" " + " ".join(survivors)``.
+    """
+    survivors = [name for name in names if Path(name).is_file()]
+    if not survivors:
+        return ""
+    return " " + " ".join(survivors)
 
 
 def _child_env(env: Mapping[str, str] | None) -> dict[str, str]:

--- a/tools/doit/docs.py
+++ b/tools/doit/docs.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from doit.tools import title_with_actions
 
+from .base import optional_root_files
+
 
 def task_docs_serve() -> dict[str, Any]:
     """Serve documentation locally with live reload."""
@@ -32,7 +34,11 @@ def task_docs_deploy() -> dict[str, Any]:
 def task_spell_check() -> dict[str, Any]:
     """Check spelling in code and documentation."""
     return {
-        "actions": ["uv run codespell src/ tests/ tools/ docs/ bootstrap.py README.md"],
+        "actions": [
+            "uv run codespell src/ tests/ tools/ docs/"
+            + optional_root_files("bootstrap.py")
+            + " README.md"
+        ],
         "title": title_with_actions,
         "verbosity": 0,
     }

--- a/tools/doit/quality.py
+++ b/tools/doit/quality.py
@@ -4,13 +4,13 @@ from typing import Any
 
 from doit.tools import title_with_actions
 
-from .base import success_message
+from .base import optional_root_files, success_message
 
 
 def task_lint() -> dict[str, Any]:
     """Run ruff linting."""
     return {
-        "actions": ["uv run ruff check src/ tests/ tools/ bootstrap.py"],
+        "actions": ["uv run ruff check src/ tests/ tools/" + optional_root_files("bootstrap.py")],
         "title": title_with_actions,
         "verbosity": 0,
     }
@@ -18,10 +18,11 @@ def task_lint() -> dict[str, Any]:
 
 def task_format() -> dict[str, Any]:
     """Format code with ruff."""
+    extras = optional_root_files("bootstrap.py")
     return {
         "actions": [
-            "uv run ruff format src/ tests/ tools/ bootstrap.py",
-            "uv run ruff check --fix src/ tests/ tools/ bootstrap.py",
+            "uv run ruff format src/ tests/ tools/" + extras,
+            "uv run ruff check --fix src/ tests/ tools/" + extras,
         ],
         "title": title_with_actions,
     }
@@ -30,7 +31,9 @@ def task_format() -> dict[str, Any]:
 def task_format_check() -> dict[str, Any]:
     """Check code formatting without modifying files."""
     return {
-        "actions": ["uv run ruff format --check src/ tests/ tools/ bootstrap.py"],
+        "actions": [
+            "uv run ruff format --check src/ tests/ tools/" + optional_root_files("bootstrap.py")
+        ],
         "title": title_with_actions,
         "verbosity": 0,
     }
@@ -39,7 +42,7 @@ def task_format_check() -> dict[str, Any]:
 def task_type_check() -> dict[str, Any]:
     """Run mypy type checking (uses pyproject.toml configuration)."""
     return {
-        "actions": ["uv run mypy src/ tools/doit/ bootstrap.py"],
+        "actions": ["uv run mypy src/ tools/doit/" + optional_root_files("bootstrap.py")],
         "title": title_with_actions,
         "verbosity": 0,
     }

--- a/tools/doit/security.py
+++ b/tools/doit/security.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from doit.tools import title_with_actions
 
+from .base import optional_root_files
+
 
 def task_audit() -> dict[str, Any]:
     """Run security audit with pip-audit (requires security extras)."""
@@ -20,8 +22,9 @@ def task_security() -> dict[str, Any]:
     """Run security checks with bandit (requires security extras)."""
     return {
         "actions": [
-            "uv run bandit -c pyproject.toml -r src/ tools/ bootstrap.py || "
-            "echo 'bandit not installed. Run: uv sync --extra security'"
+            "uv run bandit -c pyproject.toml -r src/ tools/"
+            + optional_root_files("bootstrap.py")
+            + " || echo 'bandit not installed. Run: uv sync --extra security'"
         ],
         "title": title_with_actions,
         "verbosity": 0,

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -74,6 +74,10 @@ ALL_TEMPLATE_FILES = [
     "tools/pyproject_template/cleanup.py",
     "tools/pyproject_template/utils.py",
     "tools/pyproject_template/__init__.py",
+    # doit task that wraps cleanup.py — useless in a spawned project because
+    # the module it imports is deleted above. Leaving it in ``doit list``
+    # would be misleading.
+    "tools/doit/template_clean.py",
     "docs/template/index.md",
     "docs/template/manage.md",
     "docs/template/updates.md",
@@ -175,6 +179,135 @@ def update_mkdocs_nav(root: Path | None = None, dry_run: bool = False) -> bool:
     return True
 
 
+# Regex patterns used by scrub_template_references. Defined at module scope so
+# tests can import/inspect them if needed; each pattern is self-guarded by a
+# "no match -> no change" fast path inside the function.
+
+# ``pyproject.toml`` stanza for the template-only tools.pyproject_template.*
+# mypy override. Removes the ``[[tool.mypy.overrides]]`` block (including its
+# two trailing preceding comment lines and the ``follow_imports = "skip"`` row)
+# plus the single blank line that separates it from the next section. Greedy
+# comment capture is avoided by anchoring on the module line.
+_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE = re.compile(
+    r"\[\[tool\.mypy\.overrides\]\]\n"
+    r"(?:# [^\n]*\n)*"  # optional explanatory comments
+    r'module = "tools\.pyproject_template\.\*"\n'
+    r'follow_imports = "skip"\n'
+    r"\n?",  # trailing blank line (optional so trailing-file case is tolerated)
+)
+
+# README.md block containing both template-only setup sections. Starts at
+# ``## Quick Setup (Automated)`` and runs up to (but not including) the next
+# top-level heading ``## Development Setup``. The non-greedy body match plus
+# explicit terminator keeps the scrubber from devouring unrelated sections if
+# the consumer has reshuffled headings.
+_README_TEMPLATE_SECTIONS_RE = re.compile(
+    r"## Quick Setup \(Automated\)\n.*?(?=## Development Setup\b)",
+    re.DOTALL,
+)
+
+# doit-tasks-reference.md ``### template_clean`` section. Runs from the heading
+# up to (but not including) the next ``### build`` heading. The non-greedy body
+# match guards against consuming adjacent sections.
+_DOIT_REF_TEMPLATE_CLEAN_RE = re.compile(
+    r"### `template_clean`\n.*?(?=### `build`)",
+    re.DOTALL,
+)
+
+# doit-tasks-reference.md TOC table row that lists ``template_clean`` alongside
+# ``cleanup``. Rewrites the backtick-delimited command pair so the remaining
+# task (``cleanup``) still shows up in the Maintenance row.
+_DOIT_REF_TOC_TEMPLATE_CLEAN_RE = re.compile(
+    r"`cleanup`, `template_clean`",
+)
+
+
+def scrub_template_references(root: Path | None = None, dry_run: bool = False) -> list[Path]:
+    """Remove user-visible stale references to template-only machinery.
+
+    Applies targeted regex rewrites to three files that retain documentation
+    or configuration for template-only tooling after the cleanup phase has
+    deleted the files those references point at:
+
+    * ``pyproject.toml`` — removes the ``[[tool.mypy.overrides]]`` stanza
+      targeting ``tools.pyproject_template.*`` (which no longer exists after
+      ``cleanup_template_files(CleanupMode.ALL)``).
+    * ``README.md`` — removes the ``## Quick Setup (Automated)`` and
+      ``## Using This Template (Manual)`` sections, leaving headings above
+      and below intact.
+    * ``docs/development/doit-tasks-reference.md`` — removes the
+      ``### template_clean`` section and rewrites the TOC table row so the
+      remaining ``cleanup`` entry is listed alone.
+
+    Each rewrite guards itself with a "no match -> no change" fast path so
+    repeat calls and already-scrubbed files are no-ops.
+
+    Args:
+        root: Project root directory (defaults to cwd).
+        dry_run: If True, report what would be changed but do not write files.
+
+    Returns:
+        Sorted list of paths whose contents changed (or would change, under
+        ``dry_run``). Empty list when no scrub was needed.
+    """
+    if root is None:
+        root = Path.cwd()
+
+    changed: list[Path] = []
+
+    # 1. pyproject.toml — remove the tools.pyproject_template.* mypy stanza.
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        original = pyproject.read_text(encoding="utf-8")
+        if _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE.search(original):
+            new_content = _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE.sub("", original)
+            if dry_run:
+                Logger.info("Would scrub tools.pyproject_template mypy override in pyproject.toml")
+            else:
+                pyproject.write_text(new_content, encoding="utf-8")
+                Logger.success("Removed tools.pyproject_template mypy override from pyproject.toml")
+            changed.append(pyproject)
+
+    # 2. README.md — remove both template-only setup sections.
+    readme = root / "README.md"
+    if readme.is_file():
+        original = readme.read_text(encoding="utf-8")
+        if _README_TEMPLATE_SECTIONS_RE.search(original):
+            new_content = _README_TEMPLATE_SECTIONS_RE.sub("", original)
+            if dry_run:
+                Logger.info("Would scrub template-only setup sections in README.md")
+            else:
+                readme.write_text(new_content, encoding="utf-8")
+                Logger.success("Removed template-only setup sections from README.md")
+            changed.append(readme)
+
+    # 3. docs/development/doit-tasks-reference.md — remove the template_clean
+    #    section and rewrite the TOC row.
+    doit_ref = root / "docs" / "development" / "doit-tasks-reference.md"
+    if doit_ref.is_file():
+        original = doit_ref.read_text(encoding="utf-8")
+        new_content = original
+        if _DOIT_REF_TEMPLATE_CLEAN_RE.search(new_content):
+            new_content = _DOIT_REF_TEMPLATE_CLEAN_RE.sub("", new_content)
+        if _DOIT_REF_TOC_TEMPLATE_CLEAN_RE.search(new_content):
+            new_content = _DOIT_REF_TOC_TEMPLATE_CLEAN_RE.sub("`cleanup`", new_content)
+        if new_content != original:
+            if dry_run:
+                Logger.info(
+                    "Would scrub template_clean references in "
+                    "docs/development/doit-tasks-reference.md"
+                )
+            else:
+                doit_ref.write_text(new_content, encoding="utf-8")
+                Logger.success(
+                    "Removed template_clean references from "
+                    "docs/development/doit-tasks-reference.md"
+                )
+            changed.append(doit_ref)
+
+    return sorted(changed)
+
+
 def cleanup_template_files(
     mode: CleanupMode,
     root: Path | None = None,
@@ -223,6 +356,9 @@ def cleanup_template_files(
         mkdocs_would_update = False
         if mode == CleanupMode.ALL:
             mkdocs_would_update = update_mkdocs_nav(root, dry_run=True)
+            # Also report any scrub targets; the return value is discarded
+            # here because CleanupResult has no field for it.
+            scrub_template_references(root, dry_run=True)
         return CleanupResult(files_to_delete, dirs_to_delete, [], mkdocs_would_update)
 
     # Delete files
@@ -247,6 +383,9 @@ def cleanup_template_files(
     mkdocs_updated = False
     if mode == CleanupMode.ALL:
         mkdocs_updated = update_mkdocs_nav(root, dry_run=False)
+        # Scrub user-visible references (pyproject.toml, README.md,
+        # doit-tasks-reference.md) that still point at now-deleted files.
+        scrub_template_references(root, dry_run=False)
 
     # Report results
     if deleted_files:

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -679,6 +679,53 @@ To reinstall the template-sync suite later, run:
 
             traceback.print_exc()
 
+    def verify_post_cleanup(self) -> None:
+        """Run ``doit check`` after template suite cleanup; log on failure.
+
+        The wizard already runs ``doit check`` inside
+        :meth:`setup_development_environment`, but that runs *before*
+        :meth:`cleanup_template_suite` removes ``bootstrap.py`` and the
+        template management suite. Any task command that references files
+        which cleanup just deleted would slip through undetected.
+
+        This method re-runs ``uv run doit check`` in the cloned project
+        directory after cleanup. Failure is treated leniently — matching the
+        pattern in :meth:`setup_development_environment`: the wizard prints
+        a clear diagnostic and continues to :meth:`print_manual_steps`. It
+        does **not** ``sys.exit``, because the GitHub repo has already been
+        created and partially configured; forcing an exit here would leave
+        the user with a half-set-up remote and no friendly path forward.
+        """
+        Logger.step("Verifying project after cleanup (doit check)...")
+
+        try:
+            check_result = subprocess.run(
+                ["uv", "run", "doit", "check"],
+                capture_output=False,
+                text=True,
+            )
+        except FileNotFoundError as e:
+            # uv not on PATH in this shell; surface the diagnostic but
+            # do not raise — the user can re-run manually.
+            Logger.warning(f"Post-cleanup validation could not run: {e}")
+            Logger.info(
+                "Validation failed *after* cleanup — the repo was created but "
+                "`doit check` currently fails; see output above"
+            )
+            return
+
+        if check_result.returncode != 0:
+            Logger.warning(
+                f"Post-cleanup `doit check` returned non-zero exit status {check_result.returncode}"
+            )
+            Logger.info(
+                "Validation failed *after* cleanup — the repo was created but "
+                "`doit check` currently fails; see output above"
+            )
+            return
+
+        Logger.success("Post-cleanup validation checks passed")
+
     def configure_repository_settings(self) -> None:
         """Configure repository settings to match template."""
         _configure_repository_settings(
@@ -783,6 +830,7 @@ To reinstall the template-sync suite later, run:
         3. Clone repository locally
         4. Configure local files and development environment
         5. Remove template management suite from the consumer project
+        6. Re-run ``doit check`` to confirm the post-cleanup tree is valid
         """
         self.print_banner()
         self.check_requirements()
@@ -808,6 +856,12 @@ To reinstall the template-sync suite later, run:
         # Consumers don't use or maintain the template's own tooling; they
         # can re-install it later with `bootstrap.py --sync` if desired.
         self.cleanup_template_suite()
+
+        # Re-run `doit check` after cleanup to catch any stale references
+        # that survived the template-suite removal. Lenient — logs a
+        # diagnostic and continues on failure so the wizard still reaches
+        # print_manual_steps.
+        self.verify_post_cleanup()
 
         self.print_manual_steps()
 


### PR DESCRIPTION
## Description

Spawn cleanup deletes `bootstrap.py` and the template management suite, but several doit task commands still hardcoded `bootstrap.py` in their action strings and three user-visible files (`pyproject.toml`, `README.md`, `docs/development/doit-tasks-reference.md`) still referenced template-only machinery. The net effect: `doit check` failed in spawned repos, blocking `doit release` and downstream CI. The wizard reported "Setup Complete!" without catching the regression because its single `doit check` ran **before** cleanup.

This PR fixes the primary failure (bootstrap references), broadens cleanup to scrub the three stale documentation/config artifacts plus `tools/doit/template_clean.py`, and adds a post-cleanup `doit check` inside the wizard so the same class of regression gets caught inside `setup_repo.py` in the future.

Planning notes and investigation: [issue #469 plan comment](https://github.com/endavis/pyproject-template/issues/469#issuecomment-4303649826).

## Related Issue

Addresses #469

Same family as #463, #464, #465 (all merged) — stale artifacts the spawn cleanup left behind in consumer projects.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**Primary fix — make doit task commands tolerant of `bootstrap.py` absence:**

- `tools/doit/base.py` — add `optional_root_files(*names)` helper that returns a shell-ready, space-prefixed suffix of only the root-level files that actually exist, so concatenating it onto a command string is a no-op when nothing survives.
- `tools/doit/quality.py` — `lint`, `format`, `format_check`, `type_check` now build their target lists via `optional_root_files("bootstrap.py")`.
- `tools/doit/security.py` — `security` (bandit) uses the same pattern.
- `tools/doit/docs.py` — `spell_check` (codespell) uses the same pattern.
- Behavior in the template is unchanged; spawned repos where `bootstrap.py` has been deleted now see the bootstrap arg silently dropped.

**Broader cleanup — scrub user-visible references the earlier pass missed:**

- `tools/pyproject_template/cleanup.py`:
  - Add `tools/doit/template_clean.py` to `ALL_TEMPLATE_FILES` — the doit wrapper is useless once `cleanup.py` is deleted and would show up misleadingly in `doit list`.
  - Add `scrub_template_references(root, dry_run)` that applies targeted regex rewrites to three files during `CleanupMode.ALL`:
    - `pyproject.toml` — removes the `[[tool.mypy.overrides]]` stanza targeting `tools.pyproject_template.*`.
    - `README.md` — removes the `## Quick Setup (Automated)` and `## Using This Template (Manual)` sections.
    - `docs/development/doit-tasks-reference.md` — removes the `### template_clean` subsection and rewrites the TOC row so the remaining `cleanup` task is listed alone.
  - Each rewrite self-guards with a "no match → no change" fast path so the scrubber is idempotent.

**Safety net — catch the next regression inside the wizard:**

- `tools/pyproject_template/setup_repo.py`:
  - Add `RepositorySetup.verify_post_cleanup()` which re-runs `uv run doit check` after `cleanup_template_suite` and prints a lenient diagnostic on failure. It does **not** `sys.exit` — the GitHub repo has already been created and partially configured, so forcing exit would leave the user stranded. The user still sees a clear warning and can re-run manually.
  - Wire it into `run()` between `cleanup_template_suite` and `print_manual_steps`.

## Testing

- `doit check` — all tasks green locally, including `format_check`, `lint`, `type_check`, `security`, `spell_check`, and `test`.
- 37 new tests added across six files:
  - `tests/template/test_doit_base.py` (new) — covers `optional_root_files` for present/missing/mixed inputs and empty args.
  - `tests/template/test_doit_quality.py` (new) — asserts all four tasks include/exclude `bootstrap.py` depending on presence.
  - `tests/template/test_doit_security.py` (new) — asserts bandit target list adapts to `bootstrap.py` presence.
  - `tests/template/test_doit_docs.py` (new) — asserts codespell target list adapts to `bootstrap.py` presence.
  - `tests/template/test_cleanup.py` — new `scrub_template_references` class plus new `template_clean.py` removal assertion in `ALL_TEMPLATE_FILES`.
  - `tests/template/test_setup_repo.py` — new `TestVerifyPostCleanup` class (success path, failure path, no `sys.exit`, `FileNotFoundError` handling) and `TestRunOrder` assertion that cleanup runs between env setup and manual steps.
- Manual verification: re-running the bootstrap wizard path (spawn into a fresh directory) leaves a repo where `doit check` passes with no dangling `bootstrap.py` references in task commands, `pyproject.toml`, `README.md`, or `docs/development/doit-tasks-reference.md`.

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (n/a — docs in the template itself remain accurate; the scrubber removes template-only sections from spawned projects, which is the correct behavior)
- [ ] I have updated the CHANGELOG.md (auto-generated at release time)
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR required** — issue #469 is not labeled `needs-adr`; bug fixes in this family (#463, #464, #465) did not introduce new ADRs and no existing ADR describes the spawn cleanup design.
- **Scope discipline** — this PR intentionally does not touch the hook allowlist (`tools/hooks/ai/ruff-fix-on-edit.py`), the hook test (`tests/test_hook_ruff_fix.py`), the README curl-install pointer, or `docs/development/ai/ruff-fix-hook.md` mentioned in the original issue's "Additional Context." Those are not reached by `doit check` and would expand the blast radius; they can be addressed in a follow-up if desired.
- **Separate bug noted in the issue** (`get_git_config` returning empty when no local git config exists) is explicitly out of scope here and tracked independently as #470.
