### PR TITLE
feat: migrate to Gemini Policy Engine

### DIFF
--- a/.gemini/policies/developer.toml
+++ b/.gemini/policies/developer.toml
@@ -1,0 +1,4 @@
+[[rule]]
+toolName = "*"
+decision = "ask_user"
+priority = 100

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -15,33 +15,6 @@
       }
     ]
   },
-  "tools": {
-    "allowed": [
-      "run_shell_command(git)",
-      "run_shell_command(gh)",
-      "run_shell_command(uv)",
-      "run_shell_command(doit)",
-      "run_shell_command(ls)",
-      "run_shell_command(cat)",
-      "run_shell_command(tree)",
-      "run_shell_command(find)",
-      "run_shell_command(grep)",
-      "run_shell_command(wc)",
-      "run_shell_command(mkdir)",
-      "run_shell_command(python)",
-      "run_shell_command(pytest)",
-      "run_shell_command(ruff)",
-      "run_shell_command(mypy)"
-    ],
-    "core": [
-      "ShellTool",
-      "ReadFileTool",
-      "WriteFileTool",
-      "LSTool",
-      "GrepTool"
-    ],
-    "sandbox": false
-  },
   "ui": {
     "autoApprove": false,
     "showToolCalls": true


### PR DESCRIPTION
## Description

Migrates Gemini CLI configuration from the legacy `tools` allow-list to the modern Policy Engine. This transition provides a cleaner, tiered configuration path while maintaining interaction safety through a global `ask_user` policy.

## Related Issue

Addresses #528

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Changes Made

- Created `.gemini/policies/developer.toml` with a global `ask_user` policy for all tools (`toolName = "*"`).
- Removed deprecated `tools` configuration (allowed tools list and core tools list) from `.gemini/settings.json`.
- Maintained safety guardrails via existing `BeforeTool` hook pointing to `block-dangerous-commands.py`.

## Testing

- [x] All existing tests pass (`doit check` verified)
- [x] Manually verified the "norm" configuration state.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly (issue description updated)
