### PR TITLE
docs: clarify GitHub App vs PAT setup and credential scope in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -473,7 +473,44 @@ protection rules cover tag pushes, configure a bypass for the tagging step.
 The release PR itself is reviewed and merged through the normal PR flow, so
 no bypass is required for the commit and changelog changes.
 
-#### Organization Repositories: GitHub App (Recommended)
+#### Which path should I use?
+
+The two paths below are not "personal vs. organization" — a GitHub App
+works just as well on a personal account. The real distinction is **where
+your release runs from** and **whether you want full dependabot
+auto-merge automation**:
+
+| Use case | Recommended |
+| :--- | :--- |
+| CI-driven releases (workflow publishes from GitHub Actions) | **GitHub App** |
+| Dependabot auto-merge end-to-end automation | **GitHub App** (required) |
+| Org policy disallows PATs | **GitHub App** |
+| Solo / hobby repo, releasing only from your laptop, no CI release | **Fine-grained PAT** |
+
+> [!IMPORTANT]
+> The dependabot auto-merge workflow at
+> `.github/workflows/dependabot-automerge.yml` **requires a GitHub App**. A
+> PAT does not substitute, because the workflow needs the bot's `labeled`
+> event to trigger the Merge Gate — see
+> [Dependabot Auto-merge → Required GitHub App configuration](../docs/development/dependabot-automerge.md#required-github-app-configuration).
+
+#### Recommended: GitHub App
+
+A dedicated GitHub App is the modern, audit-friendly identity for release
+automation. It works for both personal-account repositories and
+organization repositories. Use this path if you want:
+
+- The dependabot auto-merge workflow to be fully automated end-to-end
+- A clean bot identity in the audit log instead of human attribution
+- Automatic short-lived token rotation (no manual PAT renewals)
+- A bypass-listed actor for any CI-driven tag-push flow you add later
+
+> [!NOTE]
+> The publish workflow at `.github/workflows/release.yml` uses **PyPI
+> trusted publishing (OIDC)** and the built-in `GITHUB_TOKEN`. It does not
+> consume `RELEASE_APP_ID` or `RELEASE_APP_PRIVATE_KEY`. Those credentials
+> exist for the dependabot auto-merge workflow and for any CI-driven
+> tag-push extension you might add — see step 5 below.
 
 Create a dedicated GitHub App that can bypass branch protection:
 
@@ -509,14 +546,39 @@ Create a dedicated GitHub App that can bypass branch protection:
 3. Select your release app from the list
 4. Save the ruleset
 
-**4. Store Secrets:**
+**4. Store Credentials at the Repository Scope:**
 
-In your repo **Settings** → **Secrets and variables** → **Actions**:
+In your repo **Settings** → **Secrets and variables** → **Actions** — store
+both at the **repository** scope, not in an environment:
 
-- Add **Secret:** `RELEASE_APP_PRIVATE_KEY` = contents of the `.pem` file
-- Add **Variable:** `RELEASE_APP_ID` = the App ID from step 1
+- **Secrets** tab → **New repository secret:**
+  `RELEASE_APP_PRIVATE_KEY` = contents of the `.pem` file
+- **Variables** tab → **New repository variable:**
+  `RELEASE_APP_ID` = the App ID from step 1
 
-**5. Update Workflows (if using CI-based releases):**
+> [!WARNING]
+> Use the repository scope, not an environment scope. The `enable-automerge`
+> job in `.github/workflows/dependabot-automerge.yml` does not declare an
+> `environment:`, so `${{ vars.RELEASE_APP_ID }}` and
+> `${{ secrets.RELEASE_APP_PRIVATE_KEY }}` only resolve at the repository (or
+> organization) scope. Storing either as an environment secret/variable makes
+> them silently resolve to an empty string at runtime — the workflow's
+> `if: vars.RELEASE_APP_ID != ''` guard fails closed and the label is applied
+> with `GITHUB_TOKEN`, which leaves the Merge Gate's `require-label` check
+> stuck at `FAILURE`.
+
+**5. Optional: CI-Driven Tag-Push Flow (not used by this template's `release.yml`):**
+
+This template's `release.yml` is triggered by a tag push that the
+maintainer makes locally with `doit release_tag`, and the publish step
+itself uses OIDC + `GITHUB_TOKEN` — so no App credentials are consumed by
+the workflow as shipped.
+
+If you later add a CI-driven flow that needs to push commits or tags from
+inside Actions (for example, a `workflow_dispatch` job that runs `cz
+bump`, commits the changelog, and pushes the tag), mint an App
+installation token and check out with it so the push uses the App's
+identity:
 
 ```yaml
 - name: Generate release token
@@ -533,9 +595,21 @@ In your repo **Settings** → **Secrets and variables** → **Actions**:
     fetch-depth: 0
 ```
 
-#### Personal Repositories: Personal Access Token (PAT)
+Because the App is on the Ruleset bypass list (step 3), pushes signed by
+its installation token can land on `main` and on protected tag refs
+without rule violations.
 
-For personal (non-organization) repositories, use a fine-grained PAT:
+#### Alternative: Fine-Grained PAT (local-only releases)
+
+Use this path **only** if all of the following apply:
+
+- You release from a maintainer's laptop with `doit release_tag` (no CI)
+- You don't need the dependabot auto-merge workflow's full automation
+- You're comfortable rotating the PAT before its expiration
+
+For any other case, use the [GitHub App path](#recommended-github-app)
+above. CI-driven releases or dependabot auto-merge automation should not
+use a PAT.
 
 **1. Create a Fine-Grained PAT:**
 
@@ -561,22 +635,6 @@ git config --global credential.helper store
 
 # Option 2: Include token in remote URL (less secure)
 git remote set-url origin https://<token>@github.com/username/repo.git
-```
-
-**3. Store as Secret (for CI-based releases):**
-
-In your repo **Settings** → **Secrets and variables** → **Actions**:
-
-- Add **Secret:** `RELEASE_PAT` = your PAT
-
-**4. Update Workflows:**
-
-```yaml
-- name: Checkout with PAT
-  uses: actions/checkout@v4
-  with:
-    token: ${{ secrets.RELEASE_PAT }}
-    fetch-depth: 0
 ```
 
 ### Release Checklist

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -115,7 +115,7 @@ env:
 ### Configuring the App
 
 Follow the full setup in
-[GitHub Repository Settings → Release Permissions](../../.github/CONTRIBUTING.md#organization-repositories-github-app-recommended).
+[GitHub Repository Settings → Release Permissions](../../.github/CONTRIBUTING.md#recommended-github-app).
 The auto-merge workflow reuses the same App as the release workflow. When
 creating or updating the App, ensure the repository permissions include:
 


### PR DESCRIPTION
## Description

Restructures the "Setting Up Release Permissions" section of `.github/CONTRIBUTING.md` to fix three confusions in the existing copy:

1. **Misleading "personal vs. org" framing.** A GitHub App works just as well on a personal account; the real decision axis is *CI-driven vs local-only releases* and *whether you want full dependabot auto-merge automation*.
2. **No guidance on App credential storage scope.** Storing `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` in an *environment* (rather than at the repository scope) silently breaks the `enable-automerge` job — the same failure mode this session debugged for #492 / #493.
3. **`release.yml` is not currently App-credentialed.** The current docs frame "step 5" as required for "CI-based releases", but `release.yml` uses PyPI OIDC + `GITHUB_TOKEN`. The App credentials are only consumed by the dependabot auto-merge workflow today.

This PR also tightens the PAT path to its actual remaining use case (local-only releases from a maintainer's laptop) by dropping the obsolete CI-as-PAT subsections.

## Related Issue

Addresses #498

## Type of Change

- [x] Documentation update

## Changes Made

**`.github/CONTRIBUTING.md`** — restructure of the "Setting Up Release Permissions" section:

- Added `#### Which path should I use?` subsection with a decision table (CI-driven / dependabot auto-merge / org policy / solo-local) and a `> [!IMPORTANT]` callout that the dependabot auto-merge workflow requires the App and a PAT does not substitute.
- Renamed `#### Organization Repositories: GitHub App (Recommended)` → `#### Recommended: GitHub App`. Added a bullet list of "use this if you want…" reasons and a `> [!NOTE]` callout clarifying that `release.yml` uses OIDC + `GITHUB_TOKEN` and does not consume the App credentials.
- Renamed step 4 to "Store Credentials at the Repository Scope". Added a `> [!WARNING]` callout against environment-scoped storage with the concrete failure-mode chain (silent empty-string resolution → `if:` guard fails closed → label applied with `GITHUB_TOKEN` → `require-label` stuck at FAILURE).
- Renamed step 5 to "Optional: CI-Driven Tag-Push Flow (not used by this template's `release.yml`)". Added two paragraphs of context distinguishing the optional extension from the actual shipped behavior, and a closing sentence noting the App's bypass-list membership is what would let it push to protected refs.
- Renamed `#### Personal Repositories: Personal Access Token (PAT)` → `#### Alternative: Fine-Grained PAT (local-only releases)`. Added an explicit "use this **only** if all of the following apply" guard. Removed the obsolete "Step 3: Store as Secret (for CI-based releases)" and "Step 4: Update Workflows" subsections — the App path is strictly better for any CI use case, so the docs no longer suggest the PAT-in-CI pattern.

**`docs/development/dependabot-automerge.md`** (1-line change):

- Updated the `Configuring the App` cross-link at `:118` from `#organization-repositories-github-app-recommended` to `#recommended-github-app` to match the renamed heading.

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type, security, spell, 735 tests).
- [ ] Added new tests for new functionality — N/A; documentation-only.
- [x] Manually tested the changes — read both files end-to-end after the edits, verified anchor link target exists, confirmed callout admonition syntax (`> [!NOTE]`, `> [!WARNING]`, `> [!IMPORTANT]`) is GFM-compatible (the `.github/` directory is rendered by GitHub directly, not mkdocs).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — this PR *is* the documentation update.
- [ ] I have updated the CHANGELOG.md — handled at release time.
- [x] My changes generate no new warnings

## Additional Notes

This is the docs counterpart to the dependabot-automerge work that landed in this session (#493 / #495 / #497). Together those PRs made the workflow function as designed and tightened the auto-merge policy; this PR makes the setup docs match the actual configuration story so a future reader doesn't repeat the misconfigurations the workflow PRs debugged.
