### PR TITLE
feat: add /snapshot and /resume slash commands for session-resumption workflow

### DIFF
--- a/.agents/skills/resume/SKILL.md
+++ b/.agents/skills/resume/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: resume
+description: Load a previously captured snapshot prompt and continue the work it describes.
+---
+
+# Resume
+
+Load a previously captured snapshot prompt from `tmp/resume/` and continue the work it describes.
+
+## When to use
+
+Use this skill when the user wants to pick up a previously captured snapshot in a fresh Codex session. This is the **load** side of the snapshot/resume pair — `$snapshot` is the save side.
+
+Expected prompt shape:
+
+- `$resume resume the latest snapshot`
+- `$resume resume work tagged plan-test`
+
+The user supplies an optional kebab-case `<slug>` to filter by. If the slug is missing, pick the most recent snapshot regardless of slug.
+
+## Instructions
+
+### Step 1: Find the snapshot file
+
+Files live in `tmp/resume/` with names like `{inv_epoch}-<slug>.md`. The `inv_epoch` prefix is monotonically *decreasing* in time, so the lexically smallest filename is the most recent.
+
+```bash
+mkdir -p tmp/resume  # idempotent
+```
+
+**If no slug was supplied:** pick the lexically first file in the directory (newest).
+
+```bash
+ls tmp/resume/*.md 2>/dev/null | head -1
+```
+
+**If a slug was supplied:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-<slug>*.md`.
+
+```bash
+ls tmp/resume/*-<slug>*.md 2>/dev/null | head -1
+```
+
+(Lexically-first = newest, because of the inv_epoch convention.)
+
+### Step 2: Handle edge cases
+
+- **Directory empty or missing:** tell the user `tmp/resume/` has no snapshots; suggest `$snapshot <slug>` to capture one. Stop.
+- **No match for the slug:** list available snapshot filenames so the user can pick one. Stop and wait.
+- **Multiple matches:** silently pick the newest, but mention how many were considered and offer to load a different one if asked.
+
+### Step 3: Load and act on the snapshot
+
+1. Read the chosen file.
+2. Print a one-line confirmation: `Resuming from {filename} (<slug>, captured {date if discoverable})`.
+3. **Treat the file's contents as if the user had pasted them as their first message.** Follow the instructions inside — most snapshots end with a "Start by:" line that names a concrete first action; do that. If the snapshot has multiple "Pick" options, default to the recommended one unless the user said otherwise.
+4. Don't summarize the snapshot back to the user before acting — they already wrote it. Just proceed. (Exception: if the snapshot is ambiguous about the next step, ask once before acting.)
+
+### Step 4: Honor any "User direction recorded" or constraints in the snapshot
+
+Snapshots typically capture decisions and preferences from the prior session. Treat them as binding for this session unless explicitly overridden in the user's current message.
+
+## Notes
+
+- Snapshots are immutable once written. If the situation has changed since capture (a referenced PR landed, an issue closed, etc.), verify before acting on stale references — `gh issue view <n>`, `git log`, etc.
+- The companion `$snapshot` skill writes new snapshots — point users to it if they want to capture something for later in this session.
+- The `inv_epoch` prefix is a sort-only artifact; the user reads the slug, not the number. Always show the slug (or full filename) in confirmation messages, not just the prefix.

--- a/.agents/skills/snapshot/SKILL.md
+++ b/.agents/skills/snapshot/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: snapshot
+description: Capture a resumption prompt for picking up the current work later.
+---
+
+# Snapshot
+
+Capture a resumption prompt for picking up the current work later.
+
+## When to use
+
+Use this skill when the user wants to pause the current Codex session and leave a paste-ready prompt that any agent (Codex, Claude, or Gemini) can pick up later. This is the **save** side of the snapshot/resume pair — `$resume` is the load side.
+
+Expected prompt shape:
+
+- `$snapshot snapshot this work as plan-test`
+- `$snapshot capture a resumption prompt for the current branch`
+
+The user supplies an optional kebab-case `<slug>` describing the topic. If the slug is missing, infer a 3-5 word descriptive slug from the conversation context.
+
+## Instructions
+
+### Step 1: Compute the filename
+
+Filename format: `{inv_epoch}-<slug>.md` in `tmp/resume/`.
+
+`inv_epoch` is a 10-digit integer that *decreases* as time advances, so default `ls` (no flags) lists newest entries first. Compute:
+
+```bash
+INV_EPOCH=$(printf '%010d' $((9999999999 - $(date +%s))))
+```
+
+(The prefix is for sort order only; users read the slug and file contents, not the number.)
+
+Run `mkdir -p tmp/resume` before writing. Don't overwrite existing files; if a same-named file exists, append a 1-letter discriminator (`-a`, `-b`, …) to the slug.
+
+> Note: this directory deviates from the `tmp/agents/<agent-type>/` convention in `AGENTS.md`. `tmp/resume/` is intentionally shared (not per-agent) so snapshots are portable across agents — Codex can write a snapshot and Claude or Gemini can resume from it.
+
+### Step 2: Draft the prompt
+
+The prompt must be **paste-ready** — readable cold by a future agent session that has zero context from this conversation. Use absolute references throughout: issue/PR numbers, file paths, ISO dates (no "yesterday"/"this morning").
+
+Structure:
+
+- **Title** — short description of what's deferred.
+- **Paste-block intro** — one line telling the future user what to do (paste into a fresh agent session at the repo's working directory).
+- **Status as of {today's ISO date}** — what landed recently (merged PRs and closed issues with brief descriptions), current branch state, anything in-flight.
+- **Open issues** (if any are filed but not started) — number, title, one-line scope.
+- **Goal** — the bigger-picture objective this work serves.
+- **Pick: option N (the recommendation)** — list 2-3 numbered next-step options. Mark the recommendation. Brief tradeoff notes.
+- **User direction recorded** — decisions, preferences, or constraints surfaced in the current conversation that future sessions need to honor (e.g., "no cross-provider X", "always prefer Y pattern").
+- **Pre-action reads** — files/docs the future session should read before starting, scoped per option.
+- **Workflow** — short reminder of project conventions (Issue → Branch → PR per `AGENTS.md`, etc.).
+- **Start by:** — concrete first command (e.g., `$plan-issue 714`, or `git checkout main && git pull`).
+
+Add anything else load-bearing — open blockers, runtime gotchas, manual prerequisite steps. Keep tight; this is a paste-block, not a doc.
+
+Don't dump conversation history. Don't include local-environment ephemera. Don't restate auto-loaded context files.
+
+### Step 3: Confirm to the user
+
+Report:
+- The full path to the created file.
+- A one-line summary of what's captured.
+- The quick-use reminder: "paste the file contents into a fresh agent session at this repo's root."
+
+## Notes
+
+- Files persist; no auto-cleanup. The user can `rm` old prompts manually when they're stale.
+- If invoked multiple times in one session, write a new file each time. The user may want separate resumption-points for separate work threads.
+- The prefix uses 10 digits because epoch will exceed 10 digits in the year 2286; that's fine for foreseeable use. If you ever need to extend, bump to 11+ digits.
+- The companion `$resume` skill loads a captured snapshot in a future session — point users to it.

--- a/.claude/commands/resume.md
+++ b/.claude/commands/resume.md
@@ -1,0 +1,54 @@
+# Resume
+
+Load a previously captured snapshot prompt from `tmp/resume/` and continue the work it describes.
+
+When invoked, find the right snapshot file, read it, and **treat its contents as the user's initial instructions for this session.** This is the **load** side of the snapshot/resume pair — `/snapshot` is the save side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug to filter by. If empty, picks the most recent snapshot regardless of slug.
+
+## Instructions
+
+### Step 1: Find the snapshot file
+
+Files live in `tmp/resume/` with names like `{inv_epoch}-{slug}.md`. The `inv_epoch` prefix is monotonically *decreasing* in time, so the lexically smallest filename is the most recent.
+
+```bash
+mkdir -p tmp/resume  # idempotent
+```
+
+**If `$ARGUMENTS` is empty:** pick the lexically first file in the directory (newest).
+
+```bash
+ls tmp/resume/*.md 2>/dev/null | head -1
+```
+
+**If `$ARGUMENTS` is provided:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-${ARGUMENTS}*.md`.
+
+```bash
+ls tmp/resume/*-${ARGUMENTS}*.md 2>/dev/null | head -1
+```
+
+(Lexically-first = newest, because of the inv_epoch convention.)
+
+### Step 2: Handle edge cases
+
+- **Directory empty or missing:** tell the user `tmp/resume/` has no snapshots; suggest `/snapshot <slug>` to capture one. Stop.
+- **No match for the slug:** list available snapshot filenames so the user can pick one. Stop and wait.
+- **Multiple matches:** silently pick the newest, but mention how many were considered and offer to load a different one if asked.
+
+### Step 3: Load and act on the snapshot
+
+1. Read the chosen file (use the Read tool).
+2. Print a one-line confirmation: `Resuming from {filename} ({slug}, captured {date if discoverable})`.
+3. **Treat the file's contents as if the user had pasted them as their first message.** Follow the instructions inside — most snapshots end with a "Start by:" line that names a concrete first action; do that. If the snapshot has multiple "Pick" options, default to the recommended one unless the user said otherwise.
+4. Don't summarize the snapshot back to the user before acting — they already wrote it. Just proceed. (Exception: if the snapshot is ambiguous about the next step, ask once before acting.)
+
+### Step 4: Honor any "User direction recorded" or constraints in the snapshot
+
+Snapshots typically capture decisions and preferences from the prior session. Treat them as binding for this session unless explicitly overridden in the user's current message.
+
+## Notes
+
+- Snapshots are immutable once written. If the situation has changed since capture (a referenced PR landed, an issue closed, etc.), verify before acting on stale references — `gh issue view <n>`, `git log`, etc.
+- The companion `/snapshot` command writes new snapshots — point users to it if they want to capture something for later in this session.
+- The `inv_epoch` prefix is a sort-only artifact; the user reads the slug, not the number. Always show the slug (or full filename) in confirmation messages, not just the prefix.

--- a/.claude/commands/snapshot.md
+++ b/.claude/commands/snapshot.md
@@ -1,0 +1,60 @@
+# Snapshot
+
+Capture a resumption prompt for picking up the current work later.
+
+When invoked, write a self-contained prompt to `tmp/resume/` so the user (or a future agent session via `/resume`) can pick up where they left off without re-reading the current conversation. This is the **save** side of the snapshot/resume pair — `/resume` is the load side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug describing the topic. If empty, infer a 3-5 word descriptive slug from the conversation context.
+
+## Instructions
+
+### Step 1: Compute the filename
+
+Filename format: `{inv_epoch}-{slug}.md` in `tmp/resume/`.
+
+`inv_epoch` is a 10-digit integer that *decreases* as time advances, so default `ls` (no flags) lists newest entries first. Compute:
+
+```bash
+INV_EPOCH=$(printf '%010d' $((9999999999 - $(date +%s))))
+```
+
+(The prefix is for sort order only; users read the slug and file contents, not the number.)
+
+Run `mkdir -p tmp/resume` before writing. Don't overwrite existing files; if a same-named file exists, append a 1-letter discriminator (`-a`, `-b`, …) to the slug.
+
+> Note: this directory deviates from the `tmp/agents/<agent-type>/` convention in `AGENTS.md`. `tmp/resume/` is intentionally shared (not per-agent) so snapshots are portable across agents — Claude can write a snapshot and Gemini or Codex can resume from it.
+
+### Step 2: Draft the prompt
+
+The prompt must be **paste-ready** — readable cold by a future agent session that has zero context from this conversation. Use absolute references throughout: issue/PR numbers, file paths, ISO dates (no "yesterday"/"this morning").
+
+Structure:
+
+- **Title** — short description of what's deferred.
+- **Paste-block intro** — one line telling the future user what to do (paste into a fresh agent session at the repo's working directory).
+- **Status as of {today's ISO date}** — what landed recently (merged PRs and closed issues with brief descriptions), current branch state, anything in-flight.
+- **Open issues** (if any are filed but not started) — number, title, one-line scope.
+- **Goal** — the bigger-picture objective this work serves.
+- **Pick: option N (the recommendation)** — list 2-3 numbered next-step options. Mark the recommendation. Brief tradeoff notes.
+- **User direction recorded** — decisions, preferences, or constraints surfaced in the current conversation that future sessions need to honor (e.g., "no cross-provider X", "always prefer Y pattern").
+- **Pre-action reads** — files/docs the future session should read before starting, scoped per option.
+- **Workflow** — short reminder of project conventions (Issue → Branch → PR per `AGENTS.md`, etc.).
+- **Start by:** — concrete first command (e.g., `/plan-issue 714`, or `git checkout main && git pull`).
+
+Add anything else load-bearing — open blockers, runtime gotchas, manual prerequisite steps. Keep tight; this is a paste-block, not a doc.
+
+Don't dump conversation history. Don't include `.claude/scheduled_tasks.lock` or other local-environment ephemera. Don't restate `MEMORY.md` content (it's auto-loaded in future sessions).
+
+### Step 3: Confirm to the user
+
+Report:
+- The full path to the created file.
+- A one-line summary of what's captured.
+- The quick-use reminder: "paste the file contents into a fresh agent session at this repo's root."
+
+## Notes
+
+- Files persist; no auto-cleanup. The user can `rm` old prompts manually when they're stale.
+- If invoked multiple times in one session, write a new file each time. The user may want separate resumption-points for separate work threads.
+- The prefix uses 10 digits because epoch will exceed 10 digits in the year 2286; that's fine for foreseeable use. If you ever need to extend, bump to 11+ digits.
+- The companion `/resume` command loads a captured snapshot in a future session — point users to it.

--- a/.gemini/commands/resume.md
+++ b/.gemini/commands/resume.md
@@ -1,0 +1,54 @@
+# Resume (Gemini)
+
+Load a previously captured snapshot prompt from `tmp/resume/` and continue the work it describes.
+
+When invoked, find the right snapshot file, read it, and **treat its contents as the user's initial instructions for this session.** This is the **load** side of the snapshot/resume pair — `/snapshot` is the save side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug to filter by. If empty, picks the most recent snapshot regardless of slug.
+
+## Instructions
+
+### Step 1: Find the snapshot file
+
+Files live in `tmp/resume/` with names like `{inv_epoch}-{slug}.md`. The `inv_epoch` prefix is monotonically *decreasing* in time, so the lexically smallest filename is the most recent.
+
+```bash
+mkdir -p tmp/resume  # idempotent
+```
+
+**If `$ARGUMENTS` is empty:** pick the lexically first file in the directory (newest).
+
+```bash
+ls tmp/resume/*.md 2>/dev/null | head -1
+```
+
+**If `$ARGUMENTS` is provided:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-${ARGUMENTS}*.md`.
+
+```bash
+ls tmp/resume/*-${ARGUMENTS}*.md 2>/dev/null | head -1
+```
+
+(Lexically-first = newest, because of the inv_epoch convention.)
+
+### Step 2: Handle edge cases
+
+- **Directory empty or missing:** tell the user `tmp/resume/` has no snapshots; suggest `/snapshot <slug>` to capture one. Stop.
+- **No match for the slug:** list available snapshot filenames so the user can pick one. Stop and wait.
+- **Multiple matches:** silently pick the newest, but mention how many were considered and offer to load a different one if asked.
+
+### Step 3: Load and act on the snapshot
+
+1. Read the chosen file.
+2. Print a one-line confirmation: `Resuming from {filename} ({slug}, captured {date if discoverable})`.
+3. **Treat the file's contents as if the user had pasted them as their first message.** Follow the instructions inside — most snapshots end with a "Start by:" line that names a concrete first action; do that. If the snapshot has multiple "Pick" options, default to the recommended one unless the user said otherwise.
+4. Don't summarize the snapshot back to the user before acting — they already wrote it. Just proceed. (Exception: if the snapshot is ambiguous about the next step, ask once before acting.)
+
+### Step 4: Honor any "User direction recorded" or constraints in the snapshot
+
+Snapshots typically capture decisions and preferences from the prior session. Treat them as binding for this session unless explicitly overridden in the user's current message.
+
+## Notes
+
+- Snapshots are immutable once written. If the situation has changed since capture (a referenced PR landed, an issue closed, etc.), verify before acting on stale references — `gh issue view <n>`, `git log`, etc.
+- The companion `/snapshot` command writes new snapshots — point users to it if they want to capture something for later in this session.
+- The `inv_epoch` prefix is a sort-only artifact; the user reads the slug, not the number. Always show the slug (or full filename) in confirmation messages, not just the prefix.

--- a/.gemini/commands/snapshot.md
+++ b/.gemini/commands/snapshot.md
@@ -1,0 +1,60 @@
+# Snapshot (Gemini)
+
+Capture a resumption prompt for picking up the current work later.
+
+When invoked, write a self-contained prompt to `tmp/resume/` so the user (or a future agent session via `/resume`) can pick up where they left off without re-reading the current conversation. This is the **save** side of the snapshot/resume pair — `/resume` is the load side.
+
+Argument: `$ARGUMENTS` — optional kebab-case slug describing the topic. If empty, infer a 3-5 word descriptive slug from the conversation context.
+
+## Instructions
+
+### Step 1: Compute the filename
+
+Filename format: `{inv_epoch}-{slug}.md` in `tmp/resume/`.
+
+`inv_epoch` is a 10-digit integer that *decreases* as time advances, so default `ls` (no flags) lists newest entries first. Compute:
+
+```bash
+INV_EPOCH=$(printf '%010d' $((9999999999 - $(date +%s))))
+```
+
+(The prefix is for sort order only; users read the slug and file contents, not the number.)
+
+Run `mkdir -p tmp/resume` before writing. Don't overwrite existing files; if a same-named file exists, append a 1-letter discriminator (`-a`, `-b`, …) to the slug.
+
+> Note: this directory deviates from the `tmp/agents/<agent-type>/` convention in `AGENTS.md`. `tmp/resume/` is intentionally shared (not per-agent) so snapshots are portable across agents — Gemini can write a snapshot and Claude or Codex can resume from it.
+
+### Step 2: Draft the prompt
+
+The prompt must be **paste-ready** — readable cold by a future agent session that has zero context from this conversation. Use absolute references throughout: issue/PR numbers, file paths, ISO dates (no "yesterday"/"this morning").
+
+Structure:
+
+- **Title** — short description of what's deferred.
+- **Paste-block intro** — one line telling the future user what to do (paste into a fresh agent session at the repo's working directory).
+- **Status as of {today's ISO date}** — what landed recently (merged PRs and closed issues with brief descriptions), current branch state, anything in-flight.
+- **Open issues** (if any are filed but not started) — number, title, one-line scope.
+- **Goal** — the bigger-picture objective this work serves.
+- **Pick: option N (the recommendation)** — list 2-3 numbered next-step options. Mark the recommendation. Brief tradeoff notes.
+- **User direction recorded** — decisions, preferences, or constraints surfaced in the current conversation that future sessions need to honor (e.g., "no cross-provider X", "always prefer Y pattern").
+- **Pre-action reads** — files/docs the future session should read before starting, scoped per option.
+- **Workflow** — short reminder of project conventions (Issue → Branch → PR per `AGENTS.md`, etc.).
+- **Start by:** — concrete first command (e.g., `/plan-issue 714`, or `git checkout main && git pull`).
+
+Add anything else load-bearing — open blockers, runtime gotchas, manual prerequisite steps. Keep tight; this is a paste-block, not a doc.
+
+Don't dump conversation history. Don't include local-environment ephemera. Don't restate auto-loaded context files.
+
+### Step 3: Confirm to the user
+
+Report:
+- The full path to the created file.
+- A one-line summary of what's captured.
+- The quick-use reminder: "paste the file contents into a fresh agent session at this repo's root."
+
+## Notes
+
+- Files persist; no auto-cleanup. The user can `rm` old prompts manually when they're stale.
+- If invoked multiple times in one session, write a new file each time. The user may want separate resumption-points for separate work threads.
+- The prefix uses 10 digits because epoch will exceed 10 digits in the year 2286; that's fine for foreseeable use. If you ever need to extend, bump to 11+ digits.
+- The companion `/resume` command loads a captured snapshot in a future session — point users to it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,8 @@ Where `<agent-type>` is one of: `claude`, `gemini`, `copilot`, `codex`, or the r
 
 **Cleanup rule:** Agents must delete their temporary files when the task is complete. Do not leave stale files in `tmp/agents/`.
 
+**Exception:** `tmp/resume/` is the one location outside `tmp/agents/<agent-type>/`. Snapshots written by `/snapshot` are portable project-state captures meant to be readable by any agent — Claude can write a snapshot and Gemini or Codex can resume from it.
+
 ## Token Efficiency
 - **Be Concise:** Minimal text output.
 - **Use Local Tools:** Prefer native file tools over sub-agents (see [AI Agent File Operations](#ai-agent-file-operations)).

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -98,6 +98,14 @@ Dual-agent PR review. Verifies a PR exists for the current branch, then in paral
 
 Inspects the current git state (branch, uncommitted changes, recent log), extracts the issue number from the branch name if on a feature branch, checks for a plan comment, unpushed commits, and open PRs, then reports a status summary and suggests the next command to run. **Workflow position:** any time. **Design note:** read-only and side-effect-free — safe to run whenever the user is unsure where they are in the lifecycle.
 
+### `/snapshot <slug>` and `/resume <slug>`
+
+**Args:** optional kebab-case slug. **Sources:** `.claude/commands/snapshot.md`, `.claude/commands/resume.md` (Claude); `.gemini/commands/snapshot.md`, `.gemini/commands/resume.md` (Gemini); `.agents/skills/snapshot/SKILL.md`, `.agents/skills/resume/SKILL.md` (Codex).
+
+Pause-and-resume helpers for long-running workstreams. `/snapshot` writes a paste-ready resumption prompt to `tmp/resume/{inv_epoch}-{slug}.md`; `/resume` reads the matching file and treats its contents as the session's initial instructions. The `inv_epoch` prefix is a 10-digit decreasing integer so default `ls` lists newest first; users see only the slug. If `/resume` is invoked without a slug, it picks the most recent snapshot.
+
+**Cross-agent portability:** `tmp/resume/` is intentionally shared (not per-agent), so a snapshot taken in Claude can be resumed in Gemini or Codex and vice versa. This is the documented exception to the `tmp/agents/<agent-type>/` rule in `AGENTS.md`. **Workflow position:** any time, independent of the issue lifecycle. **Design note:** snapshots are immutable once written; the user is expected to verify referenced issues/PRs are still current before acting on stale references. **When to use it:** at the end of a session when work is unfinished and you want a clean handoff into the next session — capture the goal, current branch state, recommended next step, and any user direction or constraints that should bind the future session.
+
 ## Gemini
 
 Gemini-first users can complete the full issue lifecycle using Gemini-native commands. This workflow shares the same artifacts (plan comments, branch names, PR bodies) as the Claude flow, enabling seamless handoff between agents.


### PR DESCRIPTION
## Description

Adds `/snapshot <slug>` and `/resume <slug>` slash commands across all three first-party agent configs (Claude, Gemini, Codex). Snapshots are paste-ready resumption prompts written to a shared `tmp/resume/` directory so a snapshot taken in one agent can be resumed in another. Copilot CLI gets the commands automatically by auto-discovery from `.claude/commands/`.

## Related Issue

Addresses #508

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- New: `.claude/commands/snapshot.md` and `.claude/commands/resume.md` (Claude slash commands).
- New: `.gemini/commands/snapshot.md` and `.gemini/commands/resume.md` (Gemini slash commands).
- New: `.agents/skills/snapshot/SKILL.md` and `.agents/skills/resume/SKILL.md` (Codex repo-scoped skills, invoked as `$snapshot` / `$resume`).
- Modified: `AGENTS.md` — adds a one-paragraph "Exception" note in the Temporary Files section explaining that `tmp/resume/` is the one location outside the per-agent `tmp/agents/<agent-type>/` rule, because snapshots are portable, cross-agent project-state captures.
- Modified: `docs/development/ai/slash-commands.md` — adds a `### /snapshot <slug> and /resume <slug>` subsection in the alphabetical command reference covering arguments, sources for all three agents, file-naming convention (`tmp/resume/{inv_epoch}-{slug}.md` with a 10-digit decreasing-epoch prefix so default `ls` shows newest first), cross-agent portability rationale, and when to use the commands.

## Why

Multi-day workstreams routinely span multiple sessions. Without an explicit pause/resume primitive, users either rely on memory or paste ad-hoc context blobs into a fresh session — both lossy. `/snapshot` captures the session goal, branch state, recommended next step, and any binding user direction or constraints into a paste-ready file; `/resume` reads that file and treats its contents as the next session's initial instructions. Cross-agent portability matters because users often switch agents between sessions (e.g., plan in Claude, resume in Gemini for a quick continuation), and a per-agent snapshot directory would prevent that handoff.

## Testing

- [x] All existing tests pass (`doit check` — green)
- [ ] Added new tests for new functionality — N/A: no Python code changed, the implementation is six new markdown skill/command files plus two doc edits. Markdown skill files are not pytest-testable.
- [x] Manually tested the changes — cross-file validation `grep -rn "tmp/claude/resume" .` returns zero hits, confirming the migration from any prototype path to the shared `tmp/resume/` is clean.

A manual round-trip (snapshot in one session, resume in a fresh session, verify the resumed session has the goal and branch context) is recommended once this lands and downstream copies are removed (see Additional Notes).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A: markdown-only change.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — `AGENTS.md` Temporary Files exception note and a new `### /snapshot <slug> and /resume <slug>` subsection in `docs/development/ai/slash-commands.md`.
- [ ] I have updated the CHANGELOG.md — handled automatically by commitizen during release.
- [x] My changes generate no new warnings

## Additional Notes

**No ADR needed.** Per the issue body: "Small additive change that follows the existing pattern of per-agent slash command files plus a single documented exception to the temp-dir convention." No related ADR mentions the `tmp/agents/` convention, so no existing ADR needs updating either.

**Optional downstream cleanup follow-up.** The InfraFoundry repo currently carries untracked local copies of the prototype Claude variants at `../infrafoundry/.claude/commands/snapshot.md` and `../infrafoundry/.claude/commands/resume.md`. Once this template change syncs downstream, those local copies should be removed so InfraFoundry picks up the canonical versions. That's downstream cleanup and is out of scope for this PR.
