### PR TITLE
fix: fall back to --global in get_git_config when CWD has no repo

### DIFF
--- a/tests/template/test_utils.py
+++ b/tests/template/test_utils.py
@@ -146,6 +146,42 @@ class TestGetGitConfig:
             result = get_git_config("user.name", "fallback")
             assert result == "fallback"
 
+    def test_falls_back_to_global_when_unscoped_fails(self) -> None:
+        """Unscoped lookup failure triggers ``--global`` retry (#470)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout=""),
+                MagicMock(returncode=0, stdout="Global User\n"),
+            ]
+            result = get_git_config("user.name")
+            assert result == "Global User"
+            assert mock_run.call_count == 2
+            # Second call must include the --global flag.
+            second_call_argv = mock_run.call_args_list[1].args[0]
+            assert "--global" in second_call_argv
+
+    def test_returns_default_when_both_scopes_fail(self) -> None:
+        """Both unscoped and global lookups failing yields the default (#470)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout=""),
+                MagicMock(returncode=1, stdout=""),
+            ]
+            result = get_git_config("nonexistent.key", "default_value")
+            assert result == "default_value"
+            assert mock_run.call_count == 2
+
+    def test_fallback_exception_returns_default(self) -> None:
+        """Exception on the ``--global`` retry falls back to default (#470)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stdout=""),
+                FileNotFoundError,
+            ]
+            result = get_git_config("user.name", "fallback")
+            assert result == "fallback"
+            assert mock_run.call_count == 2
+
 
 class TestIsGithubUrl:
     """Tests for is_github_url function."""

--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -171,6 +171,18 @@ def get_git_config(key: str, default: str = "") -> str:
 
     Returns:
         The config value if found, otherwise the default value.
+
+    Notes:
+        The unscoped ``git config <key>`` lookup merges system, global, and
+        local config — but only when the current working directory is inside
+        a git repository. When called from outside any repo (e.g. the
+        bootstrap wizard running from ``~/src`` before the project checkout
+        exists), the unscoped call exits non-zero even for keys that are set
+        in ``~/.gitconfig``. This function retries with ``--global`` on
+        failure so that ``user.name`` and ``user.email`` resolve from the
+        user's global identity regardless of CWD (see #470). Keys that only
+        exist locally (e.g. ``remote.origin.url``) fail both calls and fall
+        through to ``default``, which is the correct behavior.
     """
     try:
         result = subprocess.run(
@@ -178,7 +190,19 @@ def get_git_config(key: str, default: str = "") -> str:
             capture_output=True,
             text=True,
         )
-        return result.stdout.strip() if result.returncode == 0 else default
+        if result.returncode == 0:
+            return result.stdout.strip()
+        # Unscoped lookup failed — retry with --global so that globally
+        # configured values (user.name, user.email) resolve even when the
+        # CWD is not inside a git repository.
+        global_result = subprocess.run(
+            ["git", "config", "--global", key],
+            capture_output=True,
+            text=True,
+        )
+        if global_result.returncode == 0:
+            return global_result.stdout.strip()
+        return default
     except (subprocess.SubprocessError, FileNotFoundError):
         return default
 


### PR DESCRIPTION
## Description

`get_git_config` returned the default when `git config <key>` exited non-zero, but that happens for `user.name` / `user.email` whenever the current working directory is not inside a git repository — even when the key is set in `~/.gitconfig`. That broke the bootstrap wizard's "required field" loop on piped stdin (and annoyed interactive users) whenever `bootstrap.py` was run from outside a repo.

This PR retries with `git config --global <key>` when the unscoped call fails, so global identity resolves regardless of CWD. Both calls sit inside the existing `except (subprocess.SubprocessError, FileNotFoundError)` guard. The signature is unchanged, and the three existing callers (`setup_repo.py`, `settings.py`, `configure.py`) pick up the fix transparently.

Plan comment: https://github.com/endavis/pyproject-template/issues/470#issuecomment-4304107585

Discovered while reproducing #469 (now merged).

## Related Issue

Addresses #470

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `tools/pyproject_template/utils.py` — `get_git_config`: on non-zero exit from the unscoped call, retry with `git config --global <key>`. Both calls remain inside the existing exception guard. Docstring updated to explain the fallback and cite #470.
- `tests/template/test_utils.py::TestGetGitConfig` — three new tests covering the fallback paths: success via `--global`, both-scopes-fail, and exception raised on the `--global` retry.

### Caller impact

| Caller | Key(s) read | Inside a repo (before/after) | Outside a repo (before/after) |
| :--- | :--- | :--- | :--- |
| `bootstrap.py` → `settings.py` | `user.name`, `user.email` | resolves / resolves (unchanged) | **default / resolves from `~/.gitconfig`** (fixed) |
| `setup_repo.py` | `user.name`, `user.email` | resolves / resolves (unchanged) | default / resolves from `~/.gitconfig` (fixed) |
| `configure.py` | `remote.origin.url` | resolves / resolves (unchanged) | default / default (unchanged — `--global` has no `remote.origin.url`) |

## Testing

- [x] All existing tests pass (`doit check` — test, lint, type-check, security, spell-check, format-check all green)
- [x] Added new tests for new functionality (3 new tests in `TestGetGitConfig`)
- [x] Manually tested the changes

Testing notes:

- `tests/template/test_utils.py::TestGetGitConfig` — 6 / 6 pass:
  - 3 preexisting tests tolerate the new two-call shape: `test_returns_config_value` (first call succeeds, second never happens), `test_returns_default_on_failure` (uses `return_value` so both calls return non-zero), `test_handles_exception` (first call raises, caught by outer guard).
  - 3 new tests cover the fallback paths: `test_falls_back_to_global_when_unscoped_fails` (success via `--global`, asserts `--global` in the second call's argv), `test_returns_default_when_both_scopes_fail` (both non-zero → default), `test_fallback_exception_returns_default` (exception on the `--global` retry → default).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (no user-facing docs reference this helper)
- [ ] I have updated the CHANGELOG.md (auto-generated at release time from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required: issue lacks `needs-adr` label, no existing ADR in `docs/decisions/` describes `get_git_config`, and this is a silent internal improvement to a helper — no public API or user-facing behavior change beyond "bootstrap now resolves global git identity when run outside a repo."
- No docs changes: `grep -rln "get_git_config"` in `docs/` returns nothing, and no doc describes the CWD-sensitivity this fix addresses.
