### PR TITLE
fix: scrub remaining tools/pyproject_template/ refs in three docs files

### DIFF
--- a/tests/template/test_cleanup.py
+++ b/tests/template/test_cleanup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -528,6 +529,122 @@ Run tests.
 Build the package.
 """
 
+    # Mirrors the live ``docs/development/github-repository-settings.md`` intro
+    # block (lines 14-22): an H1 heading, the three-sentence intro paragraph
+    # with the broken ``repo_settings.py`` link in the middle, and the next
+    # paragraph that points at the New Project Setup guide.
+    _GITHUB_SETTINGS_WITH_TEMPLATE_REFS = """\
+# GitHub Repository Settings
+
+Complete reference for the GitHub repository settings this template expects.
+New repositories created from the template are configured automatically by
+[`repo_settings.py`](../../tools/pyproject_template/repo_settings.py) via
+`update_all_repo_settings()`. This page documents what each setting is, why
+it is needed, and whether it is set automatically or requires manual action.
+
+For the initial setup workflow, see the [New Project Setup](../template/new-project.md) guide.
+
+## Repository Settings
+
+These are the general repository-level settings applied by
+`configure_repository_settings()`.
+
+| Setting | Value | Purpose |
+| :--- | :--- | :--- |
+| **Default branch** | `main` | Standard branch for PRs and CI |
+
+## Security Settings
+
+Security features are configured by `_configure_security_settings()` in
+`repo_settings.py`.
+
+| Setting | Status | Purpose |
+| :--- | :--- | :--- |
+| **Secret scanning** | Enabled | Detects accidentally committed secrets |
+"""
+
+    # Already-scrubbed equivalent of ``_GITHUB_SETTINGS_WITH_TEMPLATE_REFS``.
+    # The intro paragraph collapses from three sentences to two (sentence 2 is
+    # gone) and the Security Settings introductory paragraph is gone; the
+    # surrounding heading and table sit directly together.
+    _GITHUB_SETTINGS_WITHOUT_TEMPLATE_REFS = """\
+# GitHub Repository Settings
+
+Complete reference for the GitHub repository settings this template expects.
+This page documents what each setting is, why
+it is needed, and whether it is set automatically or requires manual action.
+
+For the initial setup workflow, see the [New Project Setup](../template/new-project.md) guide.
+
+## Repository Settings
+
+These are the general repository-level settings applied by
+`configure_repository_settings()`.
+
+| Setting | Value | Purpose |
+| :--- | :--- | :--- |
+| **Default branch** | `main` | Standard branch for PRs and CI |
+
+## Security Settings
+
+| Setting | Status | Purpose |
+| :--- | :--- | :--- |
+| **Secret scanning** | Enabled | Detects accidentally committed secrets |
+"""
+
+    # Mirrors the live ``docs/development/release-and-automation.md`` block
+    # (lines 88-109): the "Before your first pre-release" subsection plus the
+    # full "New projects (bootstrap flow)" paragraph + code block, followed by
+    # the still-correct "Existing projects" paragraph + code block.
+    _RELEASE_AUTO_WITH_TEMPLATE_REFS = """\
+### Before your first pre-release
+
+`doit release --prerelease=alpha|beta|rc` requires a baseline `v*` tag so
+commitizen has an anchor version to bump from.
+
+**New projects (bootstrap flow).** `tools/pyproject_template/configure.py`
+auto-seeds a `v0.0.0` tag on the root commit, so nothing else is required —
+only push it when you're ready:
+
+```bash
+git push origin v0.0.0
+```
+
+**Existing projects (synced from the template before the auto-seed
+landed).** Seed the baseline tag manually, once per project:
+
+```bash
+git tag v0.0.0 "$(git rev-list --max-parents=0 HEAD | head -1)"
+git push origin v0.0.0
+```
+"""
+
+    # Already-scrubbed equivalent of ``_RELEASE_AUTO_WITH_TEMPLATE_REFS``: the
+    # broken ``configure.py`` link is gone but the lead, the "push it when
+    # ready" instruction, and the trailing code block all survive.
+    _RELEASE_AUTO_WITHOUT_TEMPLATE_REFS = """\
+### Before your first pre-release
+
+`doit release --prerelease=alpha|beta|rc` requires a baseline `v*` tag so
+commitizen has an anchor version to bump from.
+
+**New projects (bootstrap flow).** A `v0.0.0` tag is auto-seeded on the
+root commit during initial setup, so nothing else is required — only push
+it when you're ready:
+
+```bash
+git push origin v0.0.0
+```
+
+**Existing projects (synced from the template before the auto-seed
+landed).** Seed the baseline tag manually, once per project:
+
+```bash
+git tag v0.0.0 "$(git rev-list --max-parents=0 HEAD | head -1)"
+git push origin v0.0.0
+```
+"""
+
     def test_scrubs_pyproject_when_stanza_present(self, tmp_path: Path) -> None:
         """pyproject.toml stanza is removed when present."""
         from tools.pyproject_template.cleanup import scrub_template_references
@@ -769,6 +886,135 @@ Build the package.
         changed = scrub_template_references(tmp_path)
         assert changed == []
 
+    def test_scrubs_github_settings_repo_settings_intro(self, tmp_path: Path) -> None:
+        """Intro paragraph: ONLY the broken-link sentence is removed (#474).
+
+        Surgical scrub. The first sentence (``Complete reference for the
+        GitHub repository settings...``) and the doc-purpose sentence
+        (``This page documents...``) must both survive; only the middle
+        sentence pointing at deleted ``repo_settings.py`` goes away.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        github_settings = tmp_path / "docs" / "development" / "github-repository-settings.md"
+        github_settings.parent.mkdir(parents=True)
+        github_settings.write_text(self._GITHUB_SETTINGS_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = github_settings.read_text(encoding="utf-8")
+        # The broken-link sentence is gone.
+        assert "tools/pyproject_template/repo_settings.py" not in new
+        assert "update_all_repo_settings()" not in new
+        # The first sentence survives.
+        assert "Complete reference for the GitHub repository settings this template expects." in new
+        # The doc-purpose sentence survives.
+        assert "This page documents what each setting is" in new
+        assert github_settings in changed
+
+    def test_scrubs_github_settings_security_paragraph(self, tmp_path: Path) -> None:
+        """Security Settings intro paragraph + trailing blank line gone (#474).
+
+        The ``## Security Settings`` heading and the table that follows must
+        both survive — the table sits directly under the heading once the
+        prose is removed.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        github_settings = tmp_path / "docs" / "development" / "github-repository-settings.md"
+        github_settings.parent.mkdir(parents=True)
+        github_settings.write_text(self._GITHUB_SETTINGS_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        scrub_template_references(tmp_path)
+
+        new = github_settings.read_text(encoding="utf-8")
+        # The introductory paragraph is gone.
+        assert "_configure_security_settings()" not in new
+        assert "Security features are configured by" not in new
+        # The heading and the table survive.
+        assert "## Security Settings" in new
+        assert "**Secret scanning**" in new
+        # And the table sits right under the heading (no double blank line).
+        assert "## Security Settings\n\n| Setting" in new
+
+    def test_scrubs_release_automation_new_projects_paragraph(self, tmp_path: Path) -> None:
+        """release-and-automation.md: paragraph rewritten, surroundings intact (#474).
+
+        The lead ``**New projects (bootstrap flow).**`` and the
+        ``git push origin v0.0.0`` code block underneath must survive
+        untouched. Only the broken ``configure.py`` link is removed; the
+        replacement prose still tells the user the v0.0.0 tag exists.
+        """
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        release_auto = tmp_path / "docs" / "development" / "release-and-automation.md"
+        release_auto.parent.mkdir(parents=True)
+        release_auto.write_text(self._RELEASE_AUTO_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path)
+
+        new = release_auto.read_text(encoding="utf-8")
+        # The broken link is gone.
+        assert "tools/pyproject_template/configure.py" not in new
+        # The lead survives (paragraph was rewritten, not stripped).
+        assert "**New projects (bootstrap flow).**" in new
+        # The trailing code block survives untouched.
+        assert "```bash\ngit push origin v0.0.0\n```" in new
+        # The user-facing instruction is preserved with the new wording.
+        assert "auto-seeded on the" in new
+        assert "only push" in new
+        # The unrelated "Existing projects" paragraph + code block survive.
+        assert "**Existing projects (synced from the template before the auto-seed" in new
+        assert release_auto in changed
+
+    def test_scrub_idempotent_for_new_targets(self, tmp_path: Path) -> None:
+        """Second pass on already-scrubbed new-target files is a no-op (#474)."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        github_settings = tmp_path / "docs" / "development" / "github-repository-settings.md"
+        github_settings.parent.mkdir(parents=True)
+        github_settings.write_text(self._GITHUB_SETTINGS_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        release_auto = tmp_path / "docs" / "development" / "release-and-automation.md"
+        release_auto.write_text(self._RELEASE_AUTO_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        # First pass: changes expected on both files.
+        first_changed = scrub_template_references(tmp_path)
+        assert github_settings in first_changed
+        assert release_auto in first_changed
+
+        # Snapshot the post-first-pass file contents.
+        snapshots = {path: path.read_text(encoding="utf-8") for path in first_changed}
+
+        # Second pass: nothing changes.
+        second_changed = scrub_template_references(tmp_path)
+        assert second_changed == []
+
+        for path, original in snapshots.items():
+            assert path.read_text(encoding="utf-8") == original
+
+    def test_dry_run_does_not_write_new_targets(self, tmp_path: Path) -> None:
+        """Under dry_run=True the new-target files are reported but not written (#474)."""
+        from tools.pyproject_template.cleanup import scrub_template_references
+
+        github_settings = tmp_path / "docs" / "development" / "github-repository-settings.md"
+        github_settings.parent.mkdir(parents=True)
+        github_settings.write_text(self._GITHUB_SETTINGS_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        release_auto = tmp_path / "docs" / "development" / "release-and-automation.md"
+        release_auto.write_text(self._RELEASE_AUTO_WITH_TEMPLATE_REFS, encoding="utf-8")
+
+        changed = scrub_template_references(tmp_path, dry_run=True)
+
+        # Both files are reported as would-change.
+        assert github_settings in changed
+        assert release_auto in changed
+        # But nothing was written.
+        assert (
+            github_settings.read_text(encoding="utf-8") == self._GITHUB_SETTINGS_WITH_TEMPLATE_REFS
+        )
+        assert release_auto.read_text(encoding="utf-8") == self._RELEASE_AUTO_WITH_TEMPLATE_REFS
+
 
 class TestCleanupAllDeletesTemplateCleanTask:
     """Regression test for issue #469: ``tools/doit/template_clean.py`` goes away.
@@ -872,3 +1118,195 @@ class TestCleanupAllInvokesScrubber:
 
         # Scrubber must not run under SETUP_ONLY.
         assert pyproject.read_text(encoding="utf-8") == pyproject_content
+
+    def test_all_mode_invokes_regenerate_and_check(self, tmp_path: Path) -> None:
+        """ALL-mode invokes ``regenerate_doc_toc`` AND ``check_stale_template_references`` (#474).
+
+        Mocks both helpers so we don't depend on the real subprocess; asserts
+        that they're each called exactly once. Also asserts the SETUP_ONLY
+        path leaves both helpers untouched.
+        """
+        from tools.pyproject_template import cleanup as cleanup_module
+        from tools.pyproject_template.cleanup import (
+            CleanupMode,
+            cleanup_template_files,
+        )
+
+        # ALL-mode needs at least one deletable file so the function reaches
+        # the post-cleanup helpers.
+        (tmp_path / "bootstrap.py").touch()
+
+        with (
+            patch.object(cleanup_module, "regenerate_doc_toc", return_value=False) as mock_regen,
+            patch.object(
+                cleanup_module, "check_stale_template_references", return_value=[]
+            ) as mock_check,
+        ):
+            cleanup_template_files(CleanupMode.ALL, tmp_path)
+
+        mock_regen.assert_called_once_with(tmp_path, dry_run=False)
+        mock_check.assert_called_once_with(tmp_path)
+
+        # SETUP_ONLY mode must NOT call either helper.
+        (tmp_path / "bootstrap.py").touch()  # recreate (was deleted above)
+        with (
+            patch.object(cleanup_module, "regenerate_doc_toc", return_value=False) as mock_regen2,
+            patch.object(
+                cleanup_module, "check_stale_template_references", return_value=[]
+            ) as mock_check2,
+        ):
+            cleanup_template_files(CleanupMode.SETUP_ONLY, tmp_path)
+
+        mock_regen2.assert_not_called()
+        mock_check2.assert_not_called()
+
+
+class TestRegenerateDocToc:
+    """Tests for ``regenerate_doc_toc`` (issue #474)."""
+
+    def test_returns_false_when_script_missing(self, tmp_path: Path) -> None:
+        """No ``tools/generate_doc_toc.py`` -> return False, no exception."""
+        from tools.pyproject_template.cleanup import regenerate_doc_toc
+
+        # Only a TOC; no generator script.
+        toc = tmp_path / "docs" / "TABLE_OF_CONTENTS.md"
+        toc.parent.mkdir(parents=True)
+        toc.write_text("# TOC\n", encoding="utf-8")
+
+        assert regenerate_doc_toc(tmp_path) is False
+
+    def test_returns_false_when_toc_missing(self, tmp_path: Path) -> None:
+        """No ``docs/TABLE_OF_CONTENTS.md`` -> return False."""
+        from tools.pyproject_template.cleanup import regenerate_doc_toc
+
+        # Only a script; no TOC.
+        script = tmp_path / "tools" / "generate_doc_toc.py"
+        script.parent.mkdir(parents=True)
+        script.write_text("print('hi')\n", encoding="utf-8")
+
+        assert regenerate_doc_toc(tmp_path) is False
+
+    def test_invokes_subprocess_and_reports_change(self, tmp_path: Path) -> None:
+        """Mocked subprocess: exit 1 -> True, exit 0 -> False, exit 2 -> False (warns)."""
+        from tools.pyproject_template.cleanup import regenerate_doc_toc
+
+        # Both files must exist for the function to invoke the subprocess.
+        script = tmp_path / "tools" / "generate_doc_toc.py"
+        script.parent.mkdir(parents=True)
+        script.write_text("print('hi')\n", encoding="utf-8")
+        toc = tmp_path / "docs" / "TABLE_OF_CONTENTS.md"
+        toc.parent.mkdir(parents=True)
+        toc.write_text("# TOC\n", encoding="utf-8")
+
+        # Exit 1 = changes written -> True.
+        completed_changed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with patch("subprocess.run", return_value=completed_changed) as mock_run:
+            assert regenerate_doc_toc(tmp_path) is True
+            mock_run.assert_called_once()
+
+        # Exit 0 = no change -> False (success path, but nothing happened).
+        completed_nochange = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with patch("subprocess.run", return_value=completed_nochange):
+            assert regenerate_doc_toc(tmp_path) is False
+
+        # Exit 2 = real failure -> False (warning logged).
+        completed_failed = subprocess.CompletedProcess(
+            args=[], returncode=2, stdout="", stderr="boom"
+        )
+        with patch("subprocess.run", return_value=completed_failed):
+            assert regenerate_doc_toc(tmp_path) is False
+
+    def test_dry_run_does_not_invoke_subprocess(self, tmp_path: Path) -> None:
+        """Under dry_run=True the subprocess is NOT invoked; returns True."""
+        from tools.pyproject_template.cleanup import regenerate_doc_toc
+
+        script = tmp_path / "tools" / "generate_doc_toc.py"
+        script.parent.mkdir(parents=True)
+        script.write_text("print('hi')\n", encoding="utf-8")
+        toc = tmp_path / "docs" / "TABLE_OF_CONTENTS.md"
+        toc.parent.mkdir(parents=True)
+        toc.write_text("# TOC\n", encoding="utf-8")
+
+        with patch("subprocess.run") as mock_run:
+            assert regenerate_doc_toc(tmp_path, dry_run=True) is True
+            mock_run.assert_not_called()
+
+
+class TestCheckStaleTemplateReferences:
+    """Tests for ``check_stale_template_references`` (issue #474)."""
+
+    def test_returns_empty_when_docs_clean(self, tmp_path: Path) -> None:
+        """Clean docs tree (no markers) -> empty list."""
+        from tools.pyproject_template.cleanup import check_stale_template_references
+
+        clean_doc = tmp_path / "docs" / "guide.md"
+        clean_doc.parent.mkdir(parents=True)
+        clean_doc.write_text("# Guide\n\nNothing template-y here.\n", encoding="utf-8")
+
+        assert check_stale_template_references(tmp_path) == []
+
+    def test_detects_pyproject_template_marker_in_docs(self, tmp_path: Path) -> None:
+        """``tools/pyproject_template/`` in a doc -> reported with line number."""
+        from tools.pyproject_template.cleanup import check_stale_template_references
+
+        bad_doc = tmp_path / "docs" / "guide.md"
+        bad_doc.parent.mkdir(parents=True)
+        bad_doc.write_text(
+            "# Guide\n\nSee `tools/pyproject_template/foo.py` for details.\n",
+            encoding="utf-8",
+        )
+
+        survivors = check_stale_template_references(tmp_path)
+        assert len(survivors) == 1
+        path, line_no, content = survivors[0]
+        assert path == bad_doc
+        assert line_no == 3
+        assert "tools/pyproject_template/foo.py" in content
+
+    def test_detects_template_tools_reference_marker(self, tmp_path: Path) -> None:
+        """``template/tools-reference.md`` in a doc -> reported."""
+        from tools.pyproject_template.cleanup import check_stale_template_references
+
+        bad_doc = tmp_path / "docs" / "TABLE_OF_CONTENTS.md"
+        bad_doc.parent.mkdir(parents=True)
+        bad_doc.write_text(
+            "# TOC\n\n- [Tools](template/tools-reference.md)\n",
+            encoding="utf-8",
+        )
+
+        survivors = check_stale_template_references(tmp_path)
+        assert len(survivors) == 1
+        path, _, content = survivors[0]
+        assert path == bad_doc
+        assert "template/tools-reference.md" in content
+
+    def test_skips_missing_docs_directory(self, tmp_path: Path) -> None:
+        """No ``docs/`` directory -> empty list (and README still scanned if present)."""
+        from tools.pyproject_template.cleanup import check_stale_template_references
+
+        # No docs/ at all.
+        assert check_stale_template_references(tmp_path) == []
+
+        # Add a clean README to confirm it's scanned without error.
+        readme = tmp_path / "README.md"
+        readme.write_text("# Hi\nNothing template-y here.\n", encoding="utf-8")
+        assert check_stale_template_references(tmp_path) == []
+
+    def test_scans_readme_at_root(self, tmp_path: Path) -> None:
+        """``README.md`` with a marker is reported."""
+        from tools.pyproject_template.cleanup import check_stale_template_references
+
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "# Project\n\nRun `tools/doit/template_clean.py --setup` to clean up.\n",
+            encoding="utf-8",
+        )
+
+        survivors = check_stale_template_references(tmp_path)
+        assert len(survivors) == 1
+        path, line_no, content = survivors[0]
+        assert path == readme
+        assert line_no == 3
+        assert "tools/doit/template_clean" in content

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -274,11 +274,62 @@ _DOIT_REF_TOC_TEMPLATE_CLEAN_RE = re.compile(
     r"`cleanup`, `template_clean`",
 )
 
+# docs/development/github-repository-settings.md intro paragraph (lines 16-20).
+# Surgical scrub: removes ONLY the broken-link sentence pointing at deleted
+# ``tools/pyproject_template/repo_settings.py``. The trailing space after
+# ``update_all_repo_settings()\.`` is part of the match so the next sentence
+# (``This page documents...``) joins cleanly to the previous newline. The
+# preceding sentence (``Complete reference for the GitHub repository settings
+# this template expects.``) and the doc-purpose sentence both survive.
+_GITHUB_SETTINGS_REPO_SETTINGS_INTRO_RE = re.compile(
+    r"New repositories created from the template are configured automatically by\n"
+    r"\[`repo_settings\.py`\]\(\.\./\.\./tools/pyproject_template/repo_settings\.py\) via\n"
+    r"`update_all_repo_settings\(\)`\. ",
+)
+
+# docs/development/github-repository-settings.md Security Settings paragraph
+# (lines 233-234). Strips the entire paragraph plus its trailing blank line so
+# the table that follows sits directly under the heading. The table is
+# self-explanatory, so removing the prose introduction does not leave a gap.
+_GITHUB_SETTINGS_SECURITY_REPO_SETTINGS_RE = re.compile(
+    r"Security features are configured by `_configure_security_settings\(\)` in\n"
+    r"`repo_settings\.py`\.\n\n",
+)
+
+# docs/development/release-and-automation.md "New projects (bootstrap flow)"
+# paragraph (lines 94-96). REWRITES (not strips) the paragraph: the spawned
+# project does have a ``v0.0.0`` tag (``configure.py`` created it during
+# bootstrap before being deleted), so the user-facing instruction "push it
+# when ready" is still correct — only the broken
+# ``tools/pyproject_template/configure.py`` link needs to go. The lead
+# ``**New projects (bootstrap flow).**`` and the trailing
+# ``git push origin v0.0.0`` code block both survive untouched.
+_RELEASE_AUTO_NEW_PROJECTS_BOOTSTRAP_RE = re.compile(
+    r"\*\*New projects \(bootstrap flow\)\.\*\* `tools/pyproject_template/configure\.py`\n"
+    r"auto-seeds a `v0\.0\.0` tag on the root commit, so nothing else is required —\n"
+    r"only push it when you're ready:\n",
+)
+
+# Markers used by ``check_stale_template_references`` to surface any future
+# regression of the #469 family bug class. Conservative list with zero
+# false-positive risk in a spawned project: every reference to
+# ``tools/pyproject_template/`` is broken once the directory is deleted; the
+# ``template/tools-reference.md`` link is defensive coverage in case the TOC
+# regenerator misses it; ``tools/doit/template_clean`` is namespaced enough
+# that no legitimate file should match. ``bootstrap.py`` is excluded because
+# legitimate ``curl ... bootstrap.py`` reinstall references survive in some
+# docs.
+_STALE_TEMPLATE_MARKERS = (
+    "tools/pyproject_template/",
+    "template/tools-reference.md",
+    "tools/doit/template_clean",
+)
+
 
 def scrub_template_references(root: Path | None = None, dry_run: bool = False) -> list[Path]:
     """Remove user-visible stale references to template-only machinery.
 
-    Applies targeted regex rewrites to three files that retain documentation
+    Applies targeted regex rewrites to five files that retain documentation
     or configuration for template-only tooling after the cleanup phase has
     deleted the files those references point at:
 
@@ -294,11 +345,28 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
     * ``docs/development/doit-tasks-reference.md`` — removes the
       ``### template_clean`` section and rewrites the TOC table row so the
       remaining ``cleanup`` entry is listed alone.
+    * ``docs/development/github-repository-settings.md`` — strips the
+      broken-link sentence in the intro paragraph that points at
+      ``tools/pyproject_template/repo_settings.py``, and removes the
+      ``Security Settings`` introductory paragraph that names
+      ``_configure_security_settings()`` in the same deleted module.
+    * ``docs/development/release-and-automation.md`` — rewrites the
+      "New projects (bootstrap flow)" paragraph so the broken link to
+      ``tools/pyproject_template/configure.py`` is gone but the user-facing
+      "push the v0.0.0 tag when ready" instruction (and its trailing
+      ``git push origin v0.0.0`` code block) survives untouched.
 
     Patterns are applied blindly; ``re.sub`` is a no-op when nothing matches,
     and the function detects whether a file changed by comparing final
     content to the original. That makes the scrubber idempotent — repeat
     calls and already-scrubbed files record no change.
+
+    Companion helpers in this module handle the cases where a regex per file
+    is the wrong tool: :func:`regenerate_doc_toc` rebuilds
+    ``docs/TABLE_OF_CONTENTS.md`` from the surviving ``docs/`` tree (so all
+    broken ``template/*.md`` links drop out in one pass), and
+    :func:`check_stale_template_references` performs a warn-only post-cleanup
+    sweep that surfaces any future regression of this bug class.
 
     Args:
         root: Project root directory (defaults to cwd).
@@ -369,7 +437,158 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
                 )
             changed.append(doit_ref)
 
+    # 4. docs/development/github-repository-settings.md — strip the broken
+    #    intro-link sentence and the Security Settings introductory paragraph.
+    github_settings = root / "docs" / "development" / "github-repository-settings.md"
+    if github_settings.is_file():
+        original = github_settings.read_text(encoding="utf-8")
+        new_content = original
+        new_content = _GITHUB_SETTINGS_REPO_SETTINGS_INTRO_RE.sub("", new_content)
+        new_content = _GITHUB_SETTINGS_SECURITY_REPO_SETTINGS_RE.sub("", new_content)
+        if new_content != original:
+            if dry_run:
+                Logger.info(
+                    "Would scrub repo_settings.py references in "
+                    "docs/development/github-repository-settings.md"
+                )
+            else:
+                github_settings.write_text(new_content, encoding="utf-8")
+                Logger.success(
+                    "Removed repo_settings.py references from "
+                    "docs/development/github-repository-settings.md"
+                )
+            changed.append(github_settings)
+
+    # 5. docs/development/release-and-automation.md — rewrite the "New
+    #    projects (bootstrap flow)" paragraph so the broken configure.py link
+    #    is gone but the surrounding instruction and code block survive.
+    release_auto = root / "docs" / "development" / "release-and-automation.md"
+    if release_auto.is_file():
+        original = release_auto.read_text(encoding="utf-8")
+        new_content = _RELEASE_AUTO_NEW_PROJECTS_BOOTSTRAP_RE.sub(
+            "**New projects (bootstrap flow).** A `v0.0.0` tag is auto-seeded on the\n"
+            "root commit during initial setup, so nothing else is required — only push\n"
+            "it when you're ready:\n",
+            original,
+        )
+        if new_content != original:
+            if dry_run:
+                Logger.info(
+                    "Would scrub configure.py references in "
+                    "docs/development/release-and-automation.md"
+                )
+            else:
+                release_auto.write_text(new_content, encoding="utf-8")
+                Logger.success(
+                    "Removed configure.py references from "
+                    "docs/development/release-and-automation.md"
+                )
+            changed.append(release_auto)
+
     return sorted(changed)
+
+
+def regenerate_doc_toc(root: Path | None = None, dry_run: bool = False) -> bool:
+    """Re-run ``tools/generate_doc_toc.py`` to rebuild ``docs/TABLE_OF_CONTENTS.md``.
+
+    The TOC is driven from the surviving ``docs/`` tree, so once
+    ``docs/template/`` is deleted in :class:`CleanupMode.ALL`, simply
+    re-running the generator naturally drops every stale ``template/*.md``
+    reference in one pass — much safer than a per-line regex strip, which
+    would leave behind any future broken ``template/*.md`` link the regex
+    didn't anticipate.
+
+    The generator script returns exit ``0`` (no change) or ``1`` (changes
+    written); both are treated as success. Anything else is logged as a
+    warning and treated as a failure.
+
+    Args:
+        root: Project root directory (defaults to cwd).
+        dry_run: If True, report what would be regenerated but do not invoke
+            the subprocess.
+
+    Returns:
+        True if the TOC was (or would be) regenerated; False if the
+        generator/TOC files are missing, the subprocess failed, or no
+        changes were needed.
+    """
+    if root is None:
+        root = Path.cwd()
+    script = root / "tools" / "generate_doc_toc.py"
+    toc = root / "docs" / "TABLE_OF_CONTENTS.md"
+    if not script.is_file() or not toc.is_file():
+        return False
+    if dry_run:
+        Logger.info("Would regenerate docs/TABLE_OF_CONTENTS.md")
+        return True
+
+    import subprocess  # nosec B404 - local import for invoking generate_doc_toc.py
+
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # generate_doc_toc.py returns 0 (no change) or 1 (changes written); both
+    # are success. Anything else is a real failure.
+    if result.returncode not in (0, 1):
+        Logger.warning(
+            f"TOC regeneration failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+        return False
+    if result.returncode == 1:
+        Logger.success("Regenerated docs/TABLE_OF_CONTENTS.md")
+        return True
+    return False
+
+
+def check_stale_template_references(
+    root: Path | None = None,
+) -> list[tuple[Path, int, str]]:
+    """Scan post-cleanup docs and README for known template-only markers.
+
+    A warn-only post-cleanup sweep. Surfaces any future regression of the
+    #469 / #474 bug class (stale references to template-only files that
+    survive the scrubber) in the wizard transcript instead of waiting for a
+    manual grep. Catches arbitrary docs files, not just the targets handled
+    explicitly by :func:`scrub_template_references`.
+
+    The marker list (:data:`_STALE_TEMPLATE_MARKERS`) is conservative — every
+    marker references a path that is guaranteed to be broken once the cleanup
+    deletes its target.
+
+    Args:
+        root: Project root directory (defaults to cwd).
+
+    Returns:
+        List of ``(path, line_no, line_content)`` tuples for any survivors.
+        Empty list when no stale references are found. The caller decides
+        what to do with the result; this function never raises and never
+        modifies any files.
+    """
+    if root is None:
+        root = Path.cwd()
+
+    survivors: list[tuple[Path, int, str]] = []
+    candidates: list[Path] = []
+    docs_dir = root / "docs"
+    if docs_dir.is_dir():
+        candidates.extend(sorted(docs_dir.rglob("*.md")))
+    readme = root / "README.md"
+    if readme.is_file():
+        candidates.append(readme)
+
+    for path in candidates:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if any(marker in line for marker in _STALE_TEMPLATE_MARKERS):
+                survivors.append((path, line_no, line))
+    return survivors
 
 
 def cleanup_template_files(
@@ -423,6 +642,11 @@ def cleanup_template_files(
             # Also report any scrub targets; the return value is discarded
             # here because CleanupResult has no field for it.
             scrub_template_references(root, dry_run=True)
+            # Mirror the live path's TOC regenerate step (read-only under
+            # dry_run). check_stale_template_references is read-only too,
+            # but it's only called in the live path because dry_run already
+            # promises no writes — running it here would just be noise.
+            regenerate_doc_toc(root, dry_run=True)
         return CleanupResult(files_to_delete, dirs_to_delete, [], mkdocs_would_update)
 
     # Delete files
@@ -448,8 +672,21 @@ def cleanup_template_files(
     if mode == CleanupMode.ALL:
         mkdocs_updated = update_mkdocs_nav(root, dry_run=False)
         # Scrub user-visible references (pyproject.toml, README.md,
-        # doit-tasks-reference.md) that still point at now-deleted files.
+        # doit-tasks-reference.md, github-repository-settings.md,
+        # release-and-automation.md) that still point at now-deleted files.
         scrub_template_references(root, dry_run=False)
+        # Regenerate the TOC from the surviving docs/ tree so any broken
+        # template/*.md links naturally drop out (no per-line regex needed).
+        regenerate_doc_toc(root, dry_run=False)
+        # Warn-only regression sweep: surface any stale template references
+        # that survived the targeted scrubs above. Catches future drift in
+        # arbitrary docs files, not just the ones explicitly handled.
+        stale = check_stale_template_references(root)
+        if stale:
+            Logger.warning(f"Stale template references survived cleanup ({len(stale)} hits):")
+            for path, line_no, content in stale:
+                rel = path.relative_to(root) if path.is_relative_to(root) else path
+                print(f"  - {rel}:{line_no}: {content.strip()}")
 
     # Report results
     if deleted_files:


### PR DESCRIPTION
## Description

Fifth bug in the spawn-cleanup-scrubber family (after #463, #464, #465, #469). After `cleanup_template_files(CleanupMode.ALL)` runs in a freshly bootstrapped project, three more docs still carried five stale references to deleted template-only files:

- `docs/development/github-repository-settings.md` lines 17-19 (sentence linking to deleted `tools/pyproject_template/repo_settings.py`).
- `docs/development/github-repository-settings.md` lines 233-234 (paragraph naming `_configure_security_settings()` in the same deleted module).
- `docs/development/release-and-automation.md` lines 94-100 (paragraph + code block naming deleted `tools/pyproject_template/configure.py`).
- `docs/TABLE_OF_CONTENTS.md` lines 26 / 56 / 124 (three "Template Tools Reference" entries linking to deleted `template/tools-reference.md`), plus several other broken `template/*.md` entries the issue grep didn't flag.

`doit check` doesn't lint markdown links, so spawned projects passed all gates while still shipping broken pointers; `mkdocs build` would fail.

This PR extends `tools/pyproject_template/cleanup.py` with three module-scope regex patterns and two new helper functions, wired into `cleanup_template_files` for `CleanupMode.ALL` only (matching the existing scrubber's mode gating).

Addresses #474

## Architecture refinements made during planning

- **`github-repository-settings.md` intro: surgical strike, not paragraph strip.** Only the broken-link sentence (one of three sentences in the intro) is removed; both surrounding sentences survive. The trailing space inside the regex is intentional so the next sentence joins cleanly to the previous newline.
- **`release-and-automation.md` "New projects" paragraph: rewrite, not strip.** The spawned project does have a `v0.0.0` tag (`configure.py` created it during bootstrap before being deleted), so the user-facing instruction "push it when ready" is still correct. Stripping the paragraph would force users into the wrong "Existing projects → seed manually" path. The lead `**New projects (bootstrap flow).**` and the trailing `git push origin v0.0.0` code block both survive untouched.
- **`docs/TABLE_OF_CONTENTS.md`: regenerate, not regex-strip.** Rather than maintain a per-line regex for the three flagged "Template Tools Reference" entries (which would leave the other broken `template/*.md` entries in place), the new `regenerate_doc_toc` helper subprocess-invokes the existing `tools/generate_doc_toc.py`. Once `docs/template/` is deleted, the regenerator naturally drops every stale `template/*.md` reference in one pass. Exit codes 0 (no change) and 1 (changes written) are both treated as success; anything else is logged as a warning. Local `subprocess` import keeps the module's existing import block unchanged.
- **Warn-only regression sweep.** New `check_stale_template_references` helper performs a post-cleanup grep over `docs/**/*.md` + `README.md` for three conservative markers (`tools/pyproject_template/`, `template/tools-reference.md`, `tools/doit/template_clean`). Survivors are emitted via `Logger.warning` + indented per-line `print`, mirroring the existing failed-delete pattern at `cleanup_template_files`. Catches future drift in any docs file, not just the targets explicitly handled by `scrub_template_references`. `bootstrap.py` is excluded from the marker list because legitimate `curl ... bootstrap.py` reinstall references survive in some docs.
- **Mode gating.** Both new helpers run in `CleanupMode.ALL` only. `regenerate_doc_toc` runs in both the live and dry-run paths (read-only under dry-run); `check_stale_template_references` runs in the live path only because dry-run already promises no writes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `tools/pyproject_template/cleanup.py`:
  - Added three module-scope compiled regex patterns: `_GITHUB_SETTINGS_REPO_SETTINGS_INTRO_RE`, `_GITHUB_SETTINGS_SECURITY_REPO_SETTINGS_RE`, `_RELEASE_AUTO_NEW_PROJECTS_BOOTSTRAP_RE`.
  - Added `_STALE_TEMPLATE_MARKERS` tuple constant.
  - Extended `scrub_template_references` with two new file blocks (github-repository-settings.md, release-and-automation.md).
  - Added `regenerate_doc_toc(root, dry_run)` helper that subprocess-invokes `tools/generate_doc_toc.py`.
  - Added `check_stale_template_references(root)` warn-only sweep helper.
  - Wired both new helpers into `cleanup_template_files` (live + dry-run paths, `CleanupMode.ALL` only).
  - Updated `scrub_template_references` docstring to list the new file targets and document the companion helpers.
- `tests/template/test_cleanup.py`:
  - Added 5 new tests in `TestScrubTemplateReferences` (intro-paragraph scrub, security-paragraph scrub, release-automation paragraph rewrite, idempotency, dry-run).
  - Added new `TestRegenerateDocToc` class with 4 tests (missing script, missing TOC, mocked subprocess for both exit codes, dry-run).
  - Added new `TestCheckStaleTemplateReferences` class with 5 tests (clean tree, marker hit, secondary marker hit, missing docs dir, README sweep).
  - Extended `TestCleanupAllInvokesScrubber` with `test_all_mode_invokes_regenerate_and_check`.

## Testing

- [x] All existing tests pass (54 tests in `tests/template/test_cleanup.py`).
- [x] Added new tests for new functionality (14 new tests across one extended class and two new classes).
- [x] `doit check` passes locally (tests, lint, format, type-check, security, spell-check).

### Test plan

- [x] **`TestScrubTemplateReferences` (5 new tests):**
  - [x] `test_scrubs_github_settings_repo_settings_intro` — only the broken-link sentence is removed; surrounding intro and doc-purpose sentences survive.
  - [x] `test_scrubs_github_settings_security_paragraph` — paragraph + trailing blank line removed; heading and table intact.
  - [x] `test_scrubs_release_automation_new_projects_paragraph` — paragraph rewrite preserves the bold lead and the `git push origin v0.0.0` code block; broken `configure.py` link is gone.
  - [x] `test_scrub_idempotent_for_new_targets` — second pass on already-scrubbed files is a no-op.
  - [x] `test_dry_run_does_not_write_new_targets` — new files are reported but not written.
- [x] **`TestRegenerateDocToc` (new class, 4 tests):**
  - [x] `test_returns_false_when_script_missing`.
  - [x] `test_returns_false_when_toc_missing`.
  - [x] `test_invokes_subprocess_and_reports_change` — exit 1 → True; exit 0 → False.
  - [x] `test_dry_run_does_not_invoke_subprocess`.
- [x] **`TestCheckStaleTemplateReferences` (new class, 5 tests):**
  - [x] `test_returns_empty_when_docs_clean`.
  - [x] `test_detects_pyproject_template_marker_in_docs`.
  - [x] `test_detects_template_tools_reference_marker`.
  - [x] `test_skips_missing_docs_directory`.
  - [x] `test_scans_readme_at_root`.
- [x] **`TestCleanupAllInvokesScrubber` (extended):**
  - [x] `test_all_mode_invokes_regenerate_and_check` — both helpers called for `CleanupMode.ALL`; neither called for `CleanupMode.SETUP_ONLY`.
- [ ] **Manual end-to-end verification:** spawn a fresh project with the patched template, then run:
  ```bash
  grep -rn "tools/pyproject_template\|template/tools-reference" docs/ README.md
  ```
  Expect zero matches. Confirm `mkdocs build` passes in the spawned project (no broken-link errors from the four files this PR touches). Confirm the wizard transcript shows the regeneration log line (`Regenerated docs/TABLE_OF_CONTENTS.md` or no-change) and any regression-check warnings.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (`scrub_template_references` docstring; no user-facing docs describe the scrubber's per-file scope)
- [x] My changes generate no new warnings

## Additional Notes

**ADR:** None required. Tactical bug fix in the same family as #463, #464, #465, #469 — none of which got ADRs. Issue does not have the `needs-adr` label.

**Doc updates:** None beyond the `scrub_template_references` docstring (already in the diff). A `grep -rn` over `docs/` for `scrub_template_references|scrub_template|scrubber` returned zero hits — no user-facing doc describes the scrubber's per-file scope.

**Why this didn't get caught earlier:** the scrubber was added in #469 with a fixed list of three files. Each file added since then needs an explicit pattern. The new `check_stale_template_references` warn-only sweep is the structural fix that makes the next regression of this class self-reporting in the wizard transcript instead of waiting for a manual grep.
