### PR TITLE
fix: allow --prerelease + --increment on doit release

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -425,20 +425,21 @@ git pull
 doit release_tag
 ```
 
-`--increment` and `--prerelease` are mutually exclusive.
+`--increment` and `--prerelease` can be combined to force a pre-release of a
+specific bump type (e.g. `--prerelease=alpha --increment=minor` → `1.1.0a0`).
+See [issue #475](https://github.com/endavis/pyproject-template/issues/475).
 
 **What `doit release` does:**
 
 1. Verifies you're on `main` with a clean working tree
 2. Validates `--prerelease` (must be empty, `alpha`, `beta`, or `rc`)
-3. Rejects `--prerelease` combined with `--increment`
-4. Pulls latest changes from remote
-5. Validates merge commit format (governance check)
-6. Validates issue links in commits
-7. Runs all checks (`doit check`)
-8. Determines the next version using commitizen (`cz bump --get-next`)
-9. Creates a `release/vX.Y.Z` branch and updates `CHANGELOG.md`
-10. Commits the changelog, pushes the branch, and opens PR `release: vX.Y.Z`
+3. Pulls latest changes from remote
+4. Validates merge commit format (governance check)
+5. Validates issue links in commits
+6. Runs all checks (`doit check`)
+7. Determines the next version using commitizen (`cz bump --get-next`)
+8. Creates a `release/vX.Y.Z` branch and updates `CHANGELOG.md`
+9. Commits the changelog, pushes the branch, and opens PR `release: vX.Y.Z`
 
 **What `doit release_tag` does:**
 

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -824,7 +824,7 @@ Open a release PR with the version bump and changelog updates.
 # Auto-detect the next version from conventional commits
 doit release
 
-# Force a specific increment (mutually exclusive with --prerelease)
+# Force a specific increment
 doit release --increment=major   # 1.0.0 → 2.0.0
 doit release --increment=minor
 doit release --increment=patch
@@ -833,23 +833,26 @@ doit release --increment=patch
 doit release --prerelease=alpha  # 1.0.0 → 1.0.1a0
 doit release --prerelease=beta
 doit release --prerelease=rc
+
+# Force a pre-release of a specific bump type (see issue #475)
+doit release --prerelease=alpha --increment=minor  # 1.0.0 → 1.1.0a0
 ```
 
 **What it does:**
 1. Verifies you're on `main` with a clean working tree
 2. Validates `--prerelease` (must be empty, `alpha`, `beta`, or `rc`)
-3. Rejects `--prerelease` combined with `--increment` (mutually exclusive)
-4. Pulls latest changes
-5. Runs governance validations (merge commit format, issue links)
-6. Runs all quality checks (`doit check`)
-7. Asks commitizen for the next version (`cz bump --get-next`)
-8. Creates a `release/vX.Y.Z` branch and updates `CHANGELOG.md`
-9. Commits the changelog, pushes the branch, and opens PR `release: vX.Y.Z`
+3. Pulls latest changes
+4. Runs governance validations (merge commit format, issue links)
+5. Runs all quality checks (`doit check`)
+6. Asks commitizen for the next version (`cz bump --get-next`)
+7. Creates a `release/vX.Y.Z` branch and updates `CHANGELOG.md`
+8. Commits the changelog, pushes the branch, and opens PR `release: vX.Y.Z`
 
 **Options:**
 - `--increment`: Force `MAJOR`, `MINOR`, or `PATCH` bump (auto-detects if empty).
 - `--prerelease`: `alpha`, `beta`, or `rc`. Empty means a production release.
-  Mutually exclusive with `--increment`.
+  Can be combined with `--increment` to force a pre-release of a specific
+  bump type (see [issue #475](https://github.com/endavis/pyproject-template/issues/475)).
 
 **Requirements:**
 - Must be on `main` branch

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -81,7 +81,9 @@ uv run doit release_tag
 ```
 
 Both commands must be run from `main` with a clean working tree.
-`--prerelease` and `--increment` are mutually exclusive on `doit release`.
+`--prerelease` and `--increment` can be combined (e.g.
+`doit release --prerelease=alpha --increment=minor` forces a pre-release of
+the chosen bump type — see [issue #475](https://github.com/endavis/pyproject-template/issues/475)).
 
 ### Before your first pre-release
 
@@ -135,15 +137,14 @@ uv run doit release --prerelease=rc
 
 1. ✅ Verifies you're on the `main` branch
 2. ✅ Validates `--prerelease` (must be empty, `alpha`, `beta`, or `rc`)
-3. ✅ Rejects `--prerelease` combined with `--increment` (mutually exclusive)
-4. ✅ Checks for uncommitted changes
-5. ✅ Pulls latest changes from remote
-6. ✅ **Runs governance validations** (merge commit format, issue links)
-7. ✅ Runs all quality checks (`doit check`)
-8. ✅ Asks commitizen for the next version (`cz bump --get-next`)
-9. ✅ Creates a `release/vX.Y.Z` branch
-10. ✅ Updates `CHANGELOG.md` and commits it
-11. ✅ Pushes the branch and opens a PR titled `release: vX.Y.Z`
+3. ✅ Checks for uncommitted changes
+4. ✅ Pulls latest changes from remote
+5. ✅ **Runs governance validations** (merge commit format, issue links)
+6. ✅ Runs all quality checks (`doit check`)
+7. ✅ Asks commitizen for the next version (`cz bump --get-next`)
+8. ✅ Creates a `release/vX.Y.Z` branch
+9. ✅ Updates `CHANGELOG.md` and commits it
+10. ✅ Pushes the branch and opens a PR titled `release: vX.Y.Z`
 
 The PR can be reviewed, discussed, and approved like any other change.
 

--- a/tests/template/test_doit_release.py
+++ b/tests/template/test_doit_release.py
@@ -417,9 +417,8 @@ class TestBuildCzGetNextCmd:
                 "rc",
                 ["uv", "run", "cz", "bump", "--get-next", "--yes", "--prerelease", "rc"],
             ),
-            # Both set: helper does NOT validate; the task is responsible for
-            # rejecting this combination. Helper just emits both flags in
-            # increment-then-prerelease order.
+            # Both set: helper emits both flags in increment-then-prerelease
+            # order; the task accepts this combination (see #475).
             (
                 "minor",
                 "alpha",
@@ -723,3 +722,109 @@ class TestReleaseTagGhSearch:
         assert '"head:release/"' in src, (
             "task_release_tag must use head:release/ to find merged release PRs"
         )
+
+
+class _ReachedCzBuild(Exception):  # noqa: N818 - sentinel, not a runtime error
+    """Sentinel raised from ``_build_cz_get_next_cmd`` to halt the task flow.
+
+    Used by ``TestCreateReleasePrValidation`` to prove that control reached
+    the cz step without exercising the real release pipeline. Suffixing
+    ``Error`` would be misleading — this signals success, not failure.
+    """
+
+
+class TestCreateReleasePrValidation:
+    """Tests for the ``--prerelease`` / ``--increment`` validation in
+    ``task_release``'s action (issue #475).
+
+    The mutex that rejected ``--prerelease`` + ``--increment`` has been
+    removed; cz itself accepts both flags (increment forces the base bump,
+    prerelease appends the suffix). These tests mock the pre-cz subprocess
+    calls and the ``_build_cz_get_next_cmd`` helper so the action runs far
+    enough to prove the combination is accepted, then stops via a sentinel
+    exception before any real release work happens.
+
+    The separate invalid-prerelease test guards against the allowed-values
+    check accidentally being deleted alongside the mutex.
+    """
+
+    @staticmethod
+    def _patch_precz_subprocess_calls(monkeypatch: MonkeyPatch) -> None:
+        """Patch everything needed to walk from the action entry to the cz call.
+
+        Mocks in ``tools.doit.release``:
+
+        - ``subprocess.run``: branch=main, status clean, all other calls no-op.
+        - ``run_streamed``: return ``None`` (used for ``git pull`` and
+          ``doit check``).
+        - ``validate_merge_commits`` / ``validate_issue_links``: return ``True``.
+        - ``_build_cz_get_next_cmd``: raise ``_ReachedCzBuild`` so the flow
+          stops before subprocess ever runs cz.
+        """
+
+        def fake_run(
+            cmd: list[str],
+            *_args: object,
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if cmd[:3] == ["git", "branch", "--show-current"]:
+                stdout = "main\n"
+            elif cmd[:3] == ["git", "status", "-s"]:
+                stdout = ""
+            else:
+                stdout = ""
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("tools.doit.release.subprocess.run", fake_run)
+        monkeypatch.setattr("tools.doit.release.run_streamed", lambda *a, **kw: None)
+        # Pretend the repo has a version tag so the tagless-repo guard at
+        # release.py (still enforced for bare --prerelease) doesn't fire
+        # and abort the flow before it reaches _build_cz_get_next_cmd.
+        monkeypatch.setattr("tools.doit.release._repo_has_version_tags", lambda: True)
+        monkeypatch.setattr(
+            "tools.doit.release.validate_merge_commits",
+            lambda _console: True,
+        )
+        monkeypatch.setattr(
+            "tools.doit.release.validate_issue_links",
+            lambda _console: True,
+        )
+
+        def raise_sentinel(_increment: str, _prerelease: str) -> list[str]:
+            raise _ReachedCzBuild
+
+        monkeypatch.setattr("tools.doit.release._build_cz_get_next_cmd", raise_sentinel)
+
+    def test_prerelease_with_increment_is_accepted(self, monkeypatch: MonkeyPatch) -> None:
+        """``--prerelease=alpha --increment=minor`` no longer aborts with SystemExit.
+
+        The mutex at ``release.py`` was removed in #475. This test proves the
+        combination is accepted by walking the action up to the
+        ``_build_cz_get_next_cmd`` call, which the monkeypatch replaces with a
+        sentinel-raising stub. If the mutex had still been in place, the action
+        would have called ``sys.exit(1)`` before reaching that call.
+        """
+        from tools.doit.release import task_release
+
+        self._patch_precz_subprocess_calls(monkeypatch)
+        action = task_release()["actions"][0]
+
+        # The sentinel proves the flow reached cz; SystemExit would mean the
+        # mutex (or some earlier validation) rejected the combination.
+        with pytest.raises(_ReachedCzBuild):
+            action(increment="minor", prerelease="alpha")
+
+    def test_invalid_prerelease_still_rejected(self, monkeypatch: MonkeyPatch) -> None:
+        """An invalid ``--prerelease`` value still raises ``SystemExit``.
+
+        Regression guard: the allowed-values check (``alpha``/``beta``/``rc``)
+        sits immediately above the removed mutex block. This test ensures it
+        was not dropped along with the mutex.
+        """
+        from tools.doit.release import task_release
+
+        self._patch_precz_subprocess_calls(monkeypatch)
+        action = task_release()["actions"][0]
+
+        with pytest.raises(SystemExit):
+            action(prerelease="gamma")

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -263,11 +263,12 @@ def task_release() -> dict[str, Any]:
     reviewer merges the PR, run ``doit release_tag`` to tag ``main`` and
     trigger the publish workflow.
 
-    CLI params (see the ``params`` entry in the returned dict): ``--increment``
-    forces a version increment type; ``--prerelease`` produces a pre-release
-    (alpha/beta/rc). The action function ``create_release_pr`` accepts these
-    as keyword arguments so doit's param parsing reaches them — see #650 for
-    why the closure approach was wrong.
+    CLI params (see the ``params`` entry in the returned dict): ``--prerelease``
+    alone uses conventional-commit hints; ``--increment`` alone forces a bump
+    type; both together force a pre-release of the chosen bump type (see #475).
+    The action function ``create_release_pr`` accepts these as keyword arguments
+    so doit's param parsing reaches them — see #650 for why the closure approach
+    was wrong.
     """
 
     def create_release_pr(increment: str = "", prerelease: str = "") -> None:
@@ -297,14 +298,6 @@ def task_release() -> dict[str, Any]:
             console.print(
                 f"[bold red]❌ Error: Invalid prerelease value '{prerelease}'. "
                 f"Allowed values: alpha, beta, rc (or empty for a production release).[/bold red]"
-            )
-            sys.exit(1)
-
-        # prerelease and increment are mutually exclusive
-        if prerelease and increment:
-            console.print(
-                "[bold red]❌ Error: --prerelease and --increment "
-                "are mutually exclusive.[/bold red]"
             )
             sys.exit(1)
 


### PR DESCRIPTION
## Description

`doit release` hardcoded `--prerelease` and `--increment` as mutually
exclusive, rejecting the combination with a custom error before ever calling
`cz bump`. But `cz bump` itself accepts both flags together — and when
commitizen can't infer a bump type from conventional-commit hints, its own
error message explicitly recommends passing `--increment` to disambiguate.

That false-mutex blocked the first-pre-release-on-a-fresh-repo path that
PR #436 introduced `--prerelease` to support. The fix removes the 7-line
mutex block in `task_release` and lets cz handle flag precedence. No new
logic is needed — the pre-existing helper `_build_cz_get_next_cmd` already
emits both flags in the correct order.

## Related Issue

Addresses #475

Plan: https://github.com/endavis/pyproject-template/issues/475#issuecomment-4306459069

Cross-links:
- #426 — original pre-release issue
- PR #436 — added `--prerelease` (the feature this bug was blocking)
- #448 — tagless-repo refuse guard (complementary; stays in place)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- `tools/doit/release.py`: deleted the mutex block that rejected
  `--prerelease` + `--increment`. Updated the `task_release` docstring so
  "CLI params" documents the three valid combinations:
  1. `--prerelease` alone → uses conventional-commit hints
  2. `--increment` alone → forces a specific bump type
  3. Both together → forces a pre-release of the chosen bump type
- `tests/template/test_doit_release.py`: updated the inline comment on the
  `("minor", "alpha", ...)` parameterize case in
  `TestBuildCzGetNextCmd.test_builds_expected_command` (was "task rejects
  this combination", now "task accepts this combination (see #475)"). Added
  `TestCreateReleasePrValidation` with two tests:
  - `test_prerelease_with_increment_is_accepted` — patches
    `_build_cz_get_next_cmd` to raise a sentinel; invokes the action with
    `increment="minor", prerelease="alpha"`; asserts the sentinel propagates
    (not `SystemExit`), proving control reaches the cz call past the former
    mutex.
  - `test_invalid_prerelease_still_rejected` — regression guard for the
    allowed-values check; invokes with `prerelease="gamma"` and asserts
    `SystemExit`.
- `docs/development/release-and-automation.md`: replaced the "mutually
  exclusive" sentence and removed the stale step 3 from the "What it does"
  list (renumbered subsequent items).
- `docs/development/doit-tasks-reference.md`: removed the "mutually
  exclusive with --prerelease" comment, added an example showing the
  combined usage, and replaced the stale "Options" caveat.
- `.github/CONTRIBUTING.md`: replaced the "mutually exclusive" sentence and
  removed the stale step 3 from the release flow list (renumbered
  subsequent items).

## Testing

- [x] All existing tests pass (`doit check` clean)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Testing notes:**
- `tests/template/test_doit_release.py` — 59 tests pass (unchanged count;
  two new tests in `TestCreateReleasePrValidation` replaced coverage
  previously carried by the removed mutex's parameterize case).
- Full `doit check` suite passes (format, lint, type, security, spell,
  test).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — deferred; `doit release` generates
      CHANGELOG entries from conventional commits at release time.
- [x] My changes generate no new warnings

## Additional Notes

- **ADR:** no `needs-adr` label; no existing ADR describes the `doit
  release` flow surface. Skipped.
- **Complementary guard:** the tagless-repo refuse from #448 stays in
  place — the fix does not touch that validation path. A pre-release on a
  fresh repo still requires a baseline tag (auto-seeded for new projects,
  documented for existing ones).
- **Why the mutex was wrong:** cz bump's own error message recommends
  passing `--increment` when conventional-commit hints are thin — the
  exact scenario on a fresh repo. The mutex rejected the combination cz
  itself was telling the user to try.
