### PR TITLE
fix: use App token in request-rebase job for dependabot push-access check

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -232,12 +232,24 @@ jobs:
     name: Request dependabot rebase for stale PRs
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      # The @dependabot rebase comment must be posted by an actor with push
+      # access. github-actions[bot] (the default GITHUB_TOKEN identity) is
+      # rejected by dependabot's command parser, so we mint an App token when
+      # the App is configured and fall back to GITHUB_TOKEN only for graceful
+      # degradation.
+      - name: Generate App token
+        id: app-token
+        if: ${{ vars.RELEASE_APP_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Find stale dependabot PRs and request rebase
         uses: actions/github-script@v9
         with:
+          github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,


### PR DESCRIPTION
## Description

The `request-rebase` job in `.github/workflows/dependabot-automerge.yml` posted `@dependabot rebase` comments using `secrets.GITHUB_TOKEN`, which authenticates as `github-actions[bot]`. Dependabot's command parser rejects comments from that actor with:

> Sorry, only users with push access can use that command.

The result was that the auto-rebase escape hatch never actually rebased anything — stale dependabot PRs stayed `BEHIND main` until a maintainer manually commented `@dependabot rebase` as themselves. Reproduced on this repo on 2026-04-27 (PRs #486–#490).

This PR mirrors the App-token / `GITHUB_TOKEN` fallback pattern that the `enable-automerge` job in the same workflow already uses, so the rebase request is now authored by the App identity (which dependabot accepts as having push access).

## Related Issue

Addresses #492

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added a `Generate App token` step to the `request-rebase` job, gated by `if: vars.RELEASE_APP_ID != ''` (same pattern as `enable-automerge`).
- Passed the resolved token to `actions/github-script@v9` via its `github-token:` input, falling back to `secrets.GITHUB_TOKEN` when the App is not configured.
- Removed the job-level `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` block — the script uses the GitHub API client from `actions/github-script`, not the `gh` CLI, so `GH_TOKEN` was unused.
- Added an inline comment explaining *why* the App is required so the fix doesn't regress.

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type, security, spell, tests).
- [ ] Added new tests for new functionality — N/A; this is a workflow YAML change with no Python surface to test.
- [x] Manually tested the changes — verified the YAML structure in-place. End-to-end validation will happen on the next `workflow_dispatch` or scheduled tick after merge: the rebase comment should be authored by the App and accepted by dependabot.

Note: this fix does not retroactively unstick the PRs already affected (#486–#490). Those still need a manual `@dependabot rebase` from a user with push access.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A; workflow YAML
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — separate in-flight docs work covers App configuration; will land in its own PR.
- [ ] I have updated the CHANGELOG.md — handled at release time.
- [x] My changes generate no new warnings

## Additional Notes

The `enable-automerge` job's pattern was the model for this change; both jobs now resolve their token the same way. The graceful fallback to `GITHUB_TOKEN` is preserved (the rebase comment will still fail if the App isn't configured, but that's the existing behavior — the App being absent is already documented as a degraded mode in `docs/development/dependabot-automerge.md`).
