### PR TITLE
chore: add sync-exclude mechanism for downstream template drift

### DIFF
--- a/docs/template/manage.md
+++ b/docs/template/manage.md
@@ -63,6 +63,42 @@ Compares your project against the latest template:
 
 **Important:** This does NOT automatically apply changes. You must manually review and apply changes you want.
 
+#### Excluding upstream files from drift checks
+
+Downstream projects often diverge from the template in deliberate ways — a
+FastAPI example app for a tool that isn't a service, a Click `test_cli.py`
+when the project uses Typer, and so on. Without a way to silence those, every
+`check` run re-flags them and buries real upstream changes.
+
+Add a hand-managed file at `.config/pyproject_template/sync-exclude.toml`
+listing upstream-relative glob patterns:
+
+```toml
+exclude = [
+    "examples/api/**",
+    "src/package_name/core.py",
+    "tests/test_cli.py",
+]
+```
+
+- Patterns are matched against upstream-relative paths via `fnmatch.fnmatch`,
+  so `*` matches any characters (including `/`) and `**` is a recursive
+  wildcard for subtrees.
+- Matched files are removed from the actionable drift list. `check` prints a
+  trailing line like `Skipped per project policy: 15 files
+  (see .config/pyproject_template/sync-exclude.toml)` so the suppression stays
+  visible without crowding the signal.
+- Pass `--show-excluded` to list every excluded path:
+  ```bash
+  python tools/pyproject_template/manage.py check --show-excluded
+  ```
+- The hardcoded skip set (build artifacts: `.git`, `__pycache__`, `.venv`,
+  `uv.lock`, etc.) takes precedence and is not user-configurable. A file that
+  matches the hardcoded set never appears in either list.
+- This file is **separate** from `settings.toml` on purpose: `settings.toml`
+  is rewritten by `manage.py sync`, which would clobber any user-managed
+  excludes. `sync-exclude.toml` is never touched by automation.
+
 ### [4] Update repository settings
 
 Configures GitHub repository settings:

--- a/tests/template/test_check_template_updates.py
+++ b/tests/template/test_check_template_updates.py
@@ -1,0 +1,160 @@
+"""Tests for sync-exclude support in ``check_template_updates``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.pyproject_template.check_template_updates import (
+    compare_files,
+    load_sync_excludes,
+)
+
+
+def _make_template(
+    template_root: Path, files: dict[str, str], *, base: str = "pyproject-template-main"
+) -> Path:
+    """Create a fake extracted template tree under ``template_root/<base>``.
+
+    Mirrors the directory shape produced by ``download_and_extract_archive``.
+    """
+    root = template_root / base
+    root.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return root
+
+
+def _write_exclude_file(project_root: Path, patterns: list[str]) -> None:
+    settings_dir = project_root / ".config" / "pyproject_template"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    body = "exclude = [\n" + "".join(f'    "{p}",\n' for p in patterns) + "]\n"
+    (settings_dir / "sync-exclude.toml").write_text(body, encoding="utf-8")
+
+
+class TestLoadSyncExcludes:
+    """Direct tests of the ``load_sync_excludes`` loader."""
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_sync_excludes(tmp_path) == []
+
+    def test_valid_file_returns_patterns(self, tmp_path: Path) -> None:
+        _write_exclude_file(tmp_path, ["examples/api/**", "src/foo.py"])
+        assert load_sync_excludes(tmp_path) == ["examples/api/**", "src/foo.py"]
+
+    def test_missing_exclude_key_returns_empty(self, tmp_path: Path) -> None:
+        settings_dir = tmp_path / ".config" / "pyproject_template"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "sync-exclude.toml").write_text("# no exclude key\n", encoding="utf-8")
+        assert load_sync_excludes(tmp_path) == []
+
+    def test_malformed_toml_returns_empty(self, tmp_path: Path) -> None:
+        settings_dir = tmp_path / ".config" / "pyproject_template"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "sync-exclude.toml").write_text("not = valid toml [[\n", encoding="utf-8")
+        assert load_sync_excludes(tmp_path) == []
+
+    def test_non_list_exclude_returns_empty(self, tmp_path: Path) -> None:
+        settings_dir = tmp_path / ".config" / "pyproject_template"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "sync-exclude.toml").write_text('exclude = "oops"\n', encoding="utf-8")
+        assert load_sync_excludes(tmp_path) == []
+
+    def test_non_string_entries_dropped(self, tmp_path: Path) -> None:
+        settings_dir = tmp_path / ".config" / "pyproject_template"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "sync-exclude.toml").write_text(
+            'exclude = ["keep.py", 42, "also.py"]\n', encoding="utf-8"
+        )
+        assert load_sync_excludes(tmp_path) == ["keep.py", "also.py"]
+
+
+class TestCompareFilesWithExcludes:
+    """``compare_files`` returns ``(different_files, excluded_files)``."""
+
+    @pytest.fixture
+    def project(self, tmp_path: Path) -> Path:
+        project = tmp_path / "project"
+        project.mkdir()
+        return project
+
+    @pytest.fixture
+    def template(self, tmp_path: Path) -> Path:
+        return tmp_path / "template"
+
+    def test_no_exclude_file_is_noop(self, project: Path, template: Path) -> None:
+        template_root = _make_template(
+            template,
+            {"docs/index.md": "upstream", "src/main.py": "upstream"},
+        )
+        # Project has neither file; both should appear in different_files.
+        diff, excluded = compare_files(project, template_root)
+        assert excluded == []
+        assert sorted(p.as_posix() for p in diff) == ["docs/index.md", "src/main.py"]
+
+    def test_glob_match_lands_in_excluded(self, project: Path, template: Path) -> None:
+        template_root = _make_template(
+            template,
+            {"examples/api/foo.py": "x", "examples/api/sub/bar.py": "y", "src/main.py": "z"},
+        )
+        _write_exclude_file(project, ["examples/api/**"])
+        diff, excluded = compare_files(project, template_root)
+        assert sorted(p.as_posix() for p in diff) == ["src/main.py"]
+        assert sorted(p.as_posix() for p in excluded) == [
+            "examples/api/foo.py",
+            "examples/api/sub/bar.py",
+        ]
+
+    def test_exact_path_match(self, project: Path, template: Path) -> None:
+        template_root = _make_template(
+            template,
+            {"src/package_name/core.py": "x", "src/package_name/cli.py": "y"},
+        )
+        _write_exclude_file(project, ["src/package_name/core.py"])
+        diff, excluded = compare_files(project, template_root)
+        assert [p.as_posix() for p in diff] == ["src/package_name/cli.py"]
+        assert [p.as_posix() for p in excluded] == ["src/package_name/core.py"]
+
+    def test_unmatched_file_still_flagged(self, project: Path, template: Path) -> None:
+        template_root = _make_template(
+            template,
+            {"README.md": "x", "examples/api/foo.py": "y"},
+        )
+        _write_exclude_file(project, ["examples/api/**"])
+        diff, excluded = compare_files(project, template_root)
+        assert [p.as_posix() for p in diff] == ["README.md"]
+        assert [p.as_posix() for p in excluded] == ["examples/api/foo.py"]
+
+    def test_hardcoded_skip_takes_precedence(self, project: Path, template: Path) -> None:
+        # __pycache__ is in the hardcoded skip set; user excludes should not
+        # override that, and __pycache__ should not appear in either bucket.
+        template_root = _make_template(
+            template,
+            {"__pycache__/cached.pyc": "x", "src/main.py": "y"},
+        )
+        _write_exclude_file(project, ["__pycache__/**"])
+        diff, excluded = compare_files(project, template_root)
+        assert [p.as_posix() for p in diff] == ["src/main.py"]
+        assert excluded == []
+
+    def test_matching_file_not_reported(self, project: Path, template: Path) -> None:
+        # If the project file matches the template, neither bucket should contain it
+        # — even if it would otherwise match an exclude pattern.
+        template_root = _make_template(template, {"src/main.py": "same"})
+        (project / "src").mkdir()
+        (project / "src" / "main.py").write_text("same", encoding="utf-8")
+        _write_exclude_file(project, ["src/main.py"])
+        diff, excluded = compare_files(project, template_root)
+        assert diff == []
+        assert excluded == []
+
+    def test_excludes_param_overrides_file(self, project: Path, template: Path) -> None:
+        # Passing ``excludes=`` explicitly bypasses the on-disk loader, which is
+        # how callers (and tests) inject patterns without a TOML file on disk.
+        template_root = _make_template(template, {"a.py": "x", "b.py": "y"})
+        diff, excluded = compare_files(project, template_root, excludes=["a.py"])
+        assert [p.as_posix() for p in diff] == ["b.py"]
+        assert [p.as_posix() for p in excluded] == ["a.py"]

--- a/tests/template/test_pyproject_template_main.py
+++ b/tests/template/test_pyproject_template_main.py
@@ -831,7 +831,7 @@ class TestYesFlagBehavior:
             main(["--yes", "sync"])
 
             mock_run_action.assert_called_once_with(
-                5, mock_manager, False, yes=True, cleanup_mode=None
+                5, mock_manager, False, yes=True, cleanup_mode=None, show_excluded=False
             )
 
     def test_sync_with_yes_skips_prompt(self, tmp_path: Path) -> None:

--- a/tools/pyproject_template/check_template_updates.py
+++ b/tools/pyproject_template/check_template_updates.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import filecmp
+import fnmatch
 import json
 import os
 import shutil
@@ -30,6 +31,11 @@ import subprocess  # nosec B404
 import sys
 import urllib.request
 from pathlib import Path
+
+try:
+    import tomllib  # py311+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
 
 # Support running as script or as module
 _script_dir = Path(__file__).parent
@@ -47,6 +53,44 @@ from utils import (  # noqa: E402
 
 # Default archive URL derived from template constants
 DEFAULT_ARCHIVE_URL = f"{TEMPLATE_URL}/archive/refs/heads/main.zip"
+
+# Project-managed exclude file: paths or globs of upstream files the downstream
+# project intentionally does not adopt. See docs/template/manage.md.
+SYNC_EXCLUDE_FILE = Path(".config/pyproject_template/sync-exclude.toml")
+
+
+def load_sync_excludes(project_root: Path) -> list[str]:
+    """Load project-managed sync exclude patterns.
+
+    Reads ``.config/pyproject_template/sync-exclude.toml`` from ``project_root``
+    and returns the top-level ``exclude`` array as a list of glob patterns. The
+    file is hand-managed by the downstream project; ``SettingsManager.save()``
+    does not touch it.
+
+    Args:
+        project_root: Project root directory.
+
+    Returns:
+        List of glob patterns. Returns an empty list when the file is absent,
+        unreadable, malformed TOML, or missing/non-list ``exclude`` key.
+    """
+    exclude_file = project_root / SYNC_EXCLUDE_FILE
+    if not exclude_file.is_file():
+        return []
+
+    try:
+        with exclude_file.open("rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError) as exc:
+        Logger.warning(f"Could not read {SYNC_EXCLUDE_FILE}: {exc}")
+        return []
+
+    excludes = data.get("exclude", [])
+    if not isinstance(excludes, list):
+        Logger.warning(f"{SYNC_EXCLUDE_FILE}: 'exclude' must be a list of strings; ignoring.")
+        return []
+
+    return [str(item) for item in excludes if isinstance(item, str)]
 
 
 def get_latest_release() -> str | None:
@@ -95,9 +139,32 @@ def open_changelog(template_dir: Path) -> None:
         Logger.warning(f"Editor '{editor}' not found, skipping changelog view")
 
 
-def compare_files(project_root: Path, template_root: Path) -> list[Path]:
-    """Compare project files against template and return list of different files."""
-    # Files/directories to skip
+def compare_files(
+    project_root: Path,
+    template_root: Path,
+    excludes: list[str] | None = None,
+) -> tuple[list[Path], list[Path]]:
+    """Compare project files against template.
+
+    Args:
+        project_root: Project root directory.
+        template_root: Extracted upstream template directory.
+        excludes: Optional list of glob patterns (matched via :func:`fnmatch.fnmatch`
+            against upstream-relative posix paths). When ``None``, the patterns are
+            loaded from the project's ``sync-exclude.toml`` via
+            :func:`load_sync_excludes`.
+
+    Returns:
+        ``(different_files, excluded_files)``. Both lists contain upstream-relative
+        paths whose contents differ from the project. Files matching ``excludes``
+        appear only in ``excluded_files``; everything else lands in
+        ``different_files``. Files matching the hardcoded ``skip_patterns`` set
+        are not in either list.
+    """
+    if excludes is None:
+        excludes = load_sync_excludes(project_root)
+
+    # Files/directories to skip (build artifacts, never user-configurable).
     skip_patterns = {
         ".git",
         ".venv",
@@ -124,13 +191,14 @@ def compare_files(project_root: Path, template_root: Path) -> list[Path]:
                 break
 
     different_files: list[Path] = []
+    excluded_files: list[Path] = []
 
     # Walk through template files
     for template_file in template_root.rglob("*"):
         if not template_file.is_file():
             continue
 
-        # Skip ignored patterns
+        # Skip hardcoded build-artifact patterns.
         rel_path = template_file.relative_to(template_root)
         if any(part in skip_patterns for part in rel_path.parts):
             continue
@@ -149,11 +217,17 @@ def compare_files(project_root: Path, template_root: Path) -> list[Path]:
 
         # Compare with project file
         project_file = project_root / mapped_path
+        if project_file.exists() and filecmp.cmp(template_file, project_file, shallow=False):
+            continue  # Files match; nothing to report.
 
-        if not project_file.exists() or not filecmp.cmp(template_file, project_file, shallow=False):
+        # File differs (or is missing). Bucket it.
+        rel_str = rel_path.as_posix()
+        if excludes and any(fnmatch.fnmatch(rel_str, pat) for pat in excludes):
+            excluded_files.append(rel_path)
+        else:
             different_files.append(rel_path)
 
-    return sorted(different_files)
+    return sorted(different_files), sorted(excluded_files)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -184,6 +258,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Show what would be checked without downloading (currently same as normal)",
     )
+    parser.add_argument(
+        "--show-excluded",
+        action="store_true",
+        help="List paths skipped via .config/pyproject_template/sync-exclude.toml",
+    )
     return parser.parse_args(argv)
 
 
@@ -192,6 +271,7 @@ def run_check_updates(
     skip_changelog: bool = False,
     keep_template: bool = False,
     dry_run: bool = False,
+    show_excluded: bool = False,
 ) -> int:
     """Check for template updates.
 
@@ -200,6 +280,7 @@ def run_check_updates(
         skip_changelog: Skip opening CHANGELOG.md in editor.
         keep_template: Keep downloaded template after comparison.
         dry_run: Show what would be done without making changes.
+        show_excluded: List paths skipped via the project's sync-exclude.toml.
 
     Returns:
         Exit code (0 for success, non-zero for error).
@@ -233,7 +314,7 @@ def run_check_updates(
 
     # Compare files
     Logger.header("Comparing your project to template")
-    different_files = compare_files(project_root, template_dir)
+    different_files, excluded_files = compare_files(project_root, template_dir)
 
     # Detect user's actual package name for display mapping
     actual_package_name: str | None = None
@@ -287,6 +368,15 @@ def run_check_updates(
 
         print(f"\nOr browse all template files: {template_dir.relative_to(project_root)}/")
 
+    if excluded_files:
+        print(
+            f"\n{Colors.CYAN}Skipped per project policy: {len(excluded_files)} files "
+            f"(see {SYNC_EXCLUDE_FILE}){Colors.NC}"
+        )
+        if show_excluded:
+            for file_path in excluded_files:
+                print(f"  {file_path}")
+
     # Cleanup
     if not keep_template:
         print()
@@ -309,6 +399,7 @@ def main(argv: list[str] | None = None) -> int:
         skip_changelog=args.skip_changelog,
         keep_template=args.keep_template,
         dry_run=args.dry_run,
+        show_excluded=args.show_excluded,
     )
 
 

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -288,6 +288,7 @@ def run_action(
     *,
     yes: bool = False,
     cleanup_mode: str | None = None,
+    show_excluded: bool = False,
 ) -> int:
     """Run the selected action."""
     if action == 1:
@@ -295,7 +296,7 @@ def run_action(
     elif action == 2:
         return action_configure(manager, dry_run, yes=yes)
     elif action == 3:
-        return action_check_updates(manager, dry_run)
+        return action_check_updates(manager, dry_run, show_excluded=show_excluded)
     elif action == 4:
         return action_repo_settings(manager, dry_run)
     elif action == 5:
@@ -413,7 +414,9 @@ def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool 
         return 1
 
 
-def action_check_updates(manager: SettingsManager, dry_run: bool) -> int:
+def action_check_updates(
+    manager: SettingsManager, dry_run: bool, *, show_excluded: bool = False
+) -> int:
     """Check for template updates (comparison only, does not modify files)."""
     Logger.header("Checking for Template Updates")
 
@@ -421,6 +424,7 @@ def action_check_updates(manager: SettingsManager, dry_run: bool) -> int:
         skip_changelog=True,
         keep_template=True,  # Keep template so user can run diff commands
         dry_run=dry_run,
+        show_excluded=show_excluded,
     )
 
     # Show commit history link if we have a sync point (after the review section)
@@ -837,6 +841,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Only check for updates (CI-friendly, fails if can't auto-detect)",
     )
+    parser.add_argument(
+        "--show-excluded",
+        action="store_true",
+        help="With 'check': list paths skipped via .config/pyproject_template/sync-exclude.toml",
+    )
 
     return parser.parse_args(argv)
 
@@ -862,7 +871,12 @@ def main(argv: list[str] | None = None) -> int:
         if action:
             cleanup_mode = getattr(args, "cleanup_mode", None)
             return run_action(
-                action, manager, args.dry_run, yes=args.yes, cleanup_mode=cleanup_mode
+                action,
+                manager,
+                args.dry_run,
+                yes=args.yes,
+                cleanup_mode=cleanup_mode,
+                show_excluded=args.show_excluded,
             )
         return 1
 
@@ -871,7 +885,7 @@ def main(argv: list[str] | None = None) -> int:
         if not manager.settings.is_configured():
             Logger.error("Cannot auto-detect settings. Run interactively first.")
             return 1
-        return action_check_updates(manager, args.dry_run)
+        return action_check_updates(manager, args.dry_run, show_excluded=args.show_excluded)
 
     # Handle --yes (non-interactive mode)
     if args.yes:


### PR DESCRIPTION
## Description

Adds a per-file exclusion mechanism so downstream projects can silence
upstream files they have intentionally chosen not to adopt, without
having those files re-flagged on every `manage.py check` run.

Patterns live in a hand-managed file at
`.config/pyproject_template/sync-exclude.toml` with a top-level
`exclude = [...]` array of glob patterns matched (via
`fnmatch.fnmatch`) against upstream-relative posix paths. Excluded
files are removed from the actionable drift list and reported on a
separate summary line; `--show-excluded` prints them all.

## Related Issue

Addresses #481

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `tools/pyproject_template/check_template_updates.py`
  - Add `SYNC_EXCLUDE_FILE` constant and `load_sync_excludes()` loader
    (warns and returns `[]` on missing file, malformed TOML, or non-list
    `exclude` key).
  - `compare_files()` now returns `tuple[list[Path], list[Path]]` of
    `(different, excluded)`. Hardcoded build-artifact `skip_patterns`
    are evaluated first and never appear in either bucket.
  - Print `Skipped per project policy: N files (see ...)` whenever the
    excluded bucket is non-empty; `--show-excluded` lists each path.
  - New `--show-excluded` CLI flag plumbed through `run_check_updates`
    and `main`.
- `tools/pyproject_template/manage.py`
  - Add `--show-excluded` global arg, threaded through `run_action`,
    `action_check_updates`, and the `--update-only` branch.
- `tests/template/test_check_template_updates.py` (new)
  - 13 tests across `TestLoadSyncExcludes` and
    `TestCompareFilesWithExcludes` covering: missing file, valid file,
    missing key, malformed TOML, non-list `exclude`, non-string
    entries, glob match, exact path match, unmatched files, hardcoded-
    skip precedence, matching files not reported, and the `excludes=`
    parameter override.
- `tests/template/test_pyproject_template_main.py`
  - Update one mock assertion to include the new `show_excluded=False`
    kwarg.
- `docs/template/manage.md`
  - New "Excluding upstream files from drift checks" subsection under
    [3] Check for template updates.

## Divergence from issue body

The issue proposed a `[sync].exclude` table inside
`.config/pyproject_template/settings.toml`. Implementation moved this
to a separate `.config/pyproject_template/sync-exclude.toml` because
`SettingsManager.save()` opens `settings.toml` with `"w"` and rewrites
it from a hardcoded dict on every sync, which would clobber any
user-managed `[sync]` block. The separate file is never touched by
automation. Behaviour is otherwise as the issue specified (glob
matching, separate summary line, `--show-excluded`, hardcoded skip
takes precedence).

## Testing

- [x] All existing tests pass (`doit check` passes locally)
- [x] Added new tests for new functionality (13 new tests)
- [x] Manually verified `compare_files` bucket semantics via the new
      tests

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (auto-generated at release time)
- [x] My changes generate no new warnings

## Additional Notes

- Issue does not have the `needs-adr` label and the change is a
  downstream-only tooling addition; no ADR was created or updated.
- The hardcoded `skip_patterns` (build artifacts: `.git`,
  `__pycache__`, `.venv`, `uv.lock`, etc.) remain non-user-configurable
  and take precedence over user excludes.
