### PR TITLE
feat: support per-platform extract_binaries in install_tool framework

### DIFF
--- a/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -14,6 +14,8 @@ Extend `tools/doit/install_tools.py` with three orthogonal capabilities while pr
 
 Supporting refactors: a private `_get_arch()` helper that maps `platform.machine()` to amd64/arm64 (passthrough for unknowns), and a private `_build_github_release_url()` so the binary path and the new archive path share URL construction.
 
+`extract_binaries` also accepts an optional per-platform `dict[str, list[str]]` keyed by `platform.system().lower()` (same convention as `asset_patterns`), for tools whose archive members differ per OS (e.g., `.exe` suffix on Windows).
+
 ## Rationale
 
 Downstream consumers (e.g., InfraFoundry) need to install five tools, but only direnv-style single binaries from GitHub releases work today. age and sops ship as multi-binary tar.gz archives; terraform and opentofu ship from non-GitHub URLs. Without these extensions every downstream consumer reinvents download/extract code with inconsistent (often missing) security handling.
@@ -41,6 +43,7 @@ The three capabilities are intentionally orthogonal so simple cases stay simple 
 ## Related Issues
 
 - Issue #326: install_tools framework: archive extraction and custom URLs
+- Issue #477: support per-platform `extract_binaries` in install_tool framework
 
 ## Related Documentation
 

--- a/docs/development/install-tools-framework.md
+++ b/docs/development/install-tools-framework.md
@@ -71,6 +71,35 @@ def task_install_age():
 `extract_binaries` matches by **basename**, so any directory structure
 inside the archive (e.g., `age/age`, `age/age-keygen`) is ignored.
 
+#### Per-platform binary names
+
+When archive members differ per OS — most commonly a `.exe` suffix on
+Windows — pass a `dict` keyed by `platform.system().lower()` instead of
+a flat list. The same key convention used by `asset_patterns` applies:
+
+```python
+from tools.doit.install_tools import create_install_task
+
+def task_install_age():
+    return create_install_task(
+        name="age",
+        repo="FiloSottile/age",
+        asset_patterns={
+            "linux": "age-v{version}-linux-amd64.tar.gz",
+            "darwin": "age-v{version}-darwin-amd64.tar.gz",
+            "windows": "age-v{version}-windows-amd64.zip",
+        },
+        extract_binaries={
+            "linux": ["age", "age-keygen"],
+            "darwin": ["age", "age-keygen"],
+            "windows": ["age.exe", "age-keygen.exe"],
+        },
+    )
+```
+
+If the current OS is missing from the dict the install aborts with the
+same `Unsupported OS` error that `asset_patterns` uses.
+
 ### Multi-arch archive from GitHub releases via `url_template` (gh)
 
 ```python

--- a/tests/template/test_doit_install_tools.py
+++ b/tests/template/test_doit_install_tools.py
@@ -534,6 +534,101 @@ class TestInstallTool:
         assert args[1] == ["age", "age-keygen"]
         assert args[2] == tmp_path
 
+    @patch("tools.doit.install_tools.download_and_extract_archive")
+    @patch("tools.doit.install_tools.get_install_dir")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Linux")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_extract_binaries_dict_resolves_for_linux(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_get_install_dir: MagicMock,
+        mock_extract: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that a per-platform extract_binaries dict resolves to the linux list."""
+        mock_get_install_dir.return_value = tmp_path
+
+        install_tool(
+            name="age",
+            repo="FiloSottile/age",
+            asset_patterns={
+                "linux": "age-v{version}-linux-amd64.tar.gz",
+                "windows": "age-v{version}-windows-amd64.zip",
+            },
+            extract_binaries={
+                "linux": ["age", "age-keygen"],
+                "windows": ["age.exe", "age-keygen.exe"],
+            },
+        )
+
+        mock_extract.assert_called_once()
+        args = mock_extract.call_args.args
+        assert args[1] == ["age", "age-keygen"]
+        assert args[2] == tmp_path
+
+    @patch("tools.doit.install_tools.download_and_extract_archive")
+    @patch("tools.doit.install_tools.get_install_dir")
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Windows")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_extract_binaries_dict_resolves_for_windows(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        mock_get_install_dir: MagicMock,
+        mock_extract: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test that a per-platform extract_binaries dict resolves to the windows list."""
+        mock_get_install_dir.return_value = tmp_path
+
+        install_tool(
+            name="age",
+            repo="FiloSottile/age",
+            asset_patterns={
+                "linux": "age-v{version}-linux-amd64.tar.gz",
+                "windows": "age-v{version}-windows-amd64.zip",
+            },
+            extract_binaries={
+                "linux": ["age", "age-keygen"],
+                "windows": ["age.exe", "age-keygen.exe"],
+            },
+        )
+
+        mock_extract.assert_called_once()
+        args = mock_extract.call_args.args
+        assert args[1] == ["age.exe", "age-keygen.exe"]
+        assert args[2] == tmp_path
+
+    @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
+    @patch("tools.doit.install_tools.platform.system", return_value="Windows")
+    @patch("tools.doit.install_tools.shutil.which", return_value=None)
+    def test_install_with_extract_binaries_dict_missing_platform_exits(
+        self,
+        mock_which: MagicMock,
+        mock_system: MagicMock,
+        mock_get_release: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Test that a per-platform extract_binaries dict missing the current OS exits."""
+        with pytest.raises(SystemExit):
+            install_tool(
+                name="age",
+                repo="FiloSottile/age",
+                asset_patterns={
+                    "linux": "age-v{version}-linux-amd64.tar.gz",
+                    "windows": "age-v{version}-windows-amd64.zip",
+                },
+                extract_binaries={"linux": ["age", "age-keygen"]},
+            )
+
+        captured = capsys.readouterr()
+        assert "Unsupported OS for age: windows" in captured.out
+
     @patch("tools.doit.install_tools.download_github_release_binary")
     @patch("tools.doit.install_tools.subprocess.run")
     @patch("tools.doit.install_tools.get_latest_github_release", return_value="1.0.0")
@@ -673,6 +768,27 @@ class TestCreateInstallTask:
         result["actions"][0]()
 
         assert mock_install.call_args.kwargs["extract_binaries"] == ["age", "age-keygen"]
+
+    @patch("tools.doit.install_tools.install_tool")
+    def test_forwards_dict_extract_binaries(self, mock_install: MagicMock) -> None:
+        """Test that a per-platform extract_binaries dict is forwarded unchanged."""
+        per_platform = {
+            "linux": ["age", "age-keygen"],
+            "windows": ["age.exe", "age-keygen.exe"],
+        }
+        result = create_install_task(
+            name="age",
+            repo="FiloSottile/age",
+            asset_patterns={
+                "linux": "age.tar.gz",
+                "windows": "age.zip",
+            },
+            extract_binaries=per_platform,
+        )
+
+        result["actions"][0]()
+
+        assert mock_install.call_args.kwargs["extract_binaries"] == per_platform
 
     @patch("tools.doit.install_tools.install_tool")
     def test_forwards_url_template(self, mock_install: MagicMock) -> None:

--- a/tools/doit/install_tools.py
+++ b/tools/doit/install_tools.py
@@ -215,7 +215,7 @@ def install_tool(
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
-    extract_binaries: list[str] | None = None,
+    extract_binaries: list[str] | dict[str, list[str]] | None = None,
     url_template: str | None = None,
     prefer_brew: bool = True,
 ) -> None:
@@ -238,6 +238,21 @@ def install_tool(
             a downloaded archive (e.g. ``["age", "age-keygen"]``). When set,
             the download is treated as an archive (`.tar.gz`/`.tgz`/`.zip`)
             and binaries are extracted into the install dir.
+
+            Also accepts a per-platform mapping using the same key
+            convention as ``asset_patterns`` (``platform.system().lower()``
+            values such as ``"linux"``, ``"darwin"``, ``"windows"``).
+            Use this when archive members differ per OS — for example,
+            when Windows builds add a ``.exe`` suffix::
+
+                extract_binaries={
+                    "linux": ["age", "age-keygen"],
+                    "darwin": ["age", "age-keygen"],
+                    "windows": ["age.exe", "age-keygen.exe"],
+                }
+
+            On a platform missing from the dict, the install aborts with
+            the same ``Unsupported OS`` error used for ``asset_patterns``.
         url_template: Optional download URL template with ``{version}``,
             ``{os}``, and ``{arch}`` placeholders. When set, this is used
             instead of building a GitHub release URL from ``asset_patterns``.
@@ -277,7 +292,14 @@ def install_tool(
             sys.exit(1)
 
         if extract_binaries:
-            download_and_extract_archive(url, extract_binaries, get_install_dir())
+            if isinstance(extract_binaries, dict):
+                if system not in extract_binaries:
+                    print(f"Unsupported OS for {name}: {system}")
+                    sys.exit(1)
+                resolved_binaries = extract_binaries[system]
+            else:
+                resolved_binaries = extract_binaries
+            download_and_extract_archive(url, resolved_binaries, get_install_dir())
         else:
             if url_template is not None:
                 install_dir = get_install_dir()
@@ -304,7 +326,7 @@ def create_install_task(
     asset_patterns: dict[str, str],
     version_cmd: list[str] | None = None,
     post_install_message: str | None = None,
-    extract_binaries: list[str] | None = None,
+    extract_binaries: list[str] | dict[str, list[str]] | None = None,
     url_template: str | None = None,
     prefer_brew: bool = True,
 ) -> dict[str, Any]:
@@ -321,7 +343,10 @@ def create_install_task(
         version_cmd: Command list for version check. Defaults to [name, "--version"].
         post_install_message: Optional message printed after installation.
         extract_binaries: Optional list of binary basenames to extract from
-            a downloaded archive. See :func:`install_tool`.
+            a downloaded archive, or a per-platform mapping keyed by
+            ``platform.system().lower()`` (e.g. ``{"linux": ["age"],
+            "windows": ["age.exe"]}``) when archive members differ per OS.
+            See :func:`install_tool`.
         url_template: Optional download URL template with ``{version}``,
             ``{os}``, ``{arch}`` placeholders. See :func:`install_tool`.
         prefer_brew: Use brew on macOS when True (default). See


### PR DESCRIPTION
## Description

Widen the `extract_binaries` parameter on `install_tool()` and
`create_install_task()` to accept either the existing `list[str]` or a new
`dict[str, list[str]]` keyed by `platform.system().lower()`. The dict
shape lets a single install task target archives whose member names
differ per OS — most commonly the `.exe` suffix on Windows builds —
without forcing every downstream consumer to branch on `platform.system()`
in their own task definitions.

If the current OS is missing from the dict, the install aborts with the
same `Unsupported OS` error / `sys.exit(1)` that `asset_patterns` already
uses, so the failure mode is consistent across the framework. The
list-shape behavior is unchanged, so existing callers (e.g.
`task_install_age` with `extract_binaries=["age", "age-keygen"]`) keep
working with no edits.

## Related Issue

Addresses #477

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `tools/doit/install_tools.py`:
  - Widen `extract_binaries` type on `install_tool()` and
    `create_install_task()` to `list[str] | dict[str, list[str]] | None`.
  - Resolve the per-platform list inside `install_tool()` via
    `platform.system().lower()`; missing key → `Unsupported OS` exit.
  - Update docstrings on both functions to document the dict shape.
- `tests/template/test_doit_install_tools.py`:
  - Add `test_install_with_extract_binaries_dict_resolves_for_linux`.
  - Add `test_install_with_extract_binaries_dict_resolves_for_windows`.
  - Add `test_install_with_extract_binaries_dict_missing_platform_exits`.
  - Add `test_forwards_dict_extract_binaries` for `create_install_task`.
- `docs/development/install-tools-framework.md`: add a
  "Per-platform binary names" subsection under the age example with a
  Linux/macOS/Windows dict sample.
- `docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md`:
  add issue #477 to Related Issues and a brief note about the dict shape
  under Decision.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Added new tests for new functionality (4 new tests covering Linux
      resolution, Windows resolution, missing-platform exit, and
      `create_install_task` forwarding of the dict)
- [x] Manually verified `doit check` passes locally on the branch

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit check`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated from conventional
      commits at release time)
- [x] My changes generate no new warnings

## Additional Notes

Backward compatible: `list[str]` shape behaves exactly as before. ADR-9015
(install_tools framework: archive extraction and custom URLs) already
covers archive extraction; this PR extends it with a Decision-section
note and a Related Issues link rather than adding a new ADR. The issue
does not carry the `needs-adr` label.
