### PR TITLE
chore: declare least-privilege permissions in pr-checks.yml

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate-pr-title:
     name: Validate PR Title Format

--- a/docs/development/github-repository-settings.md
+++ b/docs/development/github-repository-settings.md
@@ -136,7 +136,7 @@ each workflow, its trigger, and required permissions.
 | **CI (full matrix)** | `ci-full-matrix.yml` | PR to `main` (labeled with `full-matrix`) -- dispatches `ci.yml` with `full_matrix: true` | `contents: read` |
 | **CodeQL** | `codeql.yml` | Push to `main`, PR to `main`, Scheduled (Monday 04:27 UTC) | `contents: read`, `security-events: write`, `actions: read` |
 | **Merge Gate** | `merge-gate.yml` | PR to `main` (opened, labeled, unlabeled, synchronize, reopened) | `contents: read` |
-| **PR Validation** | `pr-checks.yml` | PR (opened, edited, synchronize) | Default |
+| **PR Validation** | `pr-checks.yml` | PR (opened, edited, synchronize) | `contents: read`, `pull-requests: read` |
 | **Breaking Change Detection** | `breaking-change-detection.yml` | PR (opened, synchronize, edited) | `contents: read`, `issues: write`, `pull-requests: write` |
 | **Benchmark** | `benchmark.yml` | Push to `main`, PR to `main`, `workflow_dispatch` | `contents: write`, `pull-requests: write` |
 | **Mutation Testing** | `mutation.yml` | Scheduled (Sunday midnight UTC), `workflow_dispatch` | `contents: read` |


### PR DESCRIPTION
## Description

Declare a least-privilege top-level `permissions:` block in
`.github/workflows/pr-checks.yml` so the workflow's `GITHUB_TOKEN` is no
longer granted the repository's default (write) scopes.

The three jobs in this workflow only need to read PR metadata and check out
code, so `contents: read` and `pull-requests: read` are sufficient.

This resolves CodeQL workflow-permissions alerts **#2**, **#5**, and **#18**
(one per job: `validate-pr-title`, `validate-issue-link`,
`validate-pr-description`).

## Related Issue

Addresses #503

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added a top-level `permissions:` block to `.github/workflows/pr-checks.yml`
  granting only `contents: read` and `pull-requests: read`.
- Updated the workflow permissions table in
  `docs/development/github-repository-settings.md` so the **PR Validation**
  row reflects the now-declared permissions instead of "Default".

## Testing

- [x] All existing tests pass (`doit check` PASSED locally)
- [ ] Added new tests for new functionality — N/A: CI-only change with no
      Python code paths to exercise.
- [x] Manually tested the changes — verified the YAML parses and the three
      jobs continue to use only the GitHub Script context they already had
      (`context.payload.pull_request`, `github.rest.pulls.listFiles`), both
      of which are satisfied by `pull-requests: read`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature
      works — N/A: workflow YAML change with no executable Python.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (workflow permissions
      table in `docs/development/github-repository-settings.md`)
- [ ] I have updated the CHANGELOG.md — N/A: CI-only change, no user-facing
      behavior; changelog is regenerated from conventional commits at
      release time.
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR needed.** Issue #503 has the `chore` and `needs-triage` labels;
  it does not carry `needs-adr`, and the planning comment confirmed no ADR
  is required. This is a routine hardening of an existing workflow, not an
  architectural decision.
- **No Python tests apply.** The change is to a GitHub Actions workflow
  file; there is no Python code path or runtime behavior to assert against.
  CodeQL itself will validate the permissions declaration on the next
  scheduled scan and on this PR's `pull_request` event.
- **Why these scopes:**
  - `contents: read` — required by `actions/checkout@v6` in
    `validate-issue-link`.
  - `pull-requests: read` — required by
    `github.rest.pulls.listFiles` in `validate-issue-link`; the PR title /
    body / payload reads in the other two jobs are also covered by this
    scope.
