### PR TITLE
chore: add Claude Code env-var defaults for token efficiency

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6"
+  },
   "statusLine": {
     "type": "command",
     "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -155,6 +155,46 @@ claude
 
 For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` in the repository root.
 
+#### Environment Variables
+
+`.claude/settings.json` ships an `env` block with three Claude Code defaults aimed at token efficiency and session survival on long-running work. These propagate to downstream consumers via the template-sync mechanism, so all projects derived from this template inherit the same defaults.
+
+| Var | Value | Effect | Risk |
+| :--- | :--- | :--- | :--- |
+| `ENABLE_PROMPT_CACHING_1H` | `1` | Extends prompt cache TTL from 5 minutes to 1 hour. Cuts cost on repeated reads of the same context within a session. | None — pure efficiency flag. |
+| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `50` | Auto-compaction triggers at 50% of the context window instead of the default (~92%). Sessions compact earlier, leaving more headroom for the post-compact continuation. | More frequent compaction churn until the PreCompact handoff hook (#513) lands. |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | `claude-sonnet-4-6` | Subagents (e.g. those spawned by `/implement`) default to Sonnet 4.6 instead of inheriting the parent's Opus model. | Subagent output quality drops below Opus on hard reasoning tasks. Mitigate per-agent (see below). |
+
+**Per-agent model overrides:**
+
+`CLAUDE_CODE_SUBAGENT_MODEL` is a default. Any agent file under `.claude/agents/` that declares an explicit `model:` in its YAML frontmatter wins:
+
+```yaml
+---
+name: high-stakes-reviewer
+model: claude-opus-4-7   # overrides the env-var default for this agent only
+---
+```
+
+Agents without a `model:` line inherit the env-var default. This template's `.claude/agents/implement-worker.md` deliberately does not override — implement-worker runs on Sonnet 4.6 as an explicit cost/quality trade-off. Future high-stakes subagents (e.g. design review, security review) can opt into Opus on a per-file basis.
+
+**Per-developer overrides:**
+
+To opt out or tune values for your local environment, override them in `.claude/settings.local.json` (already gitignored, used elsewhere in this template for personal config). Example:
+
+```json
+{
+  "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75"
+  }
+}
+```
+
+**Cross-references:**
+
+- The 50% autocompact threshold is paired with the PreCompact handoff hook tracked in #513 — once that hook lands, earlier compaction has lower cost because the handoff preserves more context.
+<!-- TBD: link to #514 add-ons walkthrough doc when it lands -->
+
 ### 4. GitHub Copilot CLI
 
 **Configuration:** `.copilot/` directory


### PR DESCRIPTION
## Description

Adds an `env` block to `.claude/settings.json` with three Claude Code environment variables that improve token efficiency and session survival on long-running work. All three are project-level defaults that propagate to downstream consumers via the template-sync mechanism (`infrafoundry`, `pynetappfoundry`, etc.) rather than living in per-user `settings.local.json`.

| Var | Value | Effect |
| :--- | :--- | :--- |
| `ENABLE_PROMPT_CACHING_1H` | `"1"` | Extends prompt-cache TTL from 5 min to 1 hour — pure cost win, no behaviour change. |
| `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `"50"` | Fires autocompaction at 50% of the context window instead of ~92%. Ensures headroom for the post-compact continuation; required foundation for the PreCompact handoff hook (#513). |
| `CLAUDE_CODE_SUBAGENT_MODEL` | `"claude-sonnet-4-6"` | Pins delegated subagents to Sonnet 4.6 by default (~60% cheaper than Opus for typical research/refactor/audit work). Per-agent `model:` frontmatter overrides the default. |

**Model override decision:** `.claude/agents/implement-worker.md` deliberately does not declare `model:` in its frontmatter — implement-worker runs on Sonnet 4.6 as an explicit cost/quality trade-off. High-stakes subagents can opt into Opus per-file when warranted.

Documentation added to `docs/development/AI_SETUP.md` under a new `#### Environment Variables` subsection in Section 3 (Claude Code). Covers: the three vars and their rationale, per-agent model overrides, per-developer overrides via `settings.local.json`, and cross-references to companion issues.

## Related Issue

Addresses #512

**Companion issues (not closed by this PR):**

- **#513** — feat: add PreCompact auto-checkpoint and SessionStart auto-restore hooks. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50` is the foundation; this PR ships the config side, #513 ships the hook.
- **#514** — docs: add AI agent token-efficiency add-ons walkthrough. Once the full menu of opt-in tools is documented, `AI_SETUP.md` will link there; a placeholder comment is in the new subsection.

## Type of Change

- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.claude/settings.json` — added top-level `"env"` block with three keys before the existing `"statusLine"` key.
- `docs/development/AI_SETUP.md` — added `#### Environment Variables` subsection at the end of Section 3, covering each var, override patterns, and cross-references.

## Why

Token cost on long Claude Code sessions was the motivating pain point. These three vars are the cheap-config-change subset of a broader set of efficiency techniques (distilled from current community practice). They are safe to default on:

- `ENABLE_PROMPT_CACHING_1H` — zero risk, pure win.
- `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50` — small trade-off: more frequent compaction now, substantially better post-compact context survival later (especially with #513). The value is tunable per-developer.
- `CLAUDE_CODE_SUBAGENT_MODEL` — cost reduction with a documented escape hatch (per-agent frontmatter override). Implement-worker was reviewed and accepted on Sonnet 4.6; future high-stakes agents can be pinned to Opus individually.

## Testing

- [x] All existing tests pass (`doit check` — green)
- [ ] Added new tests for new functionality — N/A: config + markdown only; nothing pytest-testable.
- [x] Manually verified — `git diff HEAD` shows only the two changed files; `doit check` clean.

**Manual verification (post-merge):** open a fresh Claude Code session in the repo, run `/implement` on any small issue, confirm the subagent's model shows as Sonnet 4.6 in the session UI. Optionally inspect env with `/status` or `env | grep -E 'ENABLE_PROMPT|CLAUDE'` in a terminal hook.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective — N/A: config + markdown only.
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly — `docs/development/AI_SETUP.md`.
- [ ] I have updated the CHANGELOG.md — handled automatically by commitizen during release.
- [x] My changes generate no new warnings

## Additional Notes

**No ADR needed.** This is a project-config tweak, not an architectural decision. The issue carries labels `chore` + `needs-triage` and no `needs-adr`. ADR-9005 (AI agent command restrictions) is unaffected — env-var defaults are not command-restriction logic.

**Downstream sync.** Once merged, `infrafoundry` and `pynetappfoundry` pick up the same defaults through the template-sync mechanism. No manual action needed in downstream repos beyond accepting the sync PR.

**Per-developer opt-out.** Any of the three values can be overridden in `.claude/settings.local.json` (gitignored). The `#### Environment Variables` subsection in `AI_SETUP.md` documents this pattern with an example snippet.
