### PR TITLE
fix: document three trusted-publisher registrations in publish_setup

### DIFF
--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -802,7 +802,7 @@ doit publish_setup
 **What it does:**
 1. Resolves the `owner/repo` slug.
 2. Creates (idempotently) the `testpypi` and `pypi` environments used by the release workflows for OIDC authentication.
-3. Prints follow-up instructions for registering the project as a trusted publisher on TestPyPI (`https://test.pypi.org/manage/account/publishing/`) and PyPI (`https://pypi.org/manage/account/publishing/`). That registration must be completed manually through the PyPI web UI.
+3. Prints follow-up instructions for registering three trusted publishers — one per `(workflow, environment)` pair the template uses: `testpypi.yml` × `testpypi`, `release.yml` × `testpypi`, and `release.yml` × `pypi`. Registration is done on TestPyPI (`https://test.pypi.org/manage/account/publishing/`) and PyPI (`https://pypi.org/manage/account/publishing/`); both must be completed manually through the PyPI web UI.
 
 **Requirements:**
 - `gh` installed and authenticated with repo-admin permissions.

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -169,13 +169,27 @@ Release workflows use GitHub environments for OIDC-based publishing.
 ### OIDC Trusted Publisher Configuration
 
 Both environments use PyPI's trusted publisher mechanism instead of API tokens.
-Configure the trusted publisher on PyPI and TestPyPI:
+PyPI scopes each trusted publisher per `(owner, repo, workflow, environment)`
+tuple, so the template requires **three** separate registrations — one for
+each `(workflow, env)` pair the publish flow uses:
+
+| # | Host | Workflow | Environment | Purpose |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | TestPyPI | `testpypi.yml` | `testpypi` | Pre-release uploads (`v*-*` tags) |
+| 2 | TestPyPI | `release.yml` | `testpypi` | Production-release canary (before PyPI) |
+| 3 | PyPI | `release.yml` | `pypi` | Production-release publish |
+
+For every registration, supply the same common fields:
 
 - **Publisher:** GitHub Actions
 - **Owner:** Your GitHub username or organization
 - **Repository:** Your repository name
-- **Workflow:** `release.yml` (for PyPI) or `testpypi.yml` (for TestPyPI)
-- **Environment:** `pypi` or `testpypi` respectively
+
+Then fill in the row-specific **Workflow** and **Environment** from the
+table above. Missing registration #2 is the most common failure mode —
+pre-releases still work, but the first production release fails at the
+`release.yml` TestPyPI canary step with `403 Invalid API Token: OIDC
+scoped token is not valid for project`.
 
 **Automated:** Partial. Run `doit publish_setup` to create the `testpypi`
 and `pypi` environments in one step (idempotent). Trusted publishers must

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -222,7 +222,7 @@ succeed:
 
 | Environment | Used by | Purpose |
 | --- | --- | --- |
-| `testpypi` | `release.yml` (pre-release step), `testpypi.yml` | OIDC identity for TestPyPI |
+| `testpypi` | `release.yml` (pre-publish canary), `testpypi.yml` | OIDC identity for TestPyPI |
 | `pypi` | `release.yml` (production step) | OIDC identity for PyPI |
 
 The environments are created empty — no protection rules, reviewers, or
@@ -273,23 +273,38 @@ full option matrix.
 
 Creating the GitHub Environment is only half the setup. The other half
 is registering this project as a trusted publisher on PyPI and TestPyPI,
-which must be done by the project owner through the PyPI web UI:
+which must be done by the project owner through the PyPI web UI.
 
-- TestPyPI: <https://test.pypi.org/manage/account/publishing/>
-- PyPI: <https://pypi.org/manage/account/publishing/>
+PyPI scopes trusted publishers per `(owner, repo, workflow, environment)`
+tuple, and the template fires three distinct `(workflow, env)` pairs —
+two against TestPyPI and one against PyPI. Each pair needs its own
+registration:
 
-For both forms, supply:
+| # | Host | Registration page | Workflow | Environment | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| 1 | TestPyPI | <https://test.pypi.org/manage/account/publishing/> | `testpypi.yml` | `testpypi` | Pre-release uploads (`v*-*` tags) |
+| 2 | TestPyPI | <https://test.pypi.org/manage/account/publishing/> | `release.yml` | `testpypi` | Production-release canary — `release.yml` uploads to TestPyPI before PyPI as a sanity check |
+| 3 | PyPI | <https://pypi.org/manage/account/publishing/> | `release.yml` | `pypi` | Production-release publish |
+
+For every form, supply the same common fields:
 
 - **PyPI project name** — the distribution name from `pyproject.toml`.
 - **Owner** — the GitHub user or organization that owns the repository.
 - **Repository name** — the repository name on GitHub.
-- **Workflow filename** — `release.yml` for PyPI, `testpypi.yml` for
-  TestPyPI.
-- **Environment name** — `pypi` for PyPI, `testpypi` for TestPyPI.
 
-Once both sides are registered, pushing a `v*` tag (via `doit release`
-followed by `doit release_tag`) triggers the publish workflow, which
-authenticates via OIDC and uploads the built distribution.
+And use the per-row **Workflow filename** and **Environment name** from
+the table above.
+
+Skipping registration #2 is the most common mistake. Pre-releases still
+work (they use registration #1), but the first production release fails
+at `release.yml`'s TestPyPI canary step with a `403 Invalid API Token:
+OIDC scoped token is not valid for project` error — because
+`release.yml` + `testpypi` is a different scope from `testpypi.yml` +
+`testpypi`.
+
+Once all three sides are registered, pushing a `v*` tag (via `doit
+release` followed by `doit release_tag`) triggers the publish workflow,
+which authenticates via OIDC and uploads the built distribution.
 
 **Further reading**
 

--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -224,8 +224,10 @@ Manually configure what the automated setup does automatically:
 3. **PyPI publishing environments**:
    - Run `doit publish_setup` to create the `testpypi` and `pypi`
      environments and print the trusted-publisher registration steps.
-   - Follow the links in the printed output to register the project as a
-     trusted publisher on TestPyPI and PyPI.
+   - Follow the links in the printed output to register **three** trusted
+     publishers — one per `(workflow, environment)` pair. See the
+     [release automation guide](../development/release-and-automation.md#trusted-publisher-registration-manual)
+     for the full table.
 
 4. **Secrets** (Settings → Secrets → Actions):
    - Add `CODECOV_TOKEN` (optional, for coverage uploads)

--- a/tests/template/test_doit_github.py
+++ b/tests/template/test_doit_github.py
@@ -1003,3 +1003,37 @@ class TestTaskPublishSetup:
         ]
         assert len(put_calls) == 1
         assert put_calls[0].args[0][4] == "repos/acme/widgets/environments/pypi"
+
+    def test_output_lists_all_three_trusted_publishers(
+        self, mock_subprocess: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Panel output enumerates all three (workflow, env) registrations."""
+        mock_subprocess.register(
+            {
+                ("gh", "repo", "view"): {"stdout": "acme/widgets\n"},
+                ("gh", "api", "repos/acme/widgets/environments/testpypi"): {"returncode": 0},
+                ("gh", "api", "repos/acme/widgets/environments/pypi"): {"returncode": 0},
+            }
+        )
+
+        self._action()()
+
+        # Collapse all whitespace so assertions are robust against any
+        # rich-driven line wrapping inside the Panel.fit output.
+        captured = capsys.readouterr().out
+        collapsed = " ".join(captured.split())
+
+        # All three (workflow, env) pairs must be mentioned.
+        assert "workflow=testpypi.yml, env=testpypi" in collapsed
+        assert "workflow=release.yml, env=testpypi" in collapsed
+        assert "workflow=release.yml, env=pypi" in collapsed
+
+        # Both publishing URLs must appear. The TestPyPI URL must appear
+        # at least twice (once per TestPyPI registration).
+        assert "https://pypi.org/manage/account/publishing/" in collapsed
+        assert "https://test.pypi.org/manage/account/publishing/" in collapsed
+        assert collapsed.count("https://test.pypi.org/manage/account/publishing/") >= 2
+
+        # The owner/repo values from _gh_repo_slug must appear.
+        assert "acme" in collapsed
+        assert "widgets" in collapsed

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -1285,17 +1285,23 @@ def task_publish_setup() -> dict[str, Any]:
         console.print(
             Panel.fit(
                 "[bold]Next steps (manual, outside this tool):[/bold]\n\n"
-                "  1. Register the TestPyPI trusted publisher:\n"
+                "  Register THREE trusted publishers — PyPI scopes them per\n"
+                "  (owner, repo, workflow, environment) tuple, so each\n"
+                "  (workflow, env) pair the template uses needs its own entry.\n\n"
+                "  1. TestPyPI — workflow=testpypi.yml, env=testpypi\n"
                 "     https://test.pypi.org/manage/account/publishing/\n"
-                "  2. Register the PyPI trusted publisher:\n"
-                "     https://pypi.org/manage/account/publishing/\n\n"
-                "  When filling the forms, use:\n"
+                "     Purpose: pre-release uploads (v*-* tags).\n\n"
+                "  2. TestPyPI — workflow=release.yml, env=testpypi\n"
+                "     https://test.pypi.org/manage/account/publishing/\n"
+                "     Purpose: production-release canary (release.yml uploads\n"
+                "     to TestPyPI before PyPI as a sanity check).\n\n"
+                "  3. PyPI — workflow=release.yml, env=pypi\n"
+                "     https://pypi.org/manage/account/publishing/\n"
+                "     Purpose: production-release publish.\n\n"
+                "  Common fields for all three forms:\n"
                 "     PyPI project name: (your pypi-name from pyproject.toml)\n"
                 f"     Repository owner:  {owner}\n"
-                f"     Repository name:   {repo}\n"
-                "     Workflow filename: release.yml (for pypi) /\n"
-                "                        testpypi.yml (for testpypi)\n"
-                "     Environment name:  pypi / testpypi",
+                f"     Repository name:   {repo}",
                 border_style="cyan",
             )
         )


### PR DESCRIPTION
## Description

`doit publish_setup` created the two GitHub environments correctly but
printed instructions for only **two** PyPI trusted-publisher registrations.
In reality, the template needs **three**: PyPI scopes trusted-publisher
credentials per `(owner, repo, workflow, environment)` tuple, and
`release.yml` pushes to TestPyPI (as a canary) on a different workflow
file than `testpypi.yml` — so that canary needs its own registration
distinct from the pre-release `testpypi.yml` × `testpypi` entry.

The practical symptom: pre-releases via `testpypi.yml` worked fine, but
the first production release hit `403 Invalid API Token: OIDC scoped
token is not valid for project` at `release.yml`'s TestPyPI canary step,
long after the user thought setup was complete.

This PR updates the `publish_setup` output and the two places in `docs/`
that explain trusted-publisher setup to enumerate all three registrations,
and pins the output shape with a new test so a future refactor can't
silently reintroduce the gap.

### Trusted publishers the template now documents

| # | Host | Workflow | Environment | Purpose |
| :--- | :--- | :--- | :--- | :--- |
| 1 | TestPyPI | `testpypi.yml` | `testpypi` | Pre-release uploads (`v*-*` tags) |
| 2 | TestPyPI | `release.yml` | `testpypi` | Production-release canary (before PyPI) |
| 3 | PyPI | `release.yml` | `pypi` | Production-release publish |

Registration #2 is the one that was previously missing and causes the
first-production-release 403.

## Related Issue

Addresses #479

Plan comment: https://github.com/endavis/pyproject-template/issues/479#issuecomment-4306937106

Related release-UX fixes in the same family:
- #475 — release mutex fix
- #478 — `release_tag` URL placeholder fix

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- `tools/doit/github.py` — rewrote the `Panel.fit(...)` block in
  `task_publish_setup().setup()` to list all three trusted publishers,
  each with its PyPI registration URL, workflow, environment, and purpose.
  Moved the shared fields (PyPI project name, owner, repo) into a single
  "common fields" block so the per-row entries stay focused on the
  `(workflow, env)` pair that differs.
- `docs/development/release-and-automation.md` — replaced the two-row
  trusted-publisher section with a three-row table covering every
  `(workflow, env)` tuple. Added a paragraph naming registration #2 as
  the usual cause of the first-production-release 403. Relabeled the
  misleading "pre-release step" cell on the environments table to
  "pre-publish canary" to match reality.
- `docs/development/github-repository-settings.md` — same three-row
  structure and same 403-canary callout in the "OIDC Trusted Publisher
  Configuration" section.
- `docs/development/doit-tasks-reference.md` — updated the `publish_setup`
  "What it does" bullet to name the three registrations rather than
  implying a single per-registry registration.
- `docs/template/new-project.md` — updated the post-setup manual-steps
  list to call out three registrations and cross-link to the detailed
  table in the release-automation guide.
- `tests/template/test_doit_github.py::TestTaskPublishSetup` — added
  `test_output_lists_all_three_trusted_publishers` using `capsys`.
  Collapses whitespace to survive rich's panel wrapping, asserts each
  of the three `workflow=X, env=Y` pairs, both PyPI URLs (TestPyPI URL
  appears at least twice since it serves two rows), and `acme`/`widgets`
  owner/repo interpolation from the monkeypatched repo slug.

## Testing

- [x] All existing tests pass (`doit check` passed locally)
- [x] Added new tests for new functionality
- [x] Manually tested the changes (reviewed rendered panel output and
      docs tables)

`TestTaskPublishSetup` now has 4 tests, all green:

```
tests/template/test_doit_github.py::TestTaskPublishSetup::test_creates_both_when_missing PASSED
tests/template/test_doit_github.py::TestTaskPublishSetup::test_idempotent_when_both_exist PASSED
tests/template/test_doit_github.py::TestTaskPublishSetup::test_creates_only_missing PASSED
tests/template/test_doit_github.py::TestTaskPublishSetup::test_output_lists_all_three_trusted_publishers PASSED
```

The new test pins the message content (all three `(workflow, env)` pairs,
both registration URLs, interpolated owner/repo), so a future refactor
that drops a row will fail this test instead of silently shipping a
first-production-release 403.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated on release)
- [x] My changes generate no new warnings

## Additional Notes

No ADR changes: issue #479 is a documentation/instructions bug fix, not
an architectural change. The template's publishing architecture
(OIDC + GitHub environments + per-`(workflow, env)` trusted-publisher
scoping) is unchanged; this PR just makes the setup instructions match
what PyPI actually requires.
