### PR TITLE
chore: add 7-day cooldown to dependabot uv updates for supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
       - "automated"
     commit-message:
       prefix: "chore(deps)"
+    # Defends auto-merge against supply-chain attacks that publish malicious
+    # versions and are yanked within hours-to-days. Security-update PRs
+    # (advisory-driven) bypass cooldown, so CVE patching is not delayed.
+    cooldown:
+      default-days: 7
+      include:
+        - "*"
     groups:
       dev-dependencies:
         patterns:

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -167,6 +167,35 @@ Lists live in `.github/automerge-config.json`:
 Globs use `*` as a wildcard and are matched case-insensitively against the full
 dependency name. Edit the file via a normal PR to change policy.
 
+## Version-update cooldown
+
+To defend against supply-chain attacks that publish malicious versions and
+are detected and yanked within hours-to-days, the `uv` ecosystem entry in
+`.github/dependabot.yml` sets a 7-day
+[`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--):
+
+```yaml
+cooldown:
+  default-days: 7
+  include:
+    - "*"
+```
+
+Dependabot waits 7 days from a new version's release date before opening a
+PR for it, so a malicious release that is yanked within a few days never
+produces a PR to auto-merge.
+
+**Security-update PRs bypass cooldown.** Per the dependabot docs: *"the
+`cooldown` option is only available for version updates, not security
+updates."* Advisory-driven PRs continue to land at full speed, so CVE
+patching latency is unchanged.
+
+**The `github-actions` ecosystem is not covered.** Dependabot's `cooldown`
+only supports SemVer ecosystems and explicitly excludes `github-actions`.
+Action bumps continue to flow through auto-merge under the existing
+`automerge-config.json` rules; tighter handling for actions is tracked
+separately.
+
 ## Rebase handling for stale PRs
 
 The workflow includes a scheduled job (every 6 hours, plus `workflow_dispatch`)
@@ -187,6 +216,7 @@ does not spam the bot while a rebase is in progress.
 ## Related
 
 - `AGENTS.md` section [Dependabot PRs](../../AGENTS.md#dependabot-prs)
+- `.github/dependabot.yml`
 - `.github/workflows/dependabot-automerge.yml`
 - `.github/workflows/dependabot-blocked-label.yml`
 - `.github/automerge-config.json`


### PR DESCRIPTION
## Description

Adds a 7-day version-update cooldown to the `uv` ecosystem entry in `.github/dependabot.yml` to defend the auto-merge path against supply-chain attacks — compromised maintainer accounts publishing malicious patches or minors that are typically detected and yanked within hours to days.

Dependabot waits 7 days from a new version's release date before opening a PR for it, so a malicious release that gets pulled within a few days never produces a PR for auto-merge to act on. **Security-update PRs (advisory-driven) bypass cooldown**, so CVE patching latency is unchanged.

## Related Issue

Addresses #494

## Type of Change

- [x] Code refactoring (configuration tightening — no behavioral change to existing code; changes upstream policy only)

## Changes Made

- `.github/dependabot.yml` — added a `cooldown` block (`default-days: 7`, `include: ["*"]`) on the `uv` ecosystem entry, with an inline comment explaining the threat model and the security-update bypass.
- `docs/development/dependabot-automerge.md` — added a `## Version-update cooldown` section that documents the configuration, the security-update bypass (quoted and linked to the GitHub docs), and the explicit non-coverage of the `github-actions` ecosystem. Added `.github/dependabot.yml` to the `## Related` list.

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type, security, spell, tests).
- [ ] Added new tests for new functionality — N/A; configuration change with no Python surface to test.
- [x] Manually tested the changes — YAML structure verified by re-read; pre-commit `check yaml` passes via `doit check`. End-to-end behavior will be observable on the next dependabot run cycle (any PRs opened for versions less than 7 days old will be deferred until they age in).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — `docs/development/dependabot-automerge.md` updated.
- [ ] I have updated the CHANGELOG.md — handled at release time.
- [x] My changes generate no new warnings

## Additional Notes

**Out of scope for this PR (intentional):**

- The `github-actions` ecosystem. Dependabot's `cooldown` only supports SemVer ecosystems and explicitly excludes `github-actions`. Hardening action bumps (e.g. SHA pinning, or a workflow-side ecosystem check that disables auto-merge for `github-actions` PRs) is a separate follow-up.
- Changes to `.github/automerge-config.json` or `.github/workflows/dependabot-automerge.yml`. Cooldown enforcement happens upstream of those.
- Currently-open dependabot PRs (#486–#490) are not affected retroactively; the cooldown applies only to PRs opened after this lands.

This builds on #492 (the `request-rebase` token fix that just merged): together, #492 made the auto-merge workflow function as designed, and this change tightens the policy it enforces.
