### PR TITLE
feat: add Gemini-native /implement and /finalize plus split planner

### DIFF
--- a/.claude/commands/plan-both.md
+++ b/.claude/commands/plan-both.md
@@ -51,10 +51,10 @@ Prompt the subagent with:
 
 Save the subagent's output as Claude's plan.
 
-**Gemini's plan** — invoke Gemini CLI non-interactively:
+**Gemini's plan** — invoke Gemini CLI non-interactively, using the stdout-only variant so Gemini does not post to GitHub itself (Claude posts both plans below):
 
 ```bash
-gemini -p "/plan-issue $ARGUMENTS" --yolo 2>/dev/null
+gemini -p "/plan-issue-stdout $ARGUMENTS" --yolo 2>/dev/null
 ```
 
 Capture the stdout output as Gemini's plan.

--- a/.gemini/commands/finalize.md
+++ b/.gemini/commands/finalize.md
@@ -1,0 +1,83 @@
+# Finalize (Gemini)
+
+Finalize the current branch: update documentation, commit changes, and create a PR.
+
+## Instructions
+
+This command operates on the current branch. It assumes implementation and review are complete.
+
+### Step 1: Gather context
+
+1. **Detect the current branch and linked issue:**
+   ```bash
+   git branch --show-current
+   ```
+   Extract the issue number from the branch name (e.g., `feat/245-description` → `#245`).
+   - If on `main`, tell the user they need to be on a feature branch and stop.
+
+2. **Get the issue details:**
+   ```bash
+   gh issue view <number> --json title,labels
+   ```
+
+3. **Check for uncommitted changes:**
+   ```bash
+   git status --short
+   ```
+   - If there are unstaged or uncommitted changes, list them for the user.
+   - These will be included in the commit — confirm with the user that all changes should be included.
+
+4. **Check what changed vs main:**
+   ```bash
+   git diff main --stat
+   ```
+
+### Step 2: Finalization
+
+Execute the finalization steps directly in the current context:
+
+1. **Read the project rules:**
+   - Read `AGENTS.md` — understand commit guidelines, PR checklist, ADR requirements.
+   - Read `.github/CONTRIBUTING.md` — understand commit format.
+   - Read `.github/pull_request_template.md` — understand PR structure.
+
+2. **Check documentation needs:**
+   - Review the changed files — do any user-facing behaviors change?
+   - If yes, identify which docs in `docs/` need updating and update them.
+   - Check `docs/decisions/` for related ADRs that need updating.
+
+3. **Check ADR needs:**
+   - If the issue has the `needs-adr` label, create an ADR using `doit adr`.
+   - If the changes relate to an existing ADR, update it with the issue link.
+   - Every ADR must link to documentation in `docs/`.
+
+4. **Run final validation:**
+   - Run: `doit check`
+   - ALL checks must pass before proceeding.
+
+5. **Draft the PR description:**
+   - Read `.github/pull_request_template.md` for structure.
+   - Run `mkdir -p tmp/agents/gemini` to ensure the directory exists.
+   - Write the PR body to `tmp/agents/gemini/pr-body-issue-<n>.md`.
+   - The body MUST include `Addresses #<issue-number>`.
+
+### Step 3: Commit and create PR
+
+1. **Show the user:**
+   - Documentation changes made (if any)
+   - ADR changes made (if any)
+   - Suggested commit message following conventional format: `<type>: <subject>`
+   - Suggested PR title following conventional format: `<type>: <subject>`
+   - Path to the PR body file (`tmp/agents/gemini/pr-body-issue-<n>.md`)
+
+2. **Ask the user for approval** to commit and create the PR.
+
+3. **Only after user confirms:**
+   - Stage files: `git add <specific files>` (include all changed files).
+   - Commit with the approved message.
+   - Create PR: `doit pr --title="<type>: <subject>" --body-file=tmp/agents/gemini/pr-body-issue-<n>.md`
+   - Delete the temp file: `rm tmp/agents/gemini/pr-body-issue-<n>.md`
+
+4. **Report the PR URL to the user.**
+
+**IMPORTANT:** Do NOT commit or create the PR without explicit user confirmation.

--- a/.gemini/commands/implement.md
+++ b/.gemini/commands/implement.md
@@ -1,0 +1,87 @@
+# Implement Issue (Gemini)
+
+Implement the plan for GitHub issue #$ARGUMENTS.
+
+## Instructions
+
+This command performs the implementation of an approved plan for the specified issue. Unlike Claude, Gemini executes the implementation steps directly within the main conversation context.
+
+### Step 1: Validate preconditions
+
+1. **Verify the issue exists and is open:**
+   ```bash
+   gh issue view $ARGUMENTS --json number,title,state,labels
+   ```
+   - If the issue does not exist or is closed, tell the user and stop.
+
+2. **Verify a plan comment exists:**
+   Fetch all comments and search for the plan header:
+   ```bash
+   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
+   ```
+   - If no plan comment is found, tell the user:
+     > "No implementation plan found for issue #$ARGUMENTS. Run `/plan-issue $ARGUMENTS` first."
+   - Stop and wait for the user.
+
+3. **Check current branch state:**
+   ```bash
+   git branch --show-current
+   git status --short
+   ```
+   - If already on a branch matching `*/$ARGUMENTS-*` (e.g., `feat/$ARGUMENTS-description`):
+     - Tell the user you're resuming work on the existing branch
+     - Skip branch creation (Step 2)
+     - If there are uncommitted changes, warn the user and ask how to proceed
+   - If on `main` or a different branch: proceed to Step 2
+
+### Step 2: Create the branch
+
+Only if not already on the correct branch:
+
+1. Fetch the issue to determine the branch type:
+   ```bash
+   gh issue view $ARGUMENTS --json title,labels
+   ```
+2. Determine branch type from labels:
+   - `enhancement` → `feat`
+   - `bug` → `fix`
+   - `refactor` → `refactor`
+   - `documentation` → `docs`
+   - `chore` → `chore`
+   - Default → `issue`
+3. Create and switch to branch:
+   ```bash
+   git checkout main && git pull
+   git checkout -b <type>/$ARGUMENTS-<short-description>
+   ```
+
+### Step 3: Implementation
+
+Execute the implementation directly in the current context:
+
+1. **Read the plan:** Fetch the plan comment again and use it as your implementation guide.
+2. **Read project rules:**
+   - Read `AGENTS.md` — understand workflow, conventions, and patterns.
+   - Read `.github/CONTRIBUTING.md` — understand commit format.
+3. **Explore the codebase:** Identify relevant files, modules, and tests if not already known from the planning phase.
+4. **Implement changes:**
+   - Create or modify the files as specified in the plan.
+   - Follow existing patterns and conventions.
+   - **Always include tests:** Add or update test files to verify your changes.
+
+### Step 4: Run validation
+
+1. Run `doit check` and iterate on any failures until they are resolved.
+
+### Step 5: Present changes to user
+
+Show the user:
+- Summary of what was implemented
+- Files changed
+- Test results
+- Any issues or deviations from the plan
+
+Tell the user:
+- Review the changes and test as needed
+- Discuss any fixes directly in conversation
+- When satisfied, use `/finalize` to commit and create a PR

--- a/.gemini/commands/plan-issue-stdout.md
+++ b/.gemini/commands/plan-issue-stdout.md
@@ -1,0 +1,75 @@
+# Plan Issue – Stdout (Gemini)
+
+Create an implementation plan for GitHub issue #$ARGUMENTS and emit it to stdout.
+
+## Instructions
+
+This command is for **orchestration use only** — it is invoked by Claude's
+`/plan-both` command via `gemini -p "/plan-issue-stdout <n>" --yolo` so the
+orchestrating Claude agent can capture the plan and post it to GitHub itself.
+
+**Output clean markdown to stdout — do NOT post to GitHub directly.** Posting
+from here would create duplicate comments because the orchestrator also posts.
+
+If you are a Gemini-first user planning an issue, use `/plan-issue` instead —
+that variant posts the approved plan to GitHub for you.
+
+### Step 1: Fetch the issue details
+
+```bash
+gh issue view $ARGUMENTS --json title,body,labels,assignees
+```
+
+- Parse the issue body to understand what needs to be done
+- Check if the issue has the `needs-adr` label
+
+### Step 2: Read the project standards
+
+- Read `AGENTS.md` — understand workflow, conventions, and patterns
+- Identify relevant coding standards and testing requirements
+
+### Step 3: Explore the codebase
+
+- Identify which files, modules, and tests are relevant
+- Understand existing patterns and conventions in the affected areas
+- Check for related ADRs in `docs/decisions/`
+
+### Step 4: Output the implementation plan
+
+Output the plan in this exact format:
+
+```
+## Implementation Plan for #<number>: <title>
+
+### Overview
+Brief description of what will be done.
+
+### Files to Create/Modify
+- [ ] `path/to/file.py` — description of changes
+- [ ] `tests/test_file.py` — description of test coverage
+
+### Test Plan
+- [ ] Test case 1: description
+- [ ] Test case 2: description
+
+### Documentation
+- [ ] Any docs that need updating
+- [ ] ADR needed: yes/no (if yes, brief description)
+
+### Validation
+- [ ] `doit check` passes
+- [ ] Manual verification steps
+
+### Risks and Considerations
+- Any potential issues, edge cases, or trade-offs to consider
+
+---
+*Plan by: Gemini* | *Date: <today's date>*
+```
+
+### Important
+
+- Output ONLY the plan markdown — no preamble, no conversational text
+- Be specific about file paths and function names
+- Include concrete test cases, not vague descriptions
+- Note any risks or alternative approaches worth considering

--- a/.gemini/commands/plan-issue.md
+++ b/.gemini/commands/plan-issue.md
@@ -1,36 +1,58 @@
 # Plan Issue (Gemini)
 
-Create an implementation plan for GitHub issue #$ARGUMENTS.
+Plan the implementation for GitHub issue #$ARGUMENTS.
 
 ## Instructions
 
-You are being invoked to provide a planning perspective. Your plan will be posted
-to the GitHub issue by the orchestrating agent (Claude). Output clean markdown to
-stdout — do NOT post to GitHub directly.
+This command runs in the main conversation context so the user can ask questions,
+discuss tradeoffs, and refine the plan interactively. After the user approves it,
+the plan is posted to the issue as a comment.
 
-### Step 1: Fetch the issue details
+If you are being invoked non-interactively by a dual-agent orchestrator (Claude's
+`/plan-both`), you should be reading `/plan-issue-stdout` instead — that variant
+emits the plan to stdout without posting, which is what the orchestrator needs.
+
+### Step 1: Validate the issue
+
+1. **Verify the issue exists and is open:**
+   ```bash
+   gh issue view $ARGUMENTS --json number,title,state,labels
+   ```
+   - If the issue does not exist, tell the user and stop.
+   - If the issue is closed, tell the user and ask if they want to reopen it or stop.
+
+2. **Check for an existing plan comment:**
+   ```bash
+   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
+   ```
+   - If a plan comment already exists, warn the user:
+     > "Issue #$ARGUMENTS already has an implementation plan comment. Continuing will post a new one. Proceed?"
+   - Wait for user confirmation before continuing.
+
+### Step 2: Read the project rules
+
+- Read `AGENTS.md` — understand workflow, conventions, and commit guidelines.
+- Identify relevant coding standards and testing requirements.
+
+### Step 3: Fetch the issue details
 
 ```bash
 gh issue view $ARGUMENTS --json title,body,labels,assignees
 ```
 
-- Parse the issue body to understand what needs to be done
-- Check if the issue has the `needs-adr` label
+- Parse the issue body to understand what needs to be done.
+- Check if the issue has the `needs-adr` label.
 
-### Step 2: Read the project standards
+### Step 4: Explore the codebase
 
-- Read `AGENTS.md` — understand workflow, conventions, and patterns
-- Identify relevant coding standards and testing requirements
+- Identify which files, modules, and tests are relevant.
+- Understand existing patterns and conventions in the affected areas.
+- Check for related ADRs in `docs/decisions/`.
+- If anything is ambiguous or there are multiple valid approaches, **ask the user** before deciding.
 
-### Step 3: Explore the codebase
+### Step 5: Draft the plan and iterate with the user
 
-- Identify which files, modules, and tests are relevant
-- Understand existing patterns and conventions in the affected areas
-- Check for related ADRs in `docs/decisions/`
-
-### Step 4: Output the implementation plan
-
-Output the plan in this exact format:
+Draft the plan in this exact format and present it to the user:
 
 ```
 ## Implementation Plan for #<number>: <title>
@@ -61,9 +83,27 @@ Brief description of what will be done.
 *Plan by: Gemini* | *Date: <today's date>*
 ```
 
-### Important
+Then:
 
-- Output ONLY the plan markdown — no preamble, no conversational text
-- Be specific about file paths and function names
-- Include concrete test cases, not vague descriptions
-- Note any risks or alternative approaches worth considering
+1. Ask the user for feedback on the plan.
+2. Discuss alternatives, answer questions, and adjust the plan as the user requests.
+3. Keep iterating until the user explicitly says the plan is approved.
+4. Do NOT post the plan until the user confirms approval.
+
+### Step 6: Post the approved plan to the issue
+
+Only after the user explicitly approves the plan, post it as a comment:
+
+```bash
+gh issue comment $ARGUMENTS --body "<approved plan>"
+```
+
+Tell the user:
+- The plan has been posted as a comment on issue #$ARGUMENTS.
+- When ready, use `/implement $ARGUMENTS` to start implementation.
+
+## See Also
+
+- `/implement $ARGUMENTS` — implement the approved plan.
+- `/finalize` — commit changes and create a PR.
+- `/plan-issue-stdout $ARGUMENTS` — orchestration-only variant (output to stdout, no posting).

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -47,6 +47,16 @@
     "showToolCalls": true
   },
   "context": {
-    "files": ["AGENTS.md", "GEMINI.md"]
+    "files": [
+      "AGENTS.md",
+      "GEMINI.md"
+    ]
+  },
+  "general": {
+    "defaultApprovalMode": "auto_edit"
+  },
+  "security": {
+    "enablePermanentToolApproval": true,
+    "autoAddToPolicyByDefault": true
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,11 +295,13 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 | CLI | Config Directory | Notes |
 | :--- | :--- | :--- |
 | Claude Code | `.claude/` | Commands, agents, settings. Primary source of slash commands. |
-| Gemini CLI | `.gemini/` | Commands and settings. Output-only commands (orchestrated by Claude). |
+| Gemini CLI | `.gemini/` | Commands and settings. Supports a standalone workflow (`/plan-issue`, `/implement`, `/finalize`) and Claude-orchestrated dual-agent flows. |
 | GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
 | Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. |
 
 Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/plan-issue`, `/implement`, `/finalize`, etc.) works out of the box.
+
+Gemini CLI ships standalone implementations of `/plan-issue`, `/implement`, and `/finalize` under `.gemini/commands/`. They share the GitHub-artifact contract (plan comment header `## Implementation Plan for #<n>: <title>`, `<type>/<n>-<slug>` branch names, `Addresses #<n>` PR body) with the Claude versions, so users can switch agents mid-workflow without losing state.
 
 Codex CLI does **not** use repo-defined slash commands in this template. Its repo-native workflow is provided through checked-in skills under `.agents/skills/`, invoked with built-in Codex skill selection such as `/skills` or explicit mentions like `$plan-issue`.
 

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -23,7 +23,7 @@ This template is designed primarily for **Claude Code**, which is the only agent
 | Agent | Permission model | Hooks support | Slash commands | LSP | Dual-agent role |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Codex CLI** | TOML approval policies (`.codex/config.toml`) plus repo skills (`.agents/skills/`) | Project-level `tools/hooks/ai/` apply via Codex hooks | Built-in only; repo workflow uses skills | Not documented | Standalone alternative (not part of dual-agent flow) |
-| **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 2 output-only (`/plan-issue`, `/review-pr`) | Not documented | Second-opinion reviewer / planner in dual-agent flow |
+| **Gemini CLI** | JSON allowlists + lifecycle hooks (`.gemini/settings.json`) | Project-level hooks apply; Gemini lifecycle hooks supported | 5 (`/plan-issue`, `/implement`, `/finalize` standalone; `/plan-issue-stdout`, `/review-pr` orchestration-only) | Not documented | Standalone alternative; second-opinion reviewer / planner in dual-agent flow |
 | **GitHub Copilot CLI** | JSON hook config (`.github/hooks/copilot-hooks.json`) | Project-level hooks apply; Copilot `preToolUse` hook wired | Auto-discovers from `.claude/commands/` | Not documented | Standalone alternative (auto-discovers Claude commands) |
 | **Claude Code** | Layered permissions (`.claude/settings.local.json` + `.claude/settings.json` PreToolUse hooks) | Project-level hooks plus Claude PreToolUse hooks | 8 (`plan-issue`, `implement`, `finalize`, `close-issue`, `plan-both`, `review-both`, `gemini-review`, `where-am-i`) | Supported | Primary orchestrator in single-agent and dual-agent flows |
 

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -34,9 +34,9 @@ The default Claude flow takes an issue from unplanned to closed. Each step produ
 
 The dual-agent flow replaces the planning and (optionally) review steps with orchestrated calls that spawn Claude and Gemini in **isolated contexts**. The design intent is that neither agent can bias the other: each generates its output without seeing the other's work, and the orchestrating Claude agent in the main conversation posts both raw outputs plus a synthesis.
 
-Gemini commands under `.gemini/commands/` are **output-only**: Gemini does not post to GitHub itself. The orchestrating Claude agent captures Gemini's stdout and posts it via `gh`.
+The Gemini commands invoked from the orchestrator (`/plan-issue-stdout` and `/review-pr`) are **output-only**: Gemini does not post to GitHub itself. The orchestrating Claude agent captures Gemini's stdout and posts it via `gh`. (Gemini's standalone planning command, `/plan-issue`, does post directly — but `/plan-both` invokes the stdout-only variant to avoid duplicate comments.)
 
-1. **`/plan-both <n>`** — replaces `/plan-issue`. Claude validates the issue, then in parallel (a) spawns a general-purpose subagent to produce a Claude plan and (b) invokes `gemini -p "/plan-issue <n>" --yolo` to produce a Gemini plan. Both are posted as separate comments on the issue, Claude synthesizes a combined plan, reviews it with the user, and posts the approved synthesized plan.
+1. **`/plan-both <n>`** — replaces `/plan-issue`. Claude validates the issue, then in parallel (a) spawns a general-purpose subagent to produce a Claude plan and (b) invokes `gemini -p "/plan-issue-stdout <n>" --yolo` to produce a Gemini plan. Both are posted as separate comments on the issue, Claude synthesizes a combined plan, reviews it with the user, and posts the approved synthesized plan.
 2. **`/implement <n>`** — same as the single-agent flow. The synthesized plan comment is the input.
 3. **`/review-both`** — runs after a PR exists. In parallel spawns a Claude review subagent and invokes `gemini -p "/review-pr" --yolo`, posts both reviews as PR comments, and posts a combined synthesis listing consensus findings, agent-specific findings, and a combined verdict. Alternatively, **`/gemini-review`** runs only the Gemini review and posts it (useful when the user wants a second opinion without a full Claude review).
 4. **`/finalize`**, merge, and **`/close-issue <n>`** — same as the single-agent flow.
@@ -78,7 +78,7 @@ Validates that the issue is open and that a plan comment exists (otherwise instr
 
 **Args:** issue number. **Source:** `.claude/commands/plan-both.md`.
 
-Dual-agent replacement for `/plan-issue`. Validates the issue, warns if plan comments already exist, then generates two plans in isolated contexts — a Claude plan via a spawned subagent and a Gemini plan via `gemini -p "/plan-issue <n>" --yolo` — posts both as separate issue comments, synthesizes a combined plan that highlights agreements and divergences, reviews the synthesis with the user, and only posts the synthesized plan after explicit approval. **Workflow position:** first step of the dual-agent workflow. **Design note:** isolated contexts are mandatory so neither agent can see the other's output while drafting; Claude is the orchestrator and the only agent that writes to GitHub.
+Dual-agent replacement for `/plan-issue`. Validates the issue, warns if plan comments already exist, then generates two plans in isolated contexts — a Claude plan via a spawned subagent and a Gemini plan via `gemini -p "/plan-issue-stdout <n>" --yolo` (the stdout-only variant of Gemini's planner) — posts both as separate issue comments, synthesizes a combined plan that highlights agreements and divergences, reviews the synthesis with the user, and only posts the synthesized plan after explicit approval. **Workflow position:** first step of the dual-agent workflow. **Design note:** isolated contexts are mandatory so neither agent can see the other's output while drafting; Claude is the orchestrator and the only agent that writes to GitHub.
 
 ### `/plan-issue <n>`
 
@@ -98,13 +98,45 @@ Dual-agent PR review. Verifies a PR exists for the current branch, then in paral
 
 Inspects the current git state (branch, uncommitted changes, recent log), extracts the issue number from the branch name if on a feature branch, checks for a plan comment, unpushed commits, and open PRs, then reports a status summary and suggests the next command to run. **Workflow position:** any time. **Design note:** read-only and side-effect-free — safe to run whenever the user is unsure where they are in the lifecycle.
 
-### `/plan-issue <n>` (Gemini)
+## Gemini
+
+Gemini-first users can complete the full issue lifecycle using Gemini-native commands. This workflow shares the same artifacts (plan comments, branch names, PR bodies) as the Claude flow, enabling seamless handoff between agents.
+
+### Standalone workflow
+
+1. **`/plan-issue <n>` (Gemini)** — Gemini reads the issue and project rules, explores the codebase, and drafts a plan inline in the conversation. After the user approves the plan, Gemini posts it as a comment on the issue with the header `## Implementation Plan for #<n>: <title>`.
+2. **User review of the plan** — same as Claude flow.
+3. **`/implement <n>` (Gemini)** — Gemini validates the plan comment, creates the feature branch, and implements the changes inline in the conversation. It runs `doit check` to verify the implementation.
+4. **User review of the changes** — same as Claude flow.
+5. **`/finalize` (Gemini)** — Gemini detects the branch and issue, checks for doc/ADR updates, runs `doit check`, and drafts the commit message and PR body. After user approval, it stages, commits, and creates the PR via `doit pr`.
+
+### Command reference
+
+#### `/finalize` (Gemini)
+
+**Args:** none. **Source:** `.gemini/commands/finalize.md`.
+
+Gemini-native implementation of the finalize command. Detects the branch and issue, checks for uncommitted changes, reviews changed files for documentation/ADR updates, runs `doit check`, and drafts a commit message and PR body (written to `tmp/agents/gemini/pr-body-issue-<n>.md`). After user approval, it stages files, commits, and creates the PR via `doit pr`. **Workflow position:** after implementation and review. **Design note:** unlike the Claude version, all operations happen inline in the main conversation context.
+
+#### `/implement <n>` (Gemini)
+
+**Args:** issue number. **Source:** `.gemini/commands/implement.md`.
+
+Gemini-native implementation of the implement command. Validates the issue and plan comment, creates the feature branch, and implements the changes inline in the conversation. Runs `doit check` to verify the implementation. **Workflow position:** after plan exists, before `/finalize`. **Design note:** performs all implementation steps directly in the main conversation context rather than spawning a subagent.
+
+#### `/plan-issue <n>` (Gemini)
 
 **Args:** issue number. **Source:** `.gemini/commands/plan-issue.md`.
 
-Invoked by Claude's `/plan-both` orchestration command via `gemini -p "/plan-issue <n>" --yolo`. Fetches the issue, reads `AGENTS.md`, explores the codebase, and outputs a plan in the standard format to stdout, signed `*Plan by: Gemini*`. **Workflow position:** called indirectly from `/plan-both`. **Design note:** output-only — the command explicitly instructs Gemini not to post to GitHub; the orchestrating Claude agent captures stdout and posts it.
+Gemini-native standalone planning command. Validates the issue, reads `AGENTS.md`, explores the codebase, and drafts a plan inline in the conversation. Iterates with the user until the plan is approved, then posts it to the issue as a comment via `gh issue comment`. Mirrors the behavior of Claude's `/plan-issue`. **Workflow position:** start of standalone Gemini workflow, before `/implement`. **Design note:** Gemini has no plan-mode equivalent, so iteration happens in the regular conversation context.
 
-### `/review-pr` (Gemini)
+#### `/plan-issue-stdout <n>` (Gemini)
+
+**Args:** issue number. **Source:** `.gemini/commands/plan-issue-stdout.md`.
+
+Orchestration-only variant of `/plan-issue`. Invoked by Claude's `/plan-both` command via `gemini -p "/plan-issue-stdout <n>" --yolo`. Fetches the issue, reads `AGENTS.md`, explores the codebase, and outputs a plan in the standard format to stdout, signed `*Plan by: Gemini*`. **Workflow position:** called indirectly from `/plan-both`. **Design note:** output-only — the command explicitly instructs Gemini not to post to GitHub; the orchestrating Claude agent captures stdout and posts it. Split from `/plan-issue` so the standalone command can post directly without producing duplicate comments under orchestration.
+
+#### `/review-pr` (Gemini)
 
 **Args:** none. **Source:** `.gemini/commands/review-pr.md`.
 
@@ -134,7 +166,7 @@ GitHub Copilot CLI automatically discovers project skills from `.claude/commands
 
 **Implement-worker subagent:** Shared with Claude — defined in `.claude/agents/implement-worker.md`. Copilot CLI's `task` tool reads this file when `/implement` spawns the subagent.
 
-**No parallel command files needed:** Because Copilot CLI discovers skills from `.claude/commands/` directly, you do not need to maintain a separate `.copilot/commands/` directory unless you need to override Claude-specific behavior for Copilot sessions.
+**No parallel command files needed:** Because Copilot CLI discovers skills from `.claude/commands/` directly, you do not need to maintain a separate `.copilot/commands/` directory unless you want to override Claude-specific behavior for Copilot sessions.
 
 ## Adding a new slash command
 


### PR DESCRIPTION
## Description

Adds standalone Gemini-native implementations of `/implement` and `/finalize` under `.gemini/commands/`, completing the Gemini-first issue-to-PR workflow. The new commands share the GitHub-artifact contract (plan comment header, `<type>/<n>-<slug>` branch names, `Addresses #<n>` PR body) with the Claude versions, so users can switch agents mid-workflow without losing state.

Also splits the existing Gemini `/plan-issue` into two commands so standalone use can post plans to GitHub directly (matching Claude's `/plan-issue`) without producing duplicate comments under dual-agent orchestration.

## Related Issue

Addresses #398

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**New commands**
- `.gemini/commands/implement.md` — Gemini-native `/implement`. Validates issue + plan comment, creates branch from issue labels, implements inline, runs `doit check`, hands off to `/finalize`.
- `.gemini/commands/finalize.md` — Gemini-native `/finalize`. Detects branch + issue, checks for doc/ADR updates, runs `doit check`, drafts commit + PR body to `tmp/agents/gemini/pr-body-issue-<n>.md`, requires user approval before staging/committing/`doit pr`.
- `.gemini/commands/plan-issue.md` — **rewritten** for standalone use. Validates issue, drafts plan inline with the user, posts to GitHub on approval. Mirrors Claude's `/plan-issue`.

**Renamed / repurposed**
- `.gemini/commands/plan-issue-stdout.md` — orchestration-only variant. Receives the original `/plan-issue` content (output-to-stdout, no posting). Used by Claude's `/plan-both`. Git treats this as a new file because the new `/plan-issue` content differs too much for rename detection.

**Updated callers**
- `.claude/commands/plan-both.md` — invocation changed from `gemini -p "/plan-issue <n>" --yolo` to `gemini -p "/plan-issue-stdout <n>" --yolo`. Without this, the new posting-`/plan-issue` would create duplicate comments (Gemini posts + Claude posts).

**Configuration**
- `.gemini/settings.json` — added `general.defaultApprovalMode: "auto_edit"` plus `security.enablePermanentToolApproval: true` and `security.autoAddToPolicyByDefault: true` so `/implement` can run end-to-end without per-tool prompts. Also restored the trailing newline.

**Documentation**
- `AGENTS.md` — refreshed the Gemini row in the AI Config Directories table; added a Gemini-native workflow paragraph between the Copilot and Codex notes.
- `docs/development/ai/slash-commands.md` — added a "Gemini" section with a standalone-workflow narrative and reference entries for `/finalize`, `/implement`, `/plan-issue`, `/plan-issue-stdout`, `/review-pr`. Updated the dual-agent narrative and `/plan-both` reference to invoke the stdout variant.
- `docs/development/AI_SETUP.md` — Gemini row now lists 5 commands (3 standalone + 2 orchestration-only) and the dual-agent role line is expanded to "standalone alternative; second-opinion reviewer/planner."

## Plan vs. delivery (from issue #398)

| # | Plan item | Status |
|---|---|---|
| 1 | `.gemini/commands/plan-issue.md`: cross-link to `/implement` / `/finalize` | ✅ Plus rewrite for standalone posting (see scope expansion below) |
| 2 | `.gemini/commands/implement.md`: precondition check → branch creation (label mapping) → inline impl → `doit check` → hand-off | ✅ Inline approach (option (a)) chosen as planned |
| 3 | `.gemini/commands/finalize.md`: detect → rules → doc/ADR → `doit check` → PR body to `tmp/agents/gemini/pr-body-issue-<n>.md` → user approval → commit + `doit pr` | ✅ |
| 4 | `docs/development/ai/slash-commands.md`: parallel Gemini entries + shared-artifact contract | ✅ |
| 5 | `AGENTS.md`: short Gemini-native workflow note pointing at the three commands | ✅ |

## Scope expansions beyond the original plan

Two changes go beyond the explicit text of #398; both are listed here for reviewer attention.

1. **`.gemini/settings.json` — auto-approval enablement.** The original plan didn't mention settings changes. Without `auto_edit` mode and the security policy flags, `/implement` stops at every tool call waiting for user approval, which defeats the purpose of an inline implement command. Defensible but worth a deliberate look.
2. **`/plan-issue` split into two commands.** The original plan said *"Leave [plan-issue] as-is; possibly add a cross-link"*. That preserved a friction point where standalone Gemini users had to manually copy the stdout output into a `gh issue comment`. Splitting into a posting `/plan-issue` and an orchestration-only `/plan-issue-stdout` removes that friction and makes the two agents' standalone behaviors symmetrical. Updated `.claude/commands/plan-both.md` accordingly.

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

Verification:
- `doit check` — all green (format, lint, type, security, spell, test)

End-to-end dry run of the standalone Gemini flow is **not** validated in this PR (no live invocation against the Gemini CLI binary). The success criterion in #398 calling for an end-to-end run should be exercised on a small follow-up issue before relying on the new commands in production.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

This branch was created off `main` after PR #484 merged the pip CVE fix. The working-tree changes were originally drafted on `main` by a prior session and were carried into the new branch via `git checkout -b`. No commits were ever made directly on `main`.
