### PR TITLE
feat: ship optional CBM gate hooks (opt-in, requires CBM MCP server)

### DIFF
--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -254,6 +254,136 @@ documented in [AI Command Blocking](command-blocking.md). The two hooks are comp
 dangerous-command hook blocks security-relevant patterns for everyone; this hook enforces
 token-efficiency discipline only for operators who opt in.
 
+## Codebase Memory MCP gate (opt-in)
+
+The [Codebase Memory MCP server](https://github.com/DeusData/codebase-memory-mcp) (CBM) builds a
+tree-sitter knowledge graph of your repository and exposes it as MCP tools
+(`search_graph`, `trace_path`, `get_architecture`, `get_code_snippet`, `index_repository`,
+`detect_changes`). Structural queries — "where is function X defined?", "what calls module Y?" —
+cost orders of magnitude fewer tokens answered by the graph than by reading files directly.
+
+Without enforcement, models default to trained behaviour: `Read`/`Grep`/`Glob` on source files.
+The three hooks below close that loop.
+
+### Three-hook design
+
+| Hook | Event | What it does |
+| :--- | :--- | :--- |
+| `cbm-code-discovery-gate.py` | `PreToolUse` on `Read\|Grep\|Glob` | Blocks code-discovery on source files unless a CBM tool ran recently or the target is in the allow-list |
+| `cbm-mcp-marker.py` | `PostToolUse` on CBM tool prefix | Touches a sidecar marker file, opening a 120s window during which the gate passes through |
+| `cbm-session-reminder.py` | `SessionStart` on `compact\|resume\|clear` | Re-injects the CBM protocol into context so the model does not forget the discipline after autocompact |
+
+### Allow-list
+
+The gate passes through automatically for paths that CBM cannot help with:
+
+| Allow-list rule | What it covers |
+| :--- | :--- |
+| Extensions `.json .yaml .yml .md .toml .lock .txt .env .sh` | Config, docs, lockfiles |
+| Path contains `.claude/`, `CLAUDE.md`, `settings`, `hooks/` | Project metadata and hooks |
+| Path contains `tests/` or `_test.` | Test files |
+
+Source-code files (`.py`, `.ts`, `.js`, `.go`, etc.) are **not** in the allow-list. A
+`Grep`/`Glob` with no `path` argument (whole-repo search) is also always gated — that is exactly
+the case CBM's `search_graph` is optimised for.
+
+### Read-after-CBM workflow
+
+1. Agent calls a CBM tool (e.g. `mcp__codebase-memory__search_graph`).
+2. `cbm-mcp-marker.py` touches `/tmp/cbm-mcp-used-{ppid}` (scoped to the Claude Code session by
+   parent PID).
+3. Within 120 seconds, `Read`/`Grep`/`Glob` on source files passes through the gate.
+4. After 120 seconds the window closes — the next code-discovery call requires another CBM call
+   first.
+
+The 120-second window is deliberately short: long enough for a focused follow-up read, short
+enough to prevent the gate from becoming permanently open after a single CBM call at session start.
+
+### Setup
+
+**Prerequisites:** install and configure the CBM MCP server. Follow the upstream instructions at
+[github.com/DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp). The
+hooks in this template assume the server is named `codebase-memory` in your MCP config.
+
+**Step 1** — Index the repository once:
+
+```bash
+# Inside a Claude Code session with CBM MCP wired:
+mcp__codebase-memory__index_repository
+```
+
+**Step 2** — Wire the three hooks in `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/cbm-code-discovery-gate.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__codebase-memory__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/cbm-mcp-marker.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/cbm-session-reminder.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This goes in `.claude/settings.local.json` (not committed) — each operator opts in individually.
+Do **not** add it to the committed `.claude/settings.json`.
+
+**Step 3** — Refresh the graph when the codebase changes materially:
+
+```bash
+mcp__codebase-memory__detect_changes   # check if refresh is needed
+mcp__codebase-memory__index_repository # re-index if needed
+```
+
+### Trust caveats
+
+CBM indexes the repository by parsing source files with tree-sitter. The resulting graph lives
+locally in whatever storage backend the CBM server is configured with. Key considerations:
+
+- **Graph staleness:** the graph reflects the codebase at the time of the last `index_repository`
+  call. After significant changes (new modules, major refactors), call `detect_changes` and
+  re-index before relying on graph results. The gate passes through regardless of graph freshness —
+  it enforces that a CBM tool *runs*, not that the graph is accurate.
+- **Server trust:** CBM reads your source files to build the graph. Apply the same due-diligence
+  you would to any tool that reads your codebase. Read the source and confirm no network egress
+  before using on sensitive or employer-owned codebases.
+- **MCP server name:** if your CBM server is configured under a different name than
+  `codebase-memory`, update the `PostToolUse` matcher (e.g. `mcp__my-cbm__.*`) to match. The
+  hook itself is tool-name-agnostic; only the matcher needs updating.
+
+**Why disabled by default:** CBM requires an external MCP server that each operator installs and
+configures separately. Wiring these hooks in committed settings would break every contributor who
+has not installed CBM.
+
 ## Session-survival of project rules
 
 This section documents the **pattern** that Caveman uses, so you can apply it to any narrow rule

--- a/tests/test_hook_cbm_code_discovery_gate.py
+++ b/tests/test_hook_cbm_code_discovery_gate.py
@@ -1,0 +1,320 @@
+"""Tests for the ``cbm-code-discovery-gate`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/cbm-code-discovery-gate.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-code-discovery-gate.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("cbm_code_discovery_gate", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["cbm_code_discovery_gate"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("cbm_code_discovery_gate", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _read_payload(path: str) -> str:
+    """Build a Read tool payload for the given path."""
+    return json.dumps({"tool_name": "Read", "tool_input": {"file_path": path}})
+
+
+def _grep_payload(path: str | None = None) -> str:
+    """Build a Grep tool payload. If path is None, simulate a whole-repo search."""
+    tool_input: dict[str, str] = {}
+    if path is not None:
+        tool_input["path"] = path
+    return json.dumps({"tool_name": "Grep", "tool_input": tool_input})
+
+
+def _glob_payload(path: str | None = None) -> str:
+    """Build a Glob tool payload. If path is None, simulate a whole-repo search."""
+    tool_input: dict[str, str] = {}
+    if path is not None:
+        tool_input["path"] = path
+    return json.dumps({"tool_name": "Glob", "tool_input": tool_input})
+
+
+def _non_gated_payload(tool_name: str) -> str:
+    """Build a non-gated tool payload."""
+    return json.dumps({"tool_name": tool_name, "tool_input": {"command": "ls -la"}})
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: non-gated tool
+# ---------------------------------------------------------------------------
+
+
+def test_non_gated_tool_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-gated tools (e.g. Bash) are always allowed — gate only applies to Read/Grep/Glob."""
+    _set_stdin(monkeypatch, _non_gated_payload("Bash"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: allow-list extension matches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "pyproject.toml",
+        "README.md",
+        "requirements.txt",
+        "config.yaml",
+        "config.yml",
+        "data.json",
+        "poetry.lock",
+        ".env",
+        "setup.sh",
+    ],
+)
+def test_allowlist_extension_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+) -> None:
+    """Read on an allow-listed extension always passes through."""
+    _set_stdin(monkeypatch, _read_payload(path))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: allow-list path fragment matches
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_claude_dir_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read on a .claude/ path always passes through."""
+    _set_stdin(monkeypatch, _read_payload(".claude/settings.json"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_allowlist_tests_dir_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read on a tests/ path always passes through."""
+    _set_stdin(monkeypatch, _read_payload("tests/test_foo.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_allowlist_hooks_dir_allows_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read on a hooks/ path always passes through."""
+    _set_stdin(monkeypatch, _read_payload("tools/hooks/ai/bash-ban-raw-tools.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+def test_allowlist_grep_on_docs_allows(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Grep on a .md file (docs) always passes through."""
+    _set_stdin(monkeypatch, _grep_payload("docs/foo.md"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Allow cases: fresh CBM marker
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_marker_allows_source_file_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Read on a source file is allowed when the CBM marker is fresh."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    marker.touch()
+
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Block cases: source file without fresh marker
+# ---------------------------------------------------------------------------
+
+
+def test_missing_marker_blocks_source_file_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Read on a source file is blocked when the CBM marker does not exist."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    # Do NOT create the marker file.
+
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_stale_marker_blocks_source_file_read(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Read on a source file is blocked when the CBM marker mtime is older than TTL."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    marker.touch()
+    stale_mtime = time.time() - (hook.MARKER_TTL_SECONDS + 60)
+    os.utime(str(marker), (stale_mtime, stale_mtime))
+
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_whole_repo_grep_no_marker_is_blocked(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Grep with no path (whole-repo) is blocked when no CBM marker exists."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    # No marker file.
+
+    _set_stdin(monkeypatch, _grep_payload(None))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_whole_repo_glob_no_marker_is_blocked(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Glob with no path (whole-repo) is blocked when no CBM marker exists."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    # No marker file.
+
+    _set_stdin(monkeypatch, _glob_payload(None))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# Stderr content checks
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_mentions_gated_tool(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason names the gated tool."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    assert "Read" in captured.err
+
+
+def test_stderr_mentions_marker_path(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The stderr block reason references the CBM marker mechanism."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    _set_stdin(monkeypatch, _read_payload("src/main.py"))
+
+    with pytest.raises(SystemExit):
+        sys.exit(hook.main())
+
+    captured = capsys.readouterr()
+    # The marker path (with ppid filled in) should appear in stderr.
+    assert str(tmp_path) in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_1(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON input exits with code 1 (parity with bash-ban-raw-tools)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 1

--- a/tests/test_hook_cbm_mcp_marker.py
+++ b/tests/test_hook_cbm_mcp_marker.py
@@ -1,0 +1,155 @@
+"""Tests for the ``cbm-mcp-marker`` PostToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/cbm-mcp-marker.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-mcp-marker.py"
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("cbm_mcp_marker", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["cbm_mcp_marker"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("cbm_mcp_marker", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _cbm_tool_payload(tool_name: str = "mcp__codebase-memory__search_graph") -> str:
+    """Build a typical PostToolUse payload for a CBM MCP tool call."""
+    return json.dumps(
+        {
+            "tool_name": tool_name,
+            "tool_input": {"query": "find main function"},
+            "tool_response": {"result": "..."},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Marker file creation
+# ---------------------------------------------------------------------------
+
+
+def test_marker_file_is_created(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker file is created when it does not already exist."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    assert not marker.exists()
+
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+
+    assert marker.exists()
+
+
+def test_marker_file_mtime_is_fresh(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker file mtime is within 5 seconds of now after hook runs."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+
+    before = time.time()
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+    after = time.time()
+
+    mtime = marker.stat().st_mtime
+    assert before - 1 <= mtime <= after + 1
+
+
+def test_marker_file_mtime_is_updated(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker file mtime is updated when the file already exists."""
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", str(tmp_path / "marker-{ppid}"))
+    marker = tmp_path / f"marker-{os.getppid()}"
+    marker.touch()
+    old_mtime = time.time() - 60
+    os.utime(str(marker), (old_mtime, old_mtime))
+
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+
+    new_mtime = marker.stat().st_mtime
+    assert new_mtime > old_mtime
+
+
+# ---------------------------------------------------------------------------
+# Marker path uses MARKER_FILE_TEMPLATE
+# ---------------------------------------------------------------------------
+
+
+def test_marker_path_uses_configured_template(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Marker is created at the path derived from MARKER_FILE_TEMPLATE."""
+    custom_template = str(tmp_path / "custom-marker-{ppid}")
+    monkeypatch.setattr(hook, "MARKER_FILE_TEMPLATE", custom_template)
+    expected_marker = tmp_path / f"custom-marker-{os.getppid()}"
+
+    _set_stdin(monkeypatch, _cbm_tool_payload())
+    assert hook.main() == 0
+
+    assert expected_marker.exists()
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON: best-effort, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON exits 0 — the marker hook never blocks (best-effort)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    assert hook.main() == 0

--- a/tests/test_hook_cbm_session_reminder.py
+++ b/tests/test_hook_cbm_session_reminder.py
@@ -1,0 +1,179 @@
+"""Tests for the ``cbm-session-reminder`` SessionStart hook.
+
+The hook script lives at ``tools/hooks/ai/cbm-session-reminder.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-session-reminder.py"
+)
+
+# Sibling reminder file (used to verify real content in integration-style tests).
+REAL_REMINDER_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "cbm-session-reminder.md"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("cbm_session_reminder", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["cbm_session_reminder"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("cbm_session_reminder", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _session_start_payload(trigger: str = "compact") -> str:
+    """Build a SessionStart payload with the given trigger."""
+    return json.dumps({"trigger": trigger, "cwd": "/some/project"})
+
+
+# ---------------------------------------------------------------------------
+# Stdout JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_is_valid_json(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Hook emits valid JSON on stdout."""
+    reminder = tmp_path / "reminder.md"
+    reminder.write_text("# Reminder\nUse CBM tools.", encoding="utf-8")
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", reminder)
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert isinstance(data, dict)
+
+
+def test_stdout_hook_event_name_is_session_start(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """hookSpecificOutput.hookEventName is 'SessionStart'."""
+    reminder = tmp_path / "reminder.md"
+    reminder.write_text("# Reminder\nUse CBM tools.", encoding="utf-8")
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", reminder)
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+
+def test_stdout_additional_context_matches_reminder_file(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """additionalContext equals the full contents of the reminder file."""
+    reminder_body = "# CBM Reminder\nUse search_graph first.\n"
+    reminder = tmp_path / "reminder.md"
+    reminder.write_text(reminder_body, encoding="utf-8")
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", reminder)
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["additionalContext"] == reminder_body
+
+
+# ---------------------------------------------------------------------------
+# Real reminder file integration
+# ---------------------------------------------------------------------------
+
+
+def test_real_reminder_file_produces_non_empty_context(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The shipped cbm-session-reminder.md produces non-empty additionalContext."""
+    # Uses the real REMINDER_TEXT_PATH from the hook (no monkeypatch needed).
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert len(data["hookSpecificOutput"]["additionalContext"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Missing reminder file: degrade gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_missing_reminder_file_exits_0_no_stdout(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When reminder file is missing, hook exits 0 and produces no stdout."""
+    monkeypatch.setattr(hook, "REMINDER_TEXT_PATH", tmp_path / "nonexistent.md")
+
+    _set_stdin(monkeypatch, _session_start_payload())
+    assert hook.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSON: best-effort, no crash
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON exits 0 — the reminder hook never blocks (best-effort)."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    assert hook.main() == 0

--- a/tools/hooks/ai/cbm-code-discovery-gate.py
+++ b/tools/hooks/ai/cbm-code-discovery-gate.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Claude Code PreToolUse hook to gate code-discovery tools behind a CBM (Codebase Memory MCP) call.
+
+This hook intercepts Read, Grep, and Glob calls before execution and blocks those targeting
+source-code files unless a CBM tool has been called recently (within MARKER_TTL_SECONDS) or
+the path matches the allow-list (configs, docs, tests, hooks, settings).
+
+The gate exists to encourage agents to query the CBM knowledge graph first — which answers
+structural queries for far fewer tokens than reading files directly — and only fall back to
+raw file reads for targets that CBM cannot help with (config, docs, test files).
+
+Allow-list:
+  File extensions: .json .yaml .yml .md .toml .lock .txt .env .sh
+  Path fragments:  .claude/ CLAUDE.md settings hooks/ tests/ _test.
+
+Escape hatch:
+  CBM marker: any call to a CBM MCP tool (matched by the PostToolUse marker hook) touches
+  MARKER_FILE_TEMPLATE, opening a MARKER_TTL_SECONDS window during which Read/Grep/Glob
+  on source files is allowed.
+
+Exit codes:
+  0 - Allow (allow-list match, marker fresh, or non-gated tool)
+  1 - Malformed JSON input
+  2 - Block (source file + no fresh marker; shows stderr to Claude)
+
+This hook is Claude-only (reads {"tool_name": ..., "tool_input": {...}}).
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# Tool names this gate applies to (the matcher does the first cut, but defensively re-check).
+GATED_TOOLS: frozenset[str] = frozenset({"Read", "Grep", "Glob"})
+
+# Files / paths that always pass through (configs, docs, tests, project metadata).
+# Source-code files (.py, .js, .ts, .go, etc.) are NOT in the allow-list and require
+# a recent CBM call.
+ALLOWLIST_REGEX: re.Pattern[str] = re.compile(
+    r"\.(json|yaml|yml|md|toml|lock|txt|env|sh)$"
+    r"|\.claude/|CLAUDE\.md|settings|hooks/|(^|/)tests?/|_test\."
+)
+
+# Marker file template. {ppid} interpolates to os.getppid() at runtime so the
+# marker is scoped per-Claude-Code-session.
+MARKER_FILE_TEMPLATE: str = "/tmp/cbm-mcp-used-{ppid}"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+
+# How long the marker stays valid after the last CBM tool call (seconds).
+MARKER_TTL_SECONDS: int = 120
+
+
+def _marker_fresh() -> bool:
+    """Return True iff the CBM marker file exists and was modified within MARKER_TTL_SECONDS."""
+    path = Path(MARKER_FILE_TEMPLATE.format(ppid=os.getppid()))
+    try:
+        mtime = path.stat().st_mtime
+        return (time.time() - mtime) <= MARKER_TTL_SECONDS
+    except OSError:
+        return False
+
+
+def _build_block_reason(tool_name: str, path_value: str) -> str:
+    """Build a human-readable block reason naming the gated tool and recovery steps."""
+    marker_path = MARKER_FILE_TEMPLATE.format(ppid=os.getppid())
+    target_desc = f"`{path_value}`" if path_value else "a whole-repo search"
+    return (
+        f"Blocked: `{tool_name}` on {target_desc} requires a recent CBM call.\n"
+        f"Call `mcp__codebase-memory__search_graph` (or another CBM tool) first, "
+        f"then retry within {MARKER_TTL_SECONDS}s.\n"
+        f"CBM marker: {marker_path}\n"
+        f"Allow-list bypass: configs, docs, tests, and settings files are always allowed."
+    )
+
+
+def main() -> int:
+    """Main entry point."""
+    try:
+        input_data: dict[str, object] = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"Invalid JSON input: {e}", file=sys.stderr)
+        return 1
+
+    # Defensive check: this hook is Claude-only and expects a specific payload shape.
+    tool_name = input_data.get("tool_name", "")
+    if not isinstance(tool_name, str) or tool_name not in GATED_TOOLS:
+        return 0
+
+    tool_input = input_data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+
+    # Extract the path argument. Read uses "file_path"; Grep/Glob use "path".
+    # If path is absent (whole-repo Grep/Glob), path_value is "" — NOT auto-allowed.
+    if tool_name == "Read":
+        path_value = tool_input.get("file_path", "")
+    else:
+        path_value = tool_input.get("path", "")
+
+    if not isinstance(path_value, str):
+        path_value = ""
+
+    # Allow-list: configs, docs, tests, hooks, settings always pass through.
+    if path_value and ALLOWLIST_REGEX.search(path_value):
+        return 0
+
+    # CBM escape hatch: marker file exists and is fresh (written by cbm-mcp-marker.py).
+    if _marker_fresh():
+        return 0
+
+    # Block: source file (or whole-repo search) without a fresh CBM call.
+    print(_build_block_reason(tool_name, path_value), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/cbm-mcp-marker.py
+++ b/tools/hooks/ai/cbm-mcp-marker.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Claude Code PostToolUse hook that touches a sidecar marker file whenever a CBM MCP tool fires.
+
+The marker file is used by the cbm-code-discovery-gate.py PreToolUse hook to open a
+MARKER_TTL_SECONDS (120s) window during which Read/Grep/Glob on source files is allowed
+without an additional CBM call.
+
+This hook is intentionally tool-name-agnostic: the ``matcher`` in settings.local.json
+(e.g., ``mcp__codebase-memory__.*``) determines which PostToolUse events reach this hook.
+Operators with non-default CBM server names tune the matcher, not this file.
+
+Exit codes:
+  0 - Always (best-effort; never blocks a tool call)
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Marker file template. {ppid} interpolates to os.getppid() at runtime so the
+# marker is scoped per-Claude-Code-session. Must match the constant in
+# cbm-code-discovery-gate.py.
+MARKER_FILE_TEMPLATE: str = "/tmp/cbm-mcp-used-{ppid}"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; never blocks. Tests call this directly."""
+    try:
+        try:
+            json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0  # Malformed JSON — best-effort, don't block.
+
+        marker = Path(MARKER_FILE_TEMPLATE.format(ppid=os.getppid()))
+        marker.touch()
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/cbm-session-reminder.md
+++ b/tools/hooks/ai/cbm-session-reminder.md
@@ -1,0 +1,44 @@
+# CBM Gate Protocol Reminder
+
+The **Codebase Memory MCP gate** is active for `Read`, `Grep`, and `Glob` on source files.
+
+## What the gate does
+
+Any `Read`/`Grep`/`Glob` call targeting a **source-code file** (`.py`, `.ts`, `.js`, `.go`, etc.)
+is blocked unless a CBM tool has been called within the last 120 seconds. This enforces the
+token-efficient query path: CBM's knowledge graph answers structural questions for far fewer tokens
+than reading files directly.
+
+## What always passes through (no CBM needed)
+
+The allow-list bypasses the gate automatically — you can read these directly:
+
+- Config files: `.json`, `.yaml`, `.yml`, `.toml`, `.lock`, `.txt`, `.env`, `.sh`
+- Docs: `.md`
+- Paths containing `.claude/`, `CLAUDE.md`, `settings`, `hooks/`, `tests/`, or `_test.`
+
+## How to work with the gate
+
+**Before querying source code, call a CBM tool first:**
+
+| Goal | CBM tool to call |
+| :--- | :--- |
+| Find where a function is defined | `mcp__codebase-memory__search_graph` |
+| Understand a module's structure | `mcp__codebase-memory__get_architecture` |
+| Trace a call path | `mcp__codebase-memory__trace_path` |
+| Read a specific function body | `mcp__codebase-memory__get_code_snippet` |
+| Ensure graph is current | `mcp__codebase-memory__index_repository` |
+
+After any CBM tool call, you have **120 seconds** to `Read`/`Grep`/`Glob` source files freely.
+
+## Whole-repo searches
+
+A `Grep` or `Glob` call with **no `path` argument** is always gated — it is exactly the case CBM
+is optimised for. Use `mcp__codebase-memory__search_graph` instead.
+
+## Keeping the graph current
+
+If the codebase has changed materially since the last index (new files, major refactors), call
+`mcp__codebase-memory__index_repository` to refresh. The gate remains active but the graph will
+give accurate results. Use `mcp__codebase-memory__detect_changes` to check whether a refresh is
+needed before indexing.

--- a/tools/hooks/ai/cbm-session-reminder.py
+++ b/tools/hooks/ai/cbm-session-reminder.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Claude Code SessionStart hook that re-injects the CBM gate protocol reminder.
+
+Triggered when Claude Code starts a session whose trigger contains "compact", "resume",
+or "clear" (configured via the matcher in ``.claude/settings.local.json``). Reads
+``cbm-session-reminder.md`` (a sibling file) and injects its contents into the new
+session via ``hookSpecificOutput.additionalContext``.
+
+This re-injection ensures that CBM gate conventions stay active throughout a session
+regardless of how many autocompact events have occurred. Without it, the model may
+honour the CBM protocol at session start but drift to raw Read/Grep/Glob late in a
+long session once the context has been compacted.
+
+The hook is best-effort: any failure (missing reminder file, malformed stdin) is
+swallowed and the hook exits 0 so it never blocks session startup.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Path to the reminder text. Sibling to the hook so it is portable.
+REMINDER_TEXT_PATH: Path = Path(__file__).resolve().parent / "cbm-session-reminder.md"
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0  # Malformed JSON — best-effort, don't block.
+
+        try:
+            body = REMINDER_TEXT_PATH.read_text(encoding="utf-8")
+        except (OSError, PermissionError):
+            return 0  # Missing or unreadable reminder file — degrade gracefully.
+
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": body,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
+        sys.stdout.flush()
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Ships three optional Claude Code hooks that enforce token-efficient code discovery when the
[Codebase Memory MCP server](https://github.com/DeusData/codebase-memory-mcp) (CBM) is installed.
The hooks are disabled by default and must be wired explicitly by each operator in
`.claude/settings.local.json`. No change is made to the committed `.claude/settings.json`.

## Related Issue

Addresses #516

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**Three new hook scripts** under `tools/hooks/ai/`:

- `cbm-code-discovery-gate.py` — `PreToolUse` hook (Read/Grep/Glob). Blocks code-discovery
  calls on source files unless a CBM tool ran within the last 120 seconds or the target is in
  the allow-list (configs, docs, tests, hooks, settings). Exits 0 (allow), 1 (malformed JSON),
  or 2 (block).
- `cbm-mcp-marker.py` — `PostToolUse` hook (CBM tool prefix). Touches
  `/tmp/cbm-mcp-used-{ppid}` to open a 120-second allow window. Always exits 0; never blocks.
- `cbm-session-reminder.py` — `SessionStart` hook (compact/resume/clear). Re-injects
  `cbm-session-reminder.md` as `hookSpecificOutput.additionalContext` so the model does not
  forget CBM gate conventions after autocompact. Always exits 0; never blocks.

**One companion file:**

- `cbm-session-reminder.md` — Human-readable CBM protocol reminder injected by the
  SessionStart hook. Describes the gate behaviour, the allow-list, per-goal CBM tool table,
  and the 120-second window.

**Documentation:**

- `docs/development/ai/token-efficiency-add-ons.md` — New "Codebase Memory MCP gate (opt-in)"
  section covering: three-hook design table, allow-list rules, read-after-CBM workflow,
  step-by-step setup (prerequisites, hook wiring JSON, re-index steps), and trust caveats
  (graph staleness, server trust, custom MCP server names).

**Three new test files** under `tests/`:

- `test_hook_cbm_code_discovery_gate.py` — 22 tests covering: non-gated tools, allow-list
  extensions (9 parametrised paths), allow-list path fragments (.claude/, tests/, hooks/,
  docs), fresh-marker allow, missing-marker block, stale-marker block, whole-repo Grep/Glob
  block, stderr content (tool name, marker path), and malformed JSON.
- `test_hook_cbm_mcp_marker.py` — 5 tests covering: marker creation, fresh mtime, mtime
  update on re-run, custom template path, and malformed JSON.
- `test_hook_cbm_session_reminder.py` — 6 tests covering: stdout is valid JSON, hookEventName
  is SessionStart, additionalContext matches reminder body, real reminder file produces
  non-empty context, missing reminder file degrades gracefully, and malformed JSON.

Total: 33 new tests across 3 files (all passing).

## Out of scope

- Wiring the hooks on by default (committed `settings.json` is unchanged).
- The upstream CBM MCP server itself — operators must install it separately.
- Hook support for Gemini CLI, Copilot CLI, or Codex CLI — these hooks are Claude Code only.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes (tests, lint, type-check, security, spell-check).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

Operators who want to enable the CBM gate must:
1. Install and configure the CBM MCP server (upstream instructions at
   github.com/DeusData/codebase-memory-mcp).
2. Index the repository once via `mcp__codebase-memory__index_repository`.
3. Add the three hook entries to `.claude/settings.local.json` (not committed) as documented
   in `docs/development/ai/token-efficiency-add-ons.md` under "Setup".

If the CBM server uses a non-default name, only the `PostToolUse` matcher in
`settings.local.json` needs updating — the hook scripts are name-agnostic.
