### PR TITLE
fix: resolve PyPI name at runtime in doit release_tag printout

### DIFF
--- a/tests/template/test_doit_release.py
+++ b/tests/template/test_doit_release.py
@@ -27,12 +27,14 @@ from tools.doit.release import (
     _build_cz_get_next_cmd,
     _extract_next_version_from_cz_output,
     _extract_version_from_release_pr,
+    _get_pypi_name_from_pyproject,
     _repo_has_version_tags,
     validate_merge_commits,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from _pytest.monkeypatch import MonkeyPatch
 
@@ -828,3 +830,67 @@ class TestCreateReleasePrValidation:
 
         with pytest.raises(SystemExit):
             action(prerelease="gamma")
+
+
+class TestGetPypiNameFromPyproject:
+    """Tests for ``_get_pypi_name_from_pyproject`` (issue #478).
+
+    The helper reads ``[project].name`` from ``pyproject.toml`` in the current
+    working directory at runtime. ``task_release_tag`` calls it to substitute
+    the project's PyPI name into the "Next steps" URL printout instead of
+    relying on the template's spawn-time placeholder substitution (which never
+    visited ``tools/doit/`` and therefore left the literal ``package-name``
+    string in URLs of every spawned project).
+
+    Each test uses ``monkeypatch.chdir(tmp_path)`` so the helper reads a
+    synthetic ``pyproject.toml`` instead of the repo's real one.
+    """
+
+    def test_returns_project_name(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        """Happy path: ``[project].name = "my-pkg"`` → ``"my-pkg"``."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "my-pkg"\nversion = "0.1.0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert _get_pypi_name_from_pyproject() == "my-pkg"
+
+    def test_returns_none_when_pyproject_missing(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """No ``pyproject.toml`` in the cwd → ``None`` (caller falls back)."""
+        monkeypatch.chdir(tmp_path)
+        assert _get_pypi_name_from_pyproject() is None
+
+    def test_returns_none_when_project_table_missing(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Valid TOML without a ``[project]`` table → ``None``."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.poetry]\nname = "irrelevant"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert _get_pypi_name_from_pyproject() is None
+
+    def test_returns_none_when_name_key_missing(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """``[project]`` table present but no ``name`` key → ``None``."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nversion = "0.1.0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert _get_pypi_name_from_pyproject() is None
+
+    def test_returns_none_for_malformed_toml(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Malformed TOML → ``None`` (the ``TOMLDecodeError`` is swallowed)."""
+        (tmp_path / "pyproject.toml").write_text(
+            "this is = = not valid toml [[",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert _get_pypi_name_from_pyproject() is None

--- a/tools/doit/release.py
+++ b/tools/doit/release.py
@@ -5,6 +5,8 @@ import os
 import re
 import subprocess  # nosec B404 - subprocess is required for doit tasks
 import sys
+import tomllib
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from doit.tools import title_with_actions
@@ -253,6 +255,39 @@ def _extract_next_version_from_cz_output(stdout: str) -> str | None:
         if match:
             return match.group(1)
     return None
+
+
+def _get_pypi_name_from_pyproject() -> str | None:
+    """Return ``[project].name`` from ``pyproject.toml`` in the current directory.
+
+    Used by ``task_release_tag`` to substitute the project's PyPI name into the
+    "Next steps" URL printout. Reading at runtime (instead of relying on the
+    template's spawn-time placeholder substitution) means the same code works
+    in the template repo and in every spawned project, without expanding the
+    substitution allowlist to cover ``tools/doit/``.
+
+    Returns:
+        The project name string when ``pyproject.toml`` exists and contains
+        ``[project].name``; ``None`` for any failure (missing file, missing
+        ``[project]`` table, missing ``name`` key, malformed TOML, OS error).
+        The caller is expected to fall back to a literal placeholder so the
+        success-path printout never crashes after the tag has been pushed.
+    """
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.exists():
+        return None
+    try:
+        with pyproject_path.open("rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError):
+        return None
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return None
+    name = project.get("name")
+    if not isinstance(name, str):
+        return None
+    return name
 
 
 def task_release() -> dict[str, Any]:
@@ -667,11 +702,16 @@ def task_release_tag() -> dict[str, Any]:
         console.print("=" * 70)
         console.print("\nNext steps:")
         console.print("1. Monitor GitHub Actions for build and publish.")
+        # Resolve the PyPI name at runtime from pyproject.toml so the same
+        # code works in the template repo and in every spawned project. Fall
+        # back to the literal placeholder if the lookup fails — the tag has
+        # already been pushed, so the printout must not crash.
+        pypi_name = _get_pypi_name_from_pyproject() or "package-name"
         console.print(
-            "2. Check TestPyPI: [link=https://test.pypi.org/project/package-name/]https://test.pypi.org/project/package-name/[/link]"
+            f"2. Check TestPyPI: [link=https://test.pypi.org/project/{pypi_name}/]https://test.pypi.org/project/{pypi_name}/[/link]"
         )
         console.print(
-            "3. Check PyPI: [link=https://pypi.org/project/package-name/]https://pypi.org/project/package-name/[/link]"
+            f"3. Check PyPI: [link=https://pypi.org/project/{pypi_name}/]https://pypi.org/project/{pypi_name}/[/link]"
         )
 
     return {


### PR DESCRIPTION
## Description

`doit release_tag` ends with a "Next steps" block that prints TestPyPI and PyPI URLs for the just-tagged release. In spawned projects, those URLs were emitting the literal `package-name` placeholder, producing broken links to `https://test.pypi.org/project/package-name/` and `https://pypi.org/project/package-name/`. The placeholder is only rewritten by the bootstrap substitution allowlist, which intentionally does not cover `tools/doit/`.

This PR resolves the PyPI name at runtime from `pyproject.toml`, so the same code works in the template repo and in every spawned project without expanding the substitution allowlist.

## Related Issue

Addresses #478

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `_get_pypi_name_from_pyproject() -> str | None` to `tools/doit/release.py`, reading `[project].name` from `pyproject.toml` via `tomllib` and returning `None` on any failure (missing file, missing `[project]`, missing `name`, malformed TOML, OS error).
- Substitute the resolved name into the TestPyPI / PyPI URLs printed by `task_release_tag`'s "Next steps" block, falling back to the literal `"package-name"` so the success-path printout never crashes after the tag has been pushed.

## Testing

- [x] All existing tests pass (`doit check` clean)
- [x] Added new tests for new functionality (5 unit tests covering happy path, missing file, missing `[project]` table, missing `name` key, malformed TOML)
- [x] Manually verified the helper resolves the project name in this repo

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (no docs changes — no page documents the literal `package-name` URL printout)
- [ ] I have updated the CHANGELOG.md (auto-generated by commitizen at release time)
- [x] My changes generate no new warnings

## Additional Notes

- Cosmetic only: no public interface change, no behavioral change beyond the printed URL strings on the success path of `doit release_tag`.
- No ADR needed: the issue does not carry the `needs-adr` label, and this is a one-helper bug fix in tooling code with no architectural decision.
