### PR TITLE
feat: add .claude/rules/ scaffold and @import pattern in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,6 @@
 @../AGENTS.md
+<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
+<!-- @./rules/*.md -->
 
 # BASIC CLAUDE INSTRUCTIONS
 

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,110 @@
+# Per-Stack Rule Files
+
+## Purpose
+
+Rule files in this directory capture **narrow, recurring footguns** that an AI agent keeps getting
+wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md` carries
+broad workflow and architectural rules for the whole project. A rule file carries three to ten
+numbered self-checks for one specific failure mode — small enough to survive a context window, sharp
+enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+## When to author a rule file
+
+Write a rule file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File structure
+
+Each rule file must have three parts:
+
+```
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+- **`Skill: <name>`** — the first line, no heading. Names the capability gate so the model can
+  self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, split it.
+
+## How to load
+
+Uncomment the `@./rules/*.md` line in `.claude/CLAUDE.md`:
+
+```
+@../AGENTS.md
+<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
+<!-- @./rules/*.md -->
+```
+
+becomes:
+
+```
+@../AGENTS.md
+@./rules/*.md
+```
+
+Note: the line stays commented out in this template repository. Downstream consumers uncomment it
+after authoring their first rule file.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule files must be derived from documented failures, not
+from intuition or generic advice. A checklist written in advance of any failure will drift into
+noise — the model will pattern-match the checklist language and satisfy it superficially. A
+checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the rule
+file is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen.md` rule file might look like for a downstream
+project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an ADR
+(ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual rule
+files belong in downstream repos, not in this template.
+
+```
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## What NOT to put in a rule file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Rule files are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the rule file is not ready to be written.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 
 | CLI | Config Directory | Notes |
 | :--- | :--- | :--- |
-| Claude Code | `.claude/` | Commands, agents, settings. Primary source of slash commands. |
+| Claude Code | `.claude/` | Commands, agents, rules, settings. Primary source of slash commands. |
 | Gemini CLI | `.gemini/` | Commands and settings. Supports a standalone workflow (`/plan-issue`, `/implement`, `/finalize`) and Claude-orchestrated dual-agent flows. |
 | GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
 | Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. |

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -146,5 +146,6 @@ Run `/where-am-i`. It is read-only, has no side effects, and will tell you the c
 - [AI Agent Setup](../AI_SETUP.md) — per-CLI configuration, permissions, and hooks.
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
 - [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
+- [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for downstream consumers who need narrow, skill-gated self-checks beyond what `AGENTS.md` covers.
 - <!-- TODO: wire this link up properly when #342 lands -->
   For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -230,6 +230,21 @@ The hook lives in `.claude/settings.json` (committed) or `.claude/settings.local
 (local-only). Keep injected text short — per-turn injection costs tokens on every message, so
 verbosity here works against the goal.
 
+### Per-stack rule files (third mechanism)
+
+A third application of the same pattern is **small per-stack rule files** imported into
+`.claude/CLAUDE.md` via the `@import` directive. Where per-turn injection is best for style rules
+that must survive every autocompact event, per-stack rule files are best for **narrow, domain-
+specific self-checks** that only apply when the agent is doing a specific class of work (code
+generation, database migrations, API contract changes, etc.).
+
+Each rule file is skill-gated, capped at 30 lines, and built from documented observed failures —
+not from generic advice. The template ships a commented-out `@import` placeholder in
+`.claude/CLAUDE.md`; downstream consumers uncomment it and add their own rule files.
+
+See [`.claude/rules/README.md`](../../../.claude/rules/README.md) for the pattern, file structure,
+and a worked example.
+
 ## Related primitives in this template
 
 These are not add-ons (they ship with the template) but they interact with the tools above:


### PR DESCRIPTION
## Description

Adds a `.claude/rules/` scaffold and the `@import` pattern to this template so downstream
consumers have a documented, first-class mechanism for narrow per-stack rule files. The directory
and README ship commented-out by default — no rule files are loaded until a downstream consumer
authors one and uncomments the import line.

## Related Issue

Addresses #518

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `.claude/rules/README.md` — new file (~110 lines) documenting the per-stack rule-file pattern:
  when to author a rule file, required file structure (Skill gate, numbered self-check list,
  Observed failures footer), 30-line size cap, and a worked example for a downstream project.
- `.claude/CLAUDE.md` — two HTML-commented lines added above `# BASIC CLAUDE INSTRUCTIONS`:
  a human-readable prompt and the dormant `@./rules/*.md` import that downstream consumers
  uncomment when they add their first rule file.
- `AGENTS.md` — AI Config Directories table: Claude Code row updated to mention `rules` alongside
  `commands`, `agents`, and `settings`.
- `docs/development/ai/token-efficiency-add-ons.md` — new "Per-stack rule files (third
  mechanism)" subsection inside "Session-survival of project rules", explaining how rule files
  complement per-turn injection and auto-load.
- `docs/development/ai/first-5-minutes.md` — one "See also" bullet pointing to
  `.claude/rules/README.md`.

## Testing

- [x] All existing tests pass (`doit check` passed locally — format, lint, type-check, security,
  spell, pytest)
- [x] No new tests required: this PR adds only documentation and inert scaffold (no executable
  code, no new CLI commands, no behavior change)
- [x] Manually verified the commented-out import line is syntactically correct for Claude Code's
  `@import` pattern

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] No new tests needed (scaffold and documentation only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Follow-ups

These issues track per-CLI ports of the same pattern and are filed separately to keep this PR
scoped to the Claude Code scaffold only:

- #521 — Gemini CLI rules scaffold (`.gemini/rules/`)
- #522 — GitHub Copilot instructions scaffold (`.github/instructions/`)
- #523 — Codex skills-as-rules pattern (`.agents/skills/`)
- #524 — Gemini token-efficiency settings analogue

None of those are in scope for this PR. They are listed here so reviewers understand the broader
context without conflating them with the changes above.
