### PR TITLE
chore: upgrade github/codeql-action from v3 to v4 (supersedes #485)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,12 +40,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/tests/test_codeql_workflow.py
+++ b/tests/test_codeql_workflow.py
@@ -169,23 +169,23 @@ class TestAnalyzeJob:
         assert checkout_steps, "expected an actions/checkout step"
         assert checkout_steps[0]["uses"] == "actions/checkout@v6"
 
-    def test_analyze_uses_codeql_init_v3(self) -> None:
-        """``github/codeql-action/init`` should be pinned to ``@v3``."""
+    def test_analyze_uses_codeql_init_v4(self) -> None:
+        """``github/codeql-action/init`` should be pinned to ``@v4``."""
         steps = _analyze_steps()
         init_steps = [
             s for s in steps if s.get("uses", "").startswith("github/codeql-action/init@")
         ]
         assert init_steps, "expected a github/codeql-action/init step"
-        assert init_steps[0]["uses"] == "github/codeql-action/init@v3"
+        assert init_steps[0]["uses"] == "github/codeql-action/init@v4"
 
-    def test_analyze_uses_codeql_analyze_v3(self) -> None:
-        """``github/codeql-action/analyze`` should be pinned to ``@v3``."""
+    def test_analyze_uses_codeql_analyze_v4(self) -> None:
+        """``github/codeql-action/analyze`` should be pinned to ``@v4``."""
         steps = _analyze_steps()
         analyze_steps = [
             s for s in steps if s.get("uses", "").startswith("github/codeql-action/analyze@")
         ]
         assert analyze_steps, "expected a github/codeql-action/analyze step"
-        assert analyze_steps[0]["uses"] == "github/codeql-action/analyze@v3"
+        assert analyze_steps[0]["uses"] == "github/codeql-action/analyze@v4"
 
     def test_analyze_init_passes_matrix_language(self) -> None:
         """The init step must receive the matrix language via ``with.languages``."""


### PR DESCRIPTION
## Description

Upgrades `github/codeql-action` from `@v3` to `@v4` in `.github/workflows/codeql.yml` and updates the corresponding pinned-version assertions in `tests/test_codeql_workflow.py`. Supersedes dependabot PR #485, which couldn't merge alone because the test file pinned `@v3`.

The version pin is a deliberate guard rail — it forces a human to consciously update the test alongside any major bump rather than letting an unreviewed major version change ride a green CI. This PR keeps the pattern intact (just rolled forward), so the next major bump (v4 → v5) will trigger the same review loop.

### Verification of v3 → v4 changes

The upgrade is, in practice, a pure Node runtime bump:

- `init/action.yml` on `v3`: `using: node20`
- `init/action.yml` on `v4`: `using: node24`
- `v3.x.y` and `v4.x.y` minor releases ship in lockstep with identical inputs and behaviors (see [tag list](https://github.com/github/codeql-action/tags)).

GitHub-hosted runners already support `node24`. No project-specific impact.

## Related Issue

Addresses #500. Supersedes #485 (which dependabot will auto-close once `main` reaches `@v4`).

## Type of Change

- [x] Code refactoring (dependency major-version bump with no functional change)

## Changes Made

- `.github/workflows/codeql.yml` (2 lines): `github/codeql-action/init@v3` → `@v4`; `github/codeql-action/analyze@v3` → `@v4`.
- `tests/test_codeql_workflow.py`:
  - Renamed `test_analyze_uses_codeql_init_v3` → `test_analyze_uses_codeql_init_v4`; updated docstring and assertion string.
  - Renamed `test_analyze_uses_codeql_analyze_v3` → `test_analyze_uses_codeql_analyze_v4`; same.

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type, security, spell, 735 tests).
- [x] Added new tests for new functionality — repurposed the existing pinned-version tests for v4.
- [x] Manually tested the changes — verified `init/action.yml` runtime is `node24` on `v4` via `gh api`; confirmed there are no input/behavior differences vs. `v3`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — N/A; no doc reference to the codeql-action version.
- [ ] I have updated the CHANGELOG.md — handled at release time.
- [x] My changes generate no new warnings

## Additional Notes

Why this lives outside #485: PR #485 is a dependabot-managed branch. We avoid pushing maintainer commits onto dependabot branches because it confuses the bot's reconciliation. Bundling the workflow bump with the test update on a fresh maintainer-owned branch is the cleanest path; #485 will close itself once `main` is at v4.
