### PR TITLE
fix: scrub remaining pyproject/README template refs in spawn cleanup (#469 follow-up)

### DIFF
--- a/tests/template/test_cleanup.py
+++ b/tests/template/test_cleanup.py
@@ -379,6 +379,38 @@ ignore_missing_imports = true
 minversion = "8.0"
 """
 
+    # Mirrors the pyproject.toml state that ``doit fmt_pyproject`` produces
+    # before the scrubber runs in the wizard: mypy overrides are normalized
+    # into an ``overrides = [...]`` inline array, and the mypy ``exclude``
+    # brackets get space-padded. Exercises every new scrub pattern added for
+    # the #469 follow-up in one realistic fixture.
+    _PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS = """\
+[tool.ruff]
+line-length = 100
+
+lint.per-file-ignores."tests/benchmarks/*.py" = [
+  "ANN401",
+]
+lint.per-file-ignores."tools/pyproject_template/*.py" = [
+  "ANN401",
+  "RUF022",
+]
+
+[tool.mypy]
+strict = true
+# tools/pyproject_template/ uses sys.path manipulation for standalone execution
+exclude = [ "tools/pyproject_template/", ".claude/", ".gemini/", ".codex/" ]
+overrides = [
+  { module = "doit.*", ignore_missing_imports = true },
+  # Standalone scripts using sys.path manipulation; excluded from discovery
+  # but still followed via imports from bootstrap.py
+  { module = "tools.pyproject_template.*", follow_imports = "skip" },
+]
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+"""
+
     _README_WITH_TEMPLATE_SECTIONS = """\
 # My Project
 
@@ -413,6 +445,38 @@ Intro text.
 ## Development Setup
 
 Dev instructions.
+"""
+
+    _README_WITH_TEMPLATE_SUBSECTIONS = """\
+# My Project
+
+Intro text.
+
+## Versioning & Releases
+
+Commitizen + hatch-vcs.
+
+### Migrating an Existing Project
+
+Bring your existing Python project into this template:
+
+```bash
+python tools/pyproject_template/migrate_existing_project.py --target /path/to/your/project
+```
+
+### Keeping Up to Date
+
+Already using this template? Stay in sync with improvements:
+
+```bash
+python tools/pyproject_template/check_template_updates.py
+```
+
+### Creating a Release
+
+```bash
+doit release
+```
 """
 
     _DOIT_REF_WITH_TEMPLATE_CLEAN = """\
@@ -551,12 +615,121 @@ Build the package.
         assert doit_ref not in changed
         assert doit_ref.read_text(encoding="utf-8") == self._DOIT_REF_WITHOUT_TEMPLATE_CLEAN
 
+    def test_scrubs_pyproject_post_fmt_inline_overrides(self, tmp_path: Path) -> None:
+        """Post-fmt inline-array mypy override is scrubbed (#469 follow-up).
+
+        The wizard runs ``doit fmt_pyproject`` before cleanup, which rewrites
+        the template's ``[[tool.mypy.overrides]]`` stanza form into an inline
+        array entry — the original scrubber only matched the stanza form, so
+        the reference survived into spawned projects.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(self._PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        # Every mention of the template path is gone.
+        assert "tools/pyproject_template" not in new
+        assert "tools.pyproject_template" not in new
+        # Unrelated overrides and excludes survive.
+        assert 'module = "doit.*"' in new
+        assert '".claude/"' in new
+        assert '".gemini/"' in new
+        assert '".codex/"' in new
+        # The unrelated ruff per-file-ignores block survives.
+        assert 'lint.per-file-ignores."tests/benchmarks/*.py"' in new
+        assert pyproject in changed
+
+    def test_scrubs_pyproject_ruff_perfile_ignores(self, tmp_path: Path) -> None:
+        """Ruff ``per-file-ignores`` block for the template path is removed (#469 follow-up)."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            'lint.per-file-ignores."tools/pyproject_template/*.py" = [\n'
+            '  "ANN401",\n'
+            '  "RUF022",\n'
+            "]\n"
+            "\n"
+            "[tool.pytest.ini_options]\n"
+            'minversion = "8.0"\n',
+            encoding="utf-8",
+        )
+
+        changed = scrub_template_references(tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        assert 'lint.per-file-ignores."tools/pyproject_template' not in new
+        assert "[tool.pytest.ini_options]" in new
+        assert pyproject in changed
+
+    def test_scrubs_pyproject_mypy_exclude_entry_and_comment(self, tmp_path: Path) -> None:
+        """Mypy ``exclude`` entry and its comment go; other excludes stay (#469 follow-up)."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[tool.mypy]\n"
+            "strict = true\n"
+            "# tools/pyproject_template/ uses sys.path manipulation for standalone execution\n"
+            'exclude = [ "tools/pyproject_template/", ".claude/", ".gemini/", ".codex/" ]\n',
+            encoding="utf-8",
+        )
+
+        changed = scrub_template_references(tmp_path)
+
+        new = pyproject.read_text(encoding="utf-8")
+        assert "tools/pyproject_template" not in new
+        # The comment line is gone (it was specifically about the removed entry).
+        assert "uses sys.path manipulation" not in new
+        # The remaining AI-config excludes survive intact.
+        assert '".claude/"' in new
+        assert '".gemini/"' in new
+        assert '".codex/"' in new
+        assert pyproject in changed
+
+    def test_scrubs_readme_template_subsections(self, tmp_path: Path) -> None:
+        """README's ``### Migrating``/``### Keeping Up to Date`` are removed (#469 follow-up).
+
+        Both subsections point at deleted template-management scripts; the
+        preceding ``## Versioning & Releases`` heading and the following
+        ``### Creating a Release`` subsection must survive.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(self._README_WITH_TEMPLATE_SUBSECTIONS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = readme.read_text(encoding="utf-8")
+        assert "### Migrating an Existing Project" not in new
+        assert "### Keeping Up to Date" not in new
+        assert "migrate_existing_project.py" not in new
+        assert "check_template_updates.py" not in new
+        # Surrounding headings survive.
+        assert "## Versioning & Releases" in new
+        assert "### Creating a Release" in new
+        assert readme in changed
+
     def test_scrub_is_idempotent(self, tmp_path: Path) -> None:
         """Running the scrubber twice must change nothing on the second pass."""
         from tools.pyproject_template.cleanup import scrub_template_references
 
-        (tmp_path / "pyproject.toml").write_text(self._PYPROJECT_WITH_STANZA, encoding="utf-8")
-        (tmp_path / "README.md").write_text(self._README_WITH_TEMPLATE_SECTIONS, encoding="utf-8")
+        # Use the realistic post-``fmt_pyproject`` fixture so the idempotency
+        # check exercises every new pattern introduced in the #469 follow-up.
+        (tmp_path / "pyproject.toml").write_text(
+            self._PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS, encoding="utf-8"
+        )
+        # README gets both the top-level template sections AND the subsections
+        # so the two README patterns are both exercised.
+        (tmp_path / "README.md").write_text(
+            self._README_WITH_TEMPLATE_SECTIONS + "\n" + self._README_WITH_TEMPLATE_SUBSECTIONS,
+            encoding="utf-8",
+        )
         doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
         doit_ref.parent.mkdir(parents=True)
         doit_ref.write_text(self._DOIT_REF_WITH_TEMPLATE_CLEAN, encoding="utf-8")

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -180,14 +180,20 @@ def update_mkdocs_nav(root: Path | None = None, dry_run: bool = False) -> bool:
 
 
 # Regex patterns used by scrub_template_references. Defined at module scope so
-# tests can import/inspect them if needed; each pattern is self-guarded by a
-# "no match -> no change" fast path inside the function.
+# tests can import/inspect them if needed. The patterns are applied blindly
+# (``re.sub`` is a no-op when nothing matches), and the function detects
+# whether any scrub occurred by comparing the final content to the original.
 
 # ``pyproject.toml`` stanza for the template-only tools.pyproject_template.*
 # mypy override. Removes the ``[[tool.mypy.overrides]]`` block (including its
 # two trailing preceding comment lines and the ``follow_imports = "skip"`` row)
 # plus the single blank line that separates it from the next section. Greedy
 # comment capture is avoided by anchoring on the module line.
+#
+# Kept as a fallback because ``doit fmt_pyproject`` in the wizard rewrites the
+# stanza form into inline-array form before the scrubber runs
+# (see ``_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE``); downstream users that
+# invoke the scrubber on an un-formatted file still need this pattern to hit.
 _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE = re.compile(
     r"\[\[tool\.mypy\.overrides\]\]\n"
     r"(?:# [^\n]*\n)*"  # optional explanatory comments
@@ -196,13 +202,60 @@ _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE = re.compile(
     r"\n?",  # trailing blank line (optional so trailing-file case is tolerated)
 )
 
-# README.md block containing both template-only setup sections. Starts at
-# ``## Quick Setup (Automated)`` and runs up to (but not including) the next
-# top-level heading ``## Development Setup``. The non-greedy body match plus
-# explicit terminator keeps the scrubber from devouring unrelated sections if
-# the consumer has reshuffled headings.
+# ``pyproject.toml`` inline-array form of the mypy override. ``doit
+# fmt_pyproject`` (run earlier in the wizard) rewrites the stanza form into
+# an entry inside ``overrides = [...]``. The two comment lines above the
+# dict entry are preserved by the formatter, so they're part of the match.
+_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE = re.compile(
+    r"  # Standalone scripts using sys\.path manipulation; excluded from discovery\n"
+    r"  # but still followed via imports from bootstrap\.py\n"
+    r'  \{ module = "tools\.pyproject_template\.\*", follow_imports = "skip" \},\n',
+)
+
+# ``pyproject.toml`` ruff ``per-file-ignores`` block targeting
+# ``tools/pyproject_template/*.py``. Matches the whole TOML entry from the
+# ``lint.per-file-ignores."tools/pyproject_template/*.py" = [`` line through
+# the closing ``]\n``; the indented body is captured non-greedily.
+_PYPROJECT_TEMPLATE_RUFF_PERFILE_RE = re.compile(
+    r'lint\.per-file-ignores\."tools/pyproject_template/\*\.py" = \[\n'
+    r"(?:  [^\n]*\n)*?"
+    r"\]\n",
+)
+
+# ``pyproject.toml`` comment line above ``[tool.mypy]::exclude`` that
+# specifically references ``tools/pyproject_template/``. Removed alongside
+# the corresponding array entry so the remaining AI-config excludes are not
+# left dangling beneath a now-irrelevant explanatory comment.
+_PYPROJECT_TEMPLATE_MYPY_EXCLUDE_COMMENT_RE = re.compile(
+    r"# tools/pyproject_template/ uses sys\.path manipulation for standalone execution\n",
+)
+
+# ``pyproject.toml`` array entry ``"tools/pyproject_template/"`` inside
+# ``[tool.mypy]::exclude = [...]``. The trailing ``\s*`` consumes the
+# separator between array entries (comma, optional whitespace and/or
+# newline), which handles both pyproject-fmt-normalized form (``[ ... ]``
+# padded with spaces) and the raw template form.
+_PYPROJECT_TEMPLATE_MYPY_EXCLUDE_ENTRY_RE = re.compile(
+    r'"tools/pyproject_template/",\s*',
+)
+
+# README.md block containing both template-only top-level setup sections.
+# Starts at ``## Quick Setup (Automated)`` and runs up to (but not including)
+# the next top-level heading ``## Development Setup``. The non-greedy body
+# match plus explicit terminator keeps the scrubber from devouring unrelated
+# sections if the consumer has reshuffled headings.
 _README_TEMPLATE_SECTIONS_RE = re.compile(
     r"## Quick Setup \(Automated\)\n.*?(?=## Development Setup\b)",
+    re.DOTALL,
+)
+
+# README.md ``### Migrating an Existing Project`` and ``### Keeping Up to
+# Date`` subsections (under ``## Versioning & Releases``). Both reference
+# template-management scripts that no longer exist in the consumer project
+# (``migrate_existing_project.py`` and ``check_template_updates.py``). The
+# terminator ``### Creating a Release`` is the next subsection that stays.
+_README_TEMPLATE_SUBSECTIONS_RE = re.compile(
+    r"### Migrating an Existing Project\n.*?(?=### Creating a Release\b)",
     re.DOTALL,
 )
 
@@ -229,18 +282,23 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
     or configuration for template-only tooling after the cleanup phase has
     deleted the files those references point at:
 
-    * ``pyproject.toml`` — removes the ``[[tool.mypy.overrides]]`` stanza
-      targeting ``tools.pyproject_template.*`` (which no longer exists after
-      ``cleanup_template_files(CleanupMode.ALL)``).
+    * ``pyproject.toml`` — removes every ``tools/pyproject_template/``
+      artifact: the ruff ``per-file-ignores`` block, the mypy ``exclude``
+      entry (and its explanatory comment), and the mypy override (in both
+      stanza and inline-array form, because ``doit fmt_pyproject`` rewrites
+      the file before cleanup runs in the wizard).
     * ``README.md`` — removes the ``## Quick Setup (Automated)`` and
-      ``## Using This Template (Manual)`` sections, leaving headings above
-      and below intact.
+      ``## Using This Template (Manual)`` top-level sections plus the
+      ``### Migrating an Existing Project`` and ``### Keeping Up to Date``
+      subsections of ``## Versioning & Releases``.
     * ``docs/development/doit-tasks-reference.md`` — removes the
       ``### template_clean`` section and rewrites the TOC table row so the
       remaining ``cleanup`` entry is listed alone.
 
-    Each rewrite guards itself with a "no match -> no change" fast path so
-    repeat calls and already-scrubbed files are no-ops.
+    Patterns are applied blindly; ``re.sub`` is a no-op when nothing matches,
+    and the function detects whether a file changed by comparing final
+    content to the original. That makes the scrubber idempotent — repeat
+    calls and already-scrubbed files record no change.
 
     Args:
         root: Project root directory (defaults to cwd).
@@ -255,30 +313,38 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
 
     changed: list[Path] = []
 
-    # 1. pyproject.toml — remove the tools.pyproject_template.* mypy stanza.
+    # 1. pyproject.toml — scrub all template-only configuration fragments.
     pyproject = root / "pyproject.toml"
     if pyproject.is_file():
         original = pyproject.read_text(encoding="utf-8")
-        if _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE.search(original):
-            new_content = _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE.sub("", original)
+        new_content = original
+        new_content = _PYPROJECT_TEMPLATE_RUFF_PERFILE_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_EXCLUDE_COMMENT_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_EXCLUDE_ENTRY_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE.sub("", new_content)
+        new_content = _PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE.sub("", new_content)
+        if new_content != original:
             if dry_run:
-                Logger.info("Would scrub tools.pyproject_template mypy override in pyproject.toml")
+                Logger.info("Would scrub template-only references in pyproject.toml")
             else:
                 pyproject.write_text(new_content, encoding="utf-8")
-                Logger.success("Removed tools.pyproject_template mypy override from pyproject.toml")
+                Logger.success("Removed template-only references from pyproject.toml")
             changed.append(pyproject)
 
-    # 2. README.md — remove both template-only setup sections.
+    # 2. README.md — scrub both top-level template sections and the two
+    #    template-management subsections under "Versioning & Releases".
     readme = root / "README.md"
     if readme.is_file():
         original = readme.read_text(encoding="utf-8")
-        if _README_TEMPLATE_SECTIONS_RE.search(original):
-            new_content = _README_TEMPLATE_SECTIONS_RE.sub("", original)
+        new_content = original
+        new_content = _README_TEMPLATE_SECTIONS_RE.sub("", new_content)
+        new_content = _README_TEMPLATE_SUBSECTIONS_RE.sub("", new_content)
+        if new_content != original:
             if dry_run:
-                Logger.info("Would scrub template-only setup sections in README.md")
+                Logger.info("Would scrub template-only sections in README.md")
             else:
                 readme.write_text(new_content, encoding="utf-8")
-                Logger.success("Removed template-only setup sections from README.md")
+                Logger.success("Removed template-only sections from README.md")
             changed.append(readme)
 
     # 3. docs/development/doit-tasks-reference.md — remove the template_clean
@@ -287,10 +353,8 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
     if doit_ref.is_file():
         original = doit_ref.read_text(encoding="utf-8")
         new_content = original
-        if _DOIT_REF_TEMPLATE_CLEAN_RE.search(new_content):
-            new_content = _DOIT_REF_TEMPLATE_CLEAN_RE.sub("", new_content)
-        if _DOIT_REF_TOC_TEMPLATE_CLEAN_RE.search(new_content):
-            new_content = _DOIT_REF_TOC_TEMPLATE_CLEAN_RE.sub("`cleanup`", new_content)
+        new_content = _DOIT_REF_TEMPLATE_CLEAN_RE.sub("", new_content)
+        new_content = _DOIT_REF_TOC_TEMPLATE_CLEAN_RE.sub("`cleanup`", new_content)
         if new_content != original:
             if dry_run:
                 Logger.info(


### PR DESCRIPTION
## Description

Follow-up to PR #471 — `scrub_template_references` missed several stale `tools/pyproject_template/` references in spawned projects. Verified against a fresh spawn at `endavis/pyprojecttest`: `doit check` passes post-cleanup (the #469 wizard verification works as designed), but the spawn still carried four unscrubbed artifacts.

**Root cause has two parts:**

1. **Timing bug with pyproject-fmt.** `setup_development_environment` runs `doit fmt_pyproject` before `cleanup_template_suite`. That rewrites `[[tool.mypy.overrides]]` stanzas into an inline-array `overrides = [...]` list. The original regex only matched the stanza form, so the `tools.pyproject_template.*` override survived every spawn.
2. **Regex scope too narrow.** The original scrubber didn't cover three additional pyproject fragments (the ruff `per-file-ignores` block, the `[tool.mypy]::exclude` array entry + its explanatory comment) or the two README subsections under `## Versioning & Releases` (`### Migrating an Existing Project`, `### Keeping Up to Date`) that point at the deleted template-management scripts.

This PR adds the missing patterns and refactors the function to apply every pattern for a given file unconditionally (`re.sub` is a no-op on no match, so the "search first" gating in the original version was unnecessary overhead).

Plan context: [issue #469 reopen comment](https://github.com/endavis/pyproject-template/issues/469).

## Related Issue

Addresses #469 (reopened)

Follow-up to PR #471 (merged in commit `c8d1bf4`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

**`tools/pyproject_template/cleanup.py`:**

- Add four new module-level regex constants alongside the existing ones:
  - `_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_INLINE_RE` — the post-`fmt_pyproject` inline-array form of the mypy override (including its two-line explanatory comment).
  - `_PYPROJECT_TEMPLATE_RUFF_PERFILE_RE` — the whole `lint.per-file-ignores."tools/pyproject_template/*.py" = [ ... ]` block.
  - `_PYPROJECT_TEMPLATE_MYPY_EXCLUDE_COMMENT_RE` — the comment line above `[tool.mypy]::exclude` that specifically references the template path.
  - `_PYPROJECT_TEMPLATE_MYPY_EXCLUDE_ENTRY_RE` — the `"tools/pyproject_template/"` entry in the `exclude` array (preserves the other AI-config excludes).
- Add one new README pattern `_README_TEMPLATE_SUBSECTIONS_RE` for `### Migrating an Existing Project` and `### Keeping Up to Date`.
- Keep the existing `_PYPROJECT_TEMPLATE_MYPY_OVERRIDE_RE` (stanza form) as a fallback for downstream users who invoke the scrubber on an unformatted file.
- Refactor `scrub_template_references` to apply every pattern for a given file unconditionally and detect change via content comparison (`new_content != original`) — cleaner than per-pattern `search → sub`.

**`tests/template/test_cleanup.py`:**

- Add `_PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS` fixture mirroring the real spawn state after `doit fmt_pyproject` normalizes the file.
- Add `_README_WITH_TEMPLATE_SUBSECTIONS` fixture for the Migrating/Keeping-Up-to-Date subsections.
- Add four new test methods in `TestScrubTemplateReferences`:
  - `test_scrubs_pyproject_post_fmt_inline_overrides` — covers the timing-bug fix.
  - `test_scrubs_pyproject_ruff_perfile_ignores` — isolates the ruff block.
  - `test_scrubs_pyproject_mypy_exclude_entry_and_comment` — isolates the comment + array-entry removal; asserts surviving AI-config excludes.
  - `test_scrubs_readme_template_subsections` — isolates the subsection scrub; asserts the `## Versioning & Releases` heading and `### Creating a Release` subsection survive.
- Extend `test_scrub_is_idempotent` to use the realistic post-fmt fixture so every pattern is exercised in the idempotency check.

## Testing

- [x] `doit check` — all gates green (format_check, lint, type_check, security, spell_check, test)
- [x] `TestScrubTemplateReferences` — 13 / 13 pass (9 prior + 4 new)
- [x] `tests/template/test_cleanup.py` — 39 / 39 pass
- [x] End-to-end verification: ran the updated scrubber in dry-run mode against the real spawned `~/src/pyprojecttest` repo; it correctly identifies both `pyproject.toml` and `README.md` as needing scrubbing. Grep of the existing spawn confirms the exact stale fragments this PR targets:
  ```
  pyproject.toml:100: lint.per-file-ignores."tools/pyproject_template/*.py" = [
  pyproject.toml:151: # tools/pyproject_template/ uses sys.path manipulation...
  pyproject.toml:152: exclude = [ "tools/pyproject_template/", ...
  pyproject.toml:157:   { module = "tools.pyproject_template.*", follow_imports = "skip" },
  README.md:108: python tools/pyproject_template/migrate_existing_project.py ...
  README.md:120: python tools/pyproject_template/check_template_updates.py
  ```

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (function docstring refreshed to describe the broader scope)
- [ ] I have updated the CHANGELOG.md (auto-generated at release time from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

- No ADR required — same bug-fix family as the original PR #471; no new architectural decision.
- Existing spawned projects (e.g. created between the #471 merge and this PR's merge) will still carry the stale refs locally. They can pick up the fix by re-running the scrubber: `uv run python -c "from tools.pyproject_template.cleanup import scrub_template_references; scrub_template_references()"` — but note that once a project is fully spawned, `tools/pyproject_template/` itself has been deleted, so the scrubber is no longer available from within the project. For those users, hand-editing or re-spawning is the path forward.
