### PR TITLE
feat: ship optional bash-ban-raw-tools hook (disabled by default)

### DIFF
--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -272,3 +272,4 @@ Then run the test suite to verify.
 - [AI Enforcement Principles](enforcement-principles.md) - Why and how we enforce rules in code
 - [AGENTS.md](../../../AGENTS.md) - AI agent rules including "When Blocked Protocol"
 - [AI Agent Setup](../AI_SETUP.md) - Setting up AI coding assistants
+- [Bash raw-tool ban](token-efficiency-add-ons.md#bash-raw-tool-ban-opt-in) - Opt-in hook that blocks raw shell commands AI agents should use native tools for (`cat`, `head`, `tail`, `find`, `grep`, `rg`, `wc`)

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -190,6 +190,70 @@ in your local Claude Code settings:
 This is a **local-only** file (not committed). Do not commit Caveman plugin config — intensity
 preference varies by operator and can conflict with other contributors' expectations.
 
+## Bash raw-tool ban (opt-in)
+
+This hook enforces what `AGENTS.md` already asks for: prefer native file tools (`Read`, `Grep`,
+`Glob`, `Edit`, `Write`) over their raw shell equivalents. When an agent defects to `Bash`, the
+raw output bypasses every other token-efficiency control and lands in context uncompressed.
+
+**What it blocks:**
+
+- Leading banned commands: `cat`, `head`, `tail`, `find`, `grep`, `rg`, `wc`
+- Piped truncators: `... | head`, `... | tail` (regardless of arguments)
+
+Each block message names the offending command, suggests the native replacement, and reminds the
+agent about the escape hatch.
+
+**Native tool replacements:**
+
+| Blocked command | Use instead |
+| :--- | :--- |
+| `cat` / `head` / `tail` | `Read` |
+| `find` | `Glob` |
+| `grep` / `rg` | `Grep` |
+| `wc` | `Read` (then count in the result) |
+
+**Opt-in via `.claude/settings.local.json`:**
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/bash-ban-raw-tools.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This goes in `.claude/settings.local.json` (not committed) — each operator opts in individually.
+Do **not** add it to the committed `.claude/settings.json`.
+
+**Escape hatch:**
+
+```bash
+touch /tmp/bash-raw-unlock
+```
+
+Allows all banned commands for 10 minutes. The file auto-expires — no cleanup needed. Useful when
+you need a one-off raw shell command without disabling the hook permanently.
+
+**Why disabled by default:** humans share the repo. Raw shell commands are legitimate in human
+workflows. The hook is only beneficial when an AI agent is the primary operator of the terminal.
+Enable it locally for AI-heavy sessions; disable it when you are working interactively.
+
+**Related:** the always-on dangerous-command hook (committed in `.claude/settings.json`) is
+documented in [AI Command Blocking](command-blocking.md). The two hooks are complementary: the
+dangerous-command hook blocks security-relevant patterns for everyone; this hook enforces
+token-efficiency discipline only for operators who opt in.
+
 ## Session-survival of project rules
 
 This section documents the **pattern** that Caveman uses, so you can apply it to any narrow rule

--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -1,0 +1,261 @@
+"""Tests for the ``bash-ban-raw-tools`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/bash-ban-raw-tools.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "bash-ban-raw-tools.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("bash_ban_raw_tools", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["bash_ban_raw_tools"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("bash_ban_raw_tools", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _bash_payload(command: str) -> str:
+    """Build a Bash tool payload for the given command."""
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+def _non_bash_payload(tool_name: str) -> str:
+    """Build a non-Bash tool payload."""
+    return json.dumps({"tool_name": tool_name, "tool_input": {"file_path": "README.md"}})
+
+
+# ---------------------------------------------------------------------------
+# Allow cases
+# ---------------------------------------------------------------------------
+
+
+def test_non_bash_tool_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-Bash tools (e.g. Read) are always allowed."""
+    _set_stdin(monkeypatch, _non_bash_payload("Read"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_benign_bash_command_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Safe Bash commands like ``ls -la`` are allowed."""
+    _set_stdin(monkeypatch, _bash_payload("ls -la"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_malformed_json_exits_1(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON input exits with code 1 (parity with block-dangerous-commands)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 1
+
+
+def test_banned_word_as_non_leading_non_pipe_token_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``echo cat`` — banned word is not the leading token and not after a pipe."""
+    _set_stdin(monkeypatch, _bash_payload("echo cat"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Block: banned leading commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat README.md",
+        "head foo.txt",
+        "tail -f log.txt",
+        "find . -name '*.py'",
+        "grep pattern file.py",
+        "rg pattern",
+        "wc -l file.txt",
+    ],
+)
+def test_banned_leading_command_exits_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Each banned leading command is blocked with exit code 2."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Block: piped truncators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls | head",
+        "ls | tail -100",
+        "cmd | head -n 5",
+    ],
+)
+def test_piped_truncator_exits_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Piped truncators (``... | head``, ``... | tail``) are blocked with exit code 2."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch: unlock file
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_unlock_file_allows_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file exists and mtime is within window, banned commands are allowed."""
+    unlock = tmp_path / "unlock"
+    unlock.touch()
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_stale_unlock_file_blocks_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file mtime is older than UNLOCK_WINDOW_SECONDS, command is blocked."""
+    unlock = tmp_path / "unlock"
+    unlock.touch()
+    # Set mtime to well past the window
+    stale_mtime = time.time() - (hook.UNLOCK_WINDOW_SECONDS + 60)
+    import os
+
+    os.utime(str(unlock), (stale_mtime, stale_mtime))
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_missing_unlock_file_blocks_banned_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When unlock file does not exist, banned commands are blocked."""
+    unlock = tmp_path / "unlock"
+    # Do NOT create the file
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+
+    _set_stdin(monkeypatch, _bash_payload("grep pattern file.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Stderr reason content checks
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_reason_mentions_offending_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason mentions the offending command."""
+    monkeypatch.setattr(hook, "UNLOCK_FILE", str(tmp_path / "unlock"))
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert "cat" in captured.err
+
+
+def test_stderr_reason_mentions_unlock_file(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason mentions the escape hatch (UNLOCK_FILE path)."""
+    unlock_path = str(tmp_path / "unlock")
+    monkeypatch.setattr(hook, "UNLOCK_FILE", unlock_path)
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert unlock_path in captured.err

--- a/tools/hooks/ai/bash-ban-raw-tools.py
+++ b/tools/hooks/ai/bash-ban-raw-tools.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse hook to block raw shell commands when native tools are available.
+
+This hook intercepts Bash commands before execution and blocks those that AI agents
+should be using native file tools for instead (Read, Grep, Glob, Edit, Write).
+
+Blocks:
+  - Leading banned commands: cat, head, tail, find, grep, rg, wc
+  - Piped truncators: ... | head, ... | tail (regardless of args)
+
+Escape hatch:
+  Touch /tmp/bash-raw-unlock (or the configured UNLOCK_FILE) to allow banned
+  commands for 10 minutes. The file auto-expires — no cleanup needed.
+
+Exit codes:
+  0 - Allow command
+  1 - Malformed JSON input
+  2 - Block command (shows stderr to Claude)
+
+This hook is Claude-only (reads {"tool_name": "Bash", "tool_input": {"command": "..."}}).
+For always-on dangerous-command blocking, see: tools/hooks/ai/block-dangerous-commands.py
+For documentation, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+import json
+import shlex
+import sys
+import time
+from pathlib import Path
+
+# Commands that AI agents should never use via Bash when native tools are available
+BANNED_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "find", "grep", "rg", "wc"})
+
+# Commands that are banned when they appear after a pipe (regardless of arguments)
+PIPE_TRUNCATORS: frozenset[str] = frozenset({"head", "tail"})
+
+# Escape hatch: touch this file to allow banned commands for UNLOCK_WINDOW_SECONDS
+UNLOCK_FILE: str = "/tmp/bash-raw-unlock"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+
+# How long the escape hatch stays valid after the file is touched (seconds)
+UNLOCK_WINDOW_SECONDS: int = 600
+
+# Native tool suggestions for each banned command
+_SUGGESTIONS: dict[str, str] = {
+    "cat": "Read",
+    "head": "Read",
+    "tail": "Read",
+    "find": "Glob",
+    "grep": "Grep",
+    "rg": "Grep",
+    "wc": "Read (then count lines/words in the result)",
+}
+
+
+def tokenize(command: str) -> list[str]:
+    """
+    Tokenize command using shlex for proper shell quote handling.
+
+    Returns list of tokens with quotes stripped from values.
+    Falls back to non-POSIX mode, then simple whitespace split on malformed input.
+    """
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        try:
+            return shlex.split(command, posix=False)
+        except ValueError:
+            return command.split()
+
+
+def is_unlocked() -> bool:
+    """Return True iff UNLOCK_FILE exists and was modified within UNLOCK_WINDOW_SECONDS."""
+    path = Path(UNLOCK_FILE)
+    try:
+        mtime = path.stat().st_mtime
+        return (time.time() - mtime) <= UNLOCK_WINDOW_SECONDS
+    except OSError:
+        return False
+
+
+def find_banned_leading(tokens: list[str]) -> str | None:
+    """Return the first token if it is in BANNED_COMMANDS, else None."""
+    if tokens and tokens[0] in BANNED_COMMANDS:
+        return tokens[0]
+    return None
+
+
+def find_banned_pipe(tokens: list[str]) -> str | None:
+    """
+    Scan for a pipe token immediately followed by a PIPE_TRUNCATOR.
+
+    Returns the truncator name if found, else None.
+    """
+    for i, token in enumerate(tokens):
+        if token == "|" and i + 1 < len(tokens) and tokens[i + 1] in PIPE_TRUNCATORS:  # nosec B105 - "|" is the shell pipe character, not a credential.
+            return tokens[i + 1]
+    return None
+
+
+def _build_reason(offending: str) -> str:
+    """Build a human-readable block reason for the given offending command."""
+    suggestion = _SUGGESTIONS.get(offending, "a native tool")
+    return (
+        f"Blocked: `{offending}` is a raw shell command.\n"
+        f"Use the native `{suggestion}` tool instead — it produces a better result "
+        f"with fewer tokens.\n"
+        f"Escape hatch: `touch {UNLOCK_FILE}` to allow raw commands for "
+        f"{UNLOCK_WINDOW_SECONDS // 60} minutes."
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    try:
+        input_data: dict[str, object] = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"Invalid JSON input: {e}", file=sys.stderr)
+        return 1
+
+    # This hook is Claude-only: expects {"tool_name": ..., "tool_input": {...}}
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        return 0
+
+    tool_input = input_data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command", "")
+    if not isinstance(command, str) or not command:
+        return 0
+
+    # Escape hatch: allow if unlock file is fresh
+    if is_unlocked():
+        return 0
+
+    tokens = tokenize(command)
+
+    # Check for banned leading command
+    offending = find_banned_leading(tokens)
+    if offending is not None:
+        print(_build_reason(offending), file=sys.stderr)
+        return 2
+
+    # Check for banned pipe-truncator
+    offending = find_banned_pipe(tokens)
+    if offending is not None:
+        print(_build_reason(offending), file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Ships an opt-in `PreToolUse` hook that enforces the `AGENTS.md` rule "prefer native file tools
over raw shell equivalents" at the tool level. When an AI agent runs `cat`, `head`, `tail`,
`find`, `grep`, `rg`, or `wc` via `Bash`, the hook exits with code 2 and tells the agent which
native tool to use instead. Raw shell output bypasses every other token-efficiency control and
lands in context uncompressed; this hook stops defections before they happen.

The hook is **disabled by default** — it is not wired into the committed `.claude/settings.json`.
Operators opt in via their local `.claude/settings.local.json`. This is deliberate: humans
collaborating in the same repo run legitimate shell commands and should not be affected.

Addresses #515

## Related Issue

Addresses #515

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **New:** `tools/hooks/ai/bash-ban-raw-tools.py` — Claude Code `PreToolUse`/`Bash` hook.
  Blocks leading banned commands (`cat`, `head`, `tail`, `find`, `grep`, `rg`, `wc`) and piped
  truncators (`... | head`, `... | tail`). All tuneable constants at the top of the file.
  Mtime-based `/tmp/bash-raw-unlock` escape hatch (10 min window). Exit codes 0/1/2.

- **New:** `tests/test_bash_ban_raw_tools.py` — 19 pytest cases loaded via `importlib`
  (required because the filename contains hyphens). Covers allow cases, all 7 banned leading
  commands, piped truncators, fresh/stale/missing unlock file, and stderr reason content.

- **Modified:** `docs/development/ai/token-efficiency-add-ons.md` — added
  `## Bash raw-tool ban (opt-in)` section with the opt-in JSON snippet, native-replacement
  table, escape-hatch usage, and rationale for the opt-in-only design.

- **Modified:** `docs/development/ai/command-blocking.md` — added cross-reference to the new
  hook under the `## Related` section so readers of the dangerous-command hook doc discover
  the complementary opt-in hook.

- **`.claude/settings.json` is intentionally NOT modified.** The hook is opt-in by design.
  Adding it to the committed settings would affect all collaborators including humans who run
  legitimate shell commands. Each operator enables it in their own
  `.claude/settings.local.json`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (`tests/test_bash_ban_raw_tools.py`, 19 cases)
- [x] Manually tested the changes

### Manual verification steps (from issue success criteria)

1. Add the hook to `.claude/settings.local.json`:
   ```json
   {
     "hooks": {
       "PreToolUse": [
         {
           "matcher": "Bash",
           "hooks": [
             {
               "type": "command",
               "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/bash-ban-raw-tools.py"
             }
           ]
         }
       ]
     }
   }
   ```
2. Start a new Claude Code session.
3. Ask Claude to run a banned command, e.g. `cat README.md` via the Bash tool.
4. Observe: Claude Code surfaces a tool-use error with the block reason; the agent recovers
   by retrying with the `Read` tool.
5. Test escape hatch: `touch /tmp/bash-raw-unlock`, then re-run the banned command — it is
   allowed. Wait 10 minutes (or set mtime to stale) — the hook blocks again automatically.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The test file uses `importlib.util.spec_from_file_location` to load the hook script because
the hyphenated filename (`bash-ban-raw-tools.py`) is not directly importable as a Python
module. This follows the same approach used by the test authors when the filename must contain
hyphens (a convention shared with `block-dangerous-commands.py`).

ADR status: not required — this is a new hook that follows the existing `tools/hooks/ai/`
pattern already documented in ADR-9005. The issue body explicitly calls this out.
