### PR TITLE
chore: remove broken request-rebase job from dependabot-automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,9 +7,6 @@ name: Dependabot Auto-merge
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-  schedule:
-    - cron: '0 */6 * * *'
-  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -227,74 +224,3 @@ jobs:
               issue_number: prNumber,
               body,
             });
-
-  request-rebase:
-    name: Request dependabot rebase for stale PRs
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    steps:
-      # The @dependabot rebase comment must be posted by an actor with push
-      # access. github-actions[bot] (the default GITHUB_TOKEN identity) is
-      # rejected by dependabot's command parser, so we mint an App token when
-      # the App is configured and fall back to GITHUB_TOKEN only for graceful
-      # degradation.
-      - name: Generate App token
-        id: app-token
-        if: ${{ vars.RELEASE_APP_ID != '' }}
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
-      - name: Find stale dependabot PRs and request rebase
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-
-            const oneHourAgo = Date.now() - 60 * 60 * 1000;
-
-            for (const pr of prs) {
-              if (!pr.user || pr.user.login !== 'dependabot[bot]') continue;
-
-              const labels = (pr.labels || []).map(l => l.name);
-              if (!labels.includes('ready-to-merge')) continue;
-
-              // Fetch fresh PR to get mergeable_state.
-              const { data: fresh } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-              });
-              if (fresh.mergeable_state !== 'behind') continue;
-
-              // Skip if @dependabot rebase was requested in the last hour.
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                per_page: 100,
-              });
-              const recentRebase = comments.some(c =>
-                c.body && c.body.includes('@dependabot rebase') &&
-                new Date(c.created_at).getTime() > oneHourAgo
-              );
-              if (recentRebase) {
-                core.info(`PR #${pr.number}: recent rebase request; skipping`);
-                continue;
-              }
-
-              core.info(`PR #${pr.number}: requesting @dependabot rebase`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: '@dependabot rebase',
-              });
-            }

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -196,22 +196,34 @@ Action bumps continue to flow through auto-merge under the existing
 `automerge-config.json` rules; tighter handling for actions is tracked
 separately.
 
-## Rebase handling for stale PRs
+## Stale PRs
 
-The workflow includes a scheduled job (every 6 hours, plus `workflow_dispatch`)
-that finds qualifying dependabot PRs whose branches have fallen behind `main`
-and asks dependabot to rebase:
+When `main` advances after a dependabot PR is opened, the PR ends up
+`BEHIND` and stops auto-merging. There is no fully-automated rebase path
+the workflow can use, so the unstick step is manual:
 
+```bash
+gh pr comment <number> --body "@dependabot rebase"
 ```
-@dependabot rebase
-```
 
-This follows the signed-commit rule documented in the
+Dependabot rebases the branch and force-pushes. The `synchronize` event
+re-runs the Merge Gate and CI, and the already-enabled auto-merge fires
+when checks go green.
+
+> [!IMPORTANT]
+> The comment **must be posted by a real user** (your `gh` CLI auth, or
+> the PR sidebar UI). Dependabot's command parser rejects `@dependabot`
+> commands from GitHub Apps, including the App configured for this repo
+> — see upstream issue
+> [dependabot/dependabot-core#9147](https://github.com/dependabot/dependabot-core/issues/9147).
+> Posting the rebase request from a workflow that authenticates as the
+> App, or as `github-actions[bot]` via `GITHUB_TOKEN`, fails with
+> *"Sorry, only users with push access can use that command."*
+
+This also follows the signed-commit rule documented in the
 [Dependabot PRs](../../AGENTS.md#dependabot-prs) section of `AGENTS.md`:
-**never** call the GitHub `update-branch` API or rebase locally, because both
-strip dependabot's verified commit signatures. The job also skips any PR that
-already received a `@dependabot rebase` comment within the last hour, so it
-does not spam the bot while a rebase is in progress.
+**never** call the GitHub `update-branch` API or rebase locally, because
+both strip dependabot's verified commit signatures.
 
 ## Related
 

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -354,14 +354,24 @@ class TestOnTriggers:
         for required in ("opened", "reopened", "synchronize", "ready_for_review"):
             assert required in types, f"pull_request_target.types missing '{required}': {types}"
 
-    def test_schedule_and_workflow_dispatch_retained(self) -> None:
-        """``schedule`` and ``workflow_dispatch`` drive the rebase-requester job,
-        so they must remain triggers on this workflow."""
+    def test_schedule_and_workflow_dispatch_absent(self) -> None:
+        """``schedule`` and ``workflow_dispatch`` must not be triggers on this
+        workflow.
+
+        These triggers previously drove a ``request-rebase`` job that posted
+        ``@dependabot rebase`` on stale PRs. That job was removed in #496
+        because dependabot's command parser rejects all GitHub App actors
+        (upstream issue dependabot/dependabot-core#9147), so the comment
+        could never be accepted. The remaining jobs (``evaluate``,
+        ``enable-automerge``, ``comment-skip``) all gate on
+        ``github.event_name == 'pull_request_target'``, so a schedule or
+        workflow_dispatch tick would just spin up an empty workflow run.
+        """
         workflow = _load_workflow()
         triggers = workflow.get("on") or workflow.get(True)
         assert triggers is not None
-        assert "schedule" in triggers
-        assert "workflow_dispatch" in triggers
+        assert "schedule" not in triggers
+        assert "workflow_dispatch" not in triggers
 
 
 class TestConcurrency:
@@ -382,9 +392,11 @@ class TestConcurrency:
     def test_concurrency_group_keyed_on_pr_number_or_ref(self) -> None:
         """The group key must reference ``pull_request.number`` and ``github.ref``.
 
-        ``pull_request.number`` isolates PR runs from each other;
-        ``github.ref`` is the fallback for schedule/workflow_dispatch runs
-        that have no PR context.
+        ``pull_request.number`` isolates PR runs from each other.
+        ``github.ref`` remains in the expression as a defensive fallback
+        for any future trigger that might lack PR context; today every
+        triggered event is ``pull_request_target`` and always populates
+        ``pull_request.number``.
         """
         workflow = _load_workflow()
         group: str = workflow["concurrency"]["group"]


### PR DESCRIPTION
## Description

Removes the `request-rebase` job from `.github/workflows/dependabot-automerge.yml`. The job posted `@dependabot rebase` on stale PRs, but dependabot's command parser rejects all GitHub App actors regardless of permissions — see upstream [dependabot/dependabot-core#9147](https://github.com/dependabot/dependabot-core/issues/9147). PR #493's App-token wiring made the comment author *correct* (`endavis-release-bot` instead of `github-actions[bot]`) but did not address the underlying authz check; end-to-end validation on workflow run [24998738823](https://github.com/endavis/pyproject-template/actions/runs/24998738823) confirmed the comment is still rejected with *"Sorry, only users with push access can use that command."*

Since there is no path that does not either re-introduce a PAT (reversing the project's App-only stance) or strip dependabot's verified commit signatures (forbidden by `AGENTS.md`), the job is removed and the documented unstick path is now manual.

The `enable-automerge` job's App-token usage from #493 is **unaffected**. That fix correctly addressed the original bug — GitHub Apps *can* author `labeled` events that trigger downstream workflows, so the `require-label` Merge Gate flip works as intended. Only the `@dependabot rebase` comment path was blocked by dependabot's authz check.

## Related Issue

Addresses #496

## Type of Change

- [x] Code refactoring (removes dead automation that cannot achieve its purpose)

## Changes Made

- **`.github/workflows/dependabot-automerge.yml`** (−73 lines): removed the entire `request-rebase` job, its `Generate App token` step, and the `actions/github-script` rebase loop. Removed `schedule:` and `workflow_dispatch:` from the `on:` block — they served no purpose without the rebase job (the surviving jobs gate on `github.event_name == 'pull_request_target'`, so cron ticks would only spin up empty workflow runs).
- **`docs/development/dependabot-automerge.md`**: replaced the `## Rebase handling for stale PRs` section with `## Stale PRs`. New copy documents the manual unstick path (`gh pr comment <number> --body "@dependabot rebase"`) and includes a `> [!IMPORTANT]` callout that links to dependabot/dependabot-core#9147 and explains why the workflow itself cannot post the command. Retains the signed-commit / no-`update-branch`-API rule.
- **`tests/test_dependabot_automerge_workflow.py`**: inverted `test_schedule_and_workflow_dispatch_retained` → `test_schedule_and_workflow_dispatch_absent`. The new test pins the intentional removal so a future change-of-mind has to delete or rewrite it, not just the workflow. Docstring references this issue (#496) and the upstream limitation. Also updated the stale rationale in `TestConcurrency.test_concurrency_group_keyed_on_pr_number_or_ref`'s docstring (the schedule/workflow_dispatch fallback rationale became inaccurate; rewrote as a defensive-fallback note — the assertion itself is unchanged).

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type, security, spell, 735 tests).
- [x] Added new tests for new functionality — repurposed the existing trigger-shape test as a positive assertion of the new state.
- [x] Manually tested the changes — workflow YAML restructured and verified by re-read; `doit check` exercises the new test against the updated workflow.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — handled at release time.
- [x] My changes generate no new warnings

## Additional Notes

This is the third in a related sequence:

- #493 — wired the App token into the workflow so `labeled` events trigger Merge Gate (fixes the `require-label` stuck-at-FAILURE bug).
- #495 — added a 7-day cooldown to `dependabot.yml` so freshly published versions can't auto-merge before the supply-chain detection window closes.
- This PR — removes the rebase-requester job that #493 *appeared* to fix but, on validation, could never have worked due to dependabot/dependabot-core#9147. Closes the loop honestly.

Out of scope: `github.ref` remains in the concurrency group expression as a defensive fallback. Removing it is cosmetic since today's only trigger always populates `pull_request.number`. Tracked for a future cleanup if it ever matters.
