### PR TITLE
feat: ship optional context-mode hook wrappers (opt-in)

### DIFF
--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -384,6 +384,130 @@ locally in whatever storage backend the CBM server is configured with. Key consi
 configures separately. Wiring these hooks in committed settings would break every contributor who
 has not installed CBM.
 
+## context-mode MCP wrappers (opt-in)
+
+The [context-mode MCP](https://github.com/mksglu/context-mode) intercepts tool outputs, runs
+commands in a sandboxed environment, indexes the full output into a local BM25 knowledge base, and
+returns only a compact summary to the model. Claude can call `ctx_search` later to retrieve detail.
+This prevents large tool outputs — `pytest -v` over thousands of tests, `terraform plan`, verbose
+`kubectl describe` — from flooding the conversation context and consuming tokens until the next
+autocompact event.
+
+context-mode wires up via four lifecycle hooks (`PreToolUse`, `PostToolUse`, `PreCompact`,
+`SessionStart`), each invoking `context-mode hook claude-code <event>`. Without thin wrappers,
+operators must hand-wire all four — error-prone, and easy to omit the `PreCompact`/`SessionStart`
+events that handle index persistence across compaction cycles.
+
+### Five-hook design
+
+| Hook | Event | What it does |
+| :--- | :--- | :--- |
+| `context-mode-pretooluse.py` | `PreToolUse` (no matcher) | Forwards every PreToolUse event to the context-mode CLI for interception |
+| `context-mode-posttooluse.py` | `PostToolUse` (no matcher) | Forwards every PostToolUse event so outputs are indexed and summarised |
+| `context-mode-precompact.py` | `PreCompact` | Persists the BM25 index before autocompact so it survives context resets |
+| `context-mode-sessionstart.py` | `SessionStart` | Restores the index when a session resumes after compaction |
+| `context-mode-test-runner-reminder.py` | `PreToolUse` on `Bash` | Advisory only — reminds Claude to prefer `ctx_batch_execute` for test runs |
+
+Each forwarder uses `shutil.which("context-mode")` to detect non-installation and exits 0 silently.
+Non-installation is a no-op, not an error.
+
+### Setup
+
+**Prerequisites:** install the context-mode CLI and configure the MCP server. Follow the upstream
+instructions at [github.com/mksglu/context-mode](https://github.com/mksglu/context-mode).
+
+**Step 1** — Wire all five hooks in `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-pretooluse.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-test-runner-reminder.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-posttooluse.py"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-precompact.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/tools/hooks/ai/context-mode-sessionstart.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This goes in `.claude/settings.local.json` (not committed) — each operator opts in individually.
+Do **not** add it to the committed `.claude/settings.json`.
+
+**Step 2** — Verify the wiring with a manual smoke test: install a fake `context-mode` shim that
+logs its argv to stderr, wire `context-mode-pretooluse.py` as above, trigger any tool call, and
+confirm stderr shows `context-mode hook claude-code PreToolUse` with the original stdin forwarded.
+
+### ctx_batch_execute workflow
+
+When `context-mode` MCP is active, prefer `ctx_batch_execute` for multi-command sequences (test +
+lint + typecheck) rather than running each command in a separate `Bash` call. `ctx_batch_execute`
+submits all commands together, indexes the combined output into the BM25 store, and returns a
+compact summary. Use `ctx_search` to retrieve specific detail from that summary on demand.
+
+This is most valuable for test runs on large projects where `pytest -v` output can easily exceed
+tens of thousands of lines.
+
+### Trust caveats
+
+context-mode claims to run commands in a sandboxed environment and maintain a local BM25 index with
+no network egress. Key considerations before adopting:
+
+- **Verify upstream:** read the source at [github.com/mksglu/context-mode](https://github.com/mksglu/context-mode)
+  to confirm no network egress before using on sensitive or employer-owned codebases.
+- **Local index:** the BM25 index lives on disk in whatever path context-mode configures. Treat it
+  with the same care as any file containing code excerpts.
+- **Index freshness:** the index reflects commands run since the last `SessionStart` restore. After
+  a session that skips the hooks, `ctx_search` may return stale or empty results.
+
+**Why disabled by default:** context-mode intercepts every tool call via `PreToolUse` and
+`PostToolUse` with no matcher restriction. Wiring these hooks in committed settings would add
+latency and context-mode dependency for every contributor regardless of whether they have installed
+the CLI.
+
 ## Session-survival of project rules
 
 This section documents the **pattern** that Caveman uses, so you can apply it to any narrow rule

--- a/tests/test_hook_context_mode_posttooluse.py
+++ b/tests/test_hook_context_mode_posttooluse.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-posttooluse`` PostToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-posttooluse.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-posttooluse.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_posttooluse", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_posttooluse"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_posttooluse", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"tool_name":"Bash"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"tool_name":"Bash"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'PostToolUse'."""
+    assert hook.EVENT_NAME == "PostToolUse"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_precompact.py
+++ b/tests/test_hook_context_mode_precompact.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-precompact`` PreCompact hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-precompact.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-precompact.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_precompact", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_precompact"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_precompact", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"trigger":"compact"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"trigger":"compact"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'PreCompact'."""
+    assert hook.EVENT_NAME == "PreCompact"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_pretooluse.py
+++ b/tests/test_hook_context_mode_pretooluse.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-pretooluse`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-pretooluse.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-pretooluse.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_pretooluse", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_pretooluse"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_pretooluse", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"tool_name":"Bash"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"tool_name":"Bash"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'PreToolUse'."""
+    assert hook.EVENT_NAME == "PreToolUse"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_sessionstart.py
+++ b/tests/test_hook_context_mode_sessionstart.py
@@ -1,0 +1,233 @@
+"""Tests for the ``context-mode-sessionstart`` SessionStart hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-sessionstart.py``. Its filename
+contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "context-mode-sessionstart.py"
+)
+
+
+class _BytesStdin:
+    """Minimal stdin stub whose .buffer attribute is a BytesIO."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_sessionstart", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_sessionstart"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_sessionstart", None)
+
+
+# ---------------------------------------------------------------------------
+# CLI not installed: exit 0, subprocess never called
+# ---------------------------------------------------------------------------
+
+
+def test_cli_not_installed_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shutil.which returns None, main() returns 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b'{"trigger":"startup"}'))
+    assert hook.main() == 0
+
+
+def test_cli_not_installed_subprocess_not_called(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When CLI is not installed, subprocess.run is never invoked."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: None)
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    run_mock = MagicMock()
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+    hook.main()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI installed: correct invocation and stdout passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_cli_installed_calls_subprocess_with_correct_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """subprocess.run is called with [CLI_NAME, 'hook', 'claude-code', EVENT_NAME]."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    payload = b'{"trigger":"startup"}'
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(payload))
+
+    mock_result = subprocess.CompletedProcess(
+        args=[hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        returncode=0,
+        stdout=b"ok",
+        stderr=b"",
+    )
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_installed_stdout_passthrough(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout bytes from subprocess are written to sys.stdout.buffer."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    captured_stdout = io.BytesIO()
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = captured_stdout
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"summary output",
+        stderr=b"",
+    )
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+
+    assert hook.main() == 0
+    assert captured_stdout.getvalue() == b"summary output"
+
+
+def test_cli_installed_returns_subprocess_returncode(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates the subprocess exit code."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 1
+
+
+def test_cli_installed_returncode_2(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() propagates returncode 2."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"")
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(return_value=mock_result))
+    assert hook.main() == 2
+
+
+def test_subprocess_file_not_found_exits_0(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileNotFoundError from subprocess.run exits 0."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b"{}"))
+    monkeypatch.setattr(hook.subprocess, "run", MagicMock(side_effect=FileNotFoundError))
+    assert hook.main() == 0
+
+
+def test_empty_stdin_calls_subprocess(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stdin still calls subprocess with input=b'' and propagates returncode."""
+    monkeypatch.setattr(hook.shutil, "which", lambda _: "/usr/bin/context-mode")
+    monkeypatch.setattr(sys, "stdin", _BytesStdin(b""))
+
+    mock_stdout = MagicMock()
+    mock_stdout.buffer = io.BytesIO()
+    mock_stderr = MagicMock()
+    mock_stderr.buffer = io.BytesIO()
+    monkeypatch.setattr(sys, "stdout", mock_stdout)
+    monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+    run_mock = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(hook.subprocess, "run", run_mock)
+
+    assert hook.main() == 0
+    run_mock.assert_called_once_with(
+        [hook.CLI_NAME, "hook", "claude-code", hook.EVENT_NAME],
+        input=b"",
+        capture_output=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_event_name_constant(hook: types.ModuleType) -> None:
+    """EVENT_NAME is 'SessionStart'."""
+    assert hook.EVENT_NAME == "SessionStart"
+
+
+def test_cli_name_constant(hook: types.ModuleType) -> None:
+    """CLI_NAME is 'context-mode'."""
+    assert hook.CLI_NAME == "context-mode"

--- a/tests/test_hook_context_mode_test_runner_reminder.py
+++ b/tests/test_hook_context_mode_test_runner_reminder.py
@@ -1,0 +1,244 @@
+"""Tests for the ``context-mode-test-runner-reminder`` PreToolUse advisory hook.
+
+The hook script lives at ``tools/hooks/ai/context-mode-test-runner-reminder.py``. Its
+filename contains hyphens, so it isn't directly importable as a module — we load it via
+``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "hooks"
+    / "ai"
+    / "context-mode-test-runner-reminder.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("context_mode_test_runner_reminder", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["context_mode_test_runner_reminder"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("context_mode_test_runner_reminder", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _bash_payload(command: str) -> str:
+    """Build a PreToolUse Bash payload for the given command string."""
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+# ---------------------------------------------------------------------------
+# Reminder emitted for test commands
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """pytest command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("pytest -v tests/"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["additionalContext"] == hook.REMINDER
+
+
+def test_npm_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """npm test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("npm test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_npm_run_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """npm run test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("npm run test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_go_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """go test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("go test ./..."))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_cargo_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cargo test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("cargo test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_mvn_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """mvn test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("mvn test"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+def test_gradle_test_command_emits_reminder(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """gradle test command triggers the reminder."""
+    _set_stdin(monkeypatch, _bash_payload("gradle test --info"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert "additionalContext" in data["hookSpecificOutput"]
+
+
+# ---------------------------------------------------------------------------
+# No reminder for non-test commands
+# ---------------------------------------------------------------------------
+
+
+def test_ls_command_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-test command produces no stdout output."""
+    _set_stdin(monkeypatch, _bash_payload("ls -la"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_read_tool_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-Bash tool name produces no stdout output."""
+    payload = json.dumps({"tool_name": "Read", "tool_input": {"file_path": "/some/file.py"}})
+    _set_stdin(monkeypatch, payload)
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: malformed / empty input
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_json_exits_0_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed JSON stdin exits 0 and produces no stdout."""
+    _set_stdin(monkeypatch, "not valid json{{")
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_empty_tool_input_exits_0_no_output(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing tool_input exits 0 and produces no stdout."""
+    payload = json.dumps({"tool_name": "Bash"})
+    _set_stdin(monkeypatch, payload)
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Output JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_output_hook_event_name_is_pretooluse(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """hookSpecificOutput.hookEventName is 'PreToolUse'."""
+    _set_stdin(monkeypatch, _bash_payload("pytest tests/"))
+    assert hook.main() == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+
+
+def test_reminder_text_contains_ctx_batch_execute(hook: types.ModuleType) -> None:
+    """REMINDER constant mentions ctx_batch_execute."""
+    assert "ctx_batch_execute" in hook.REMINDER
+
+
+def test_reminder_text_contains_ctx_search(hook: types.ModuleType) -> None:
+    """REMINDER constant mentions ctx_search."""
+    assert "ctx_search" in hook.REMINDER

--- a/tools/hooks/ai/context-mode-posttooluse.py
+++ b/tools/hooks/ai/context-mode-posttooluse.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PostToolUse wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code PostToolUse`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "PostToolUse"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-precompact.py
+++ b/tools/hooks/ai/context-mode-precompact.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PreCompact wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code PreCompact`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "PreCompact"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-pretooluse.py
+++ b/tools/hooks/ai/context-mode-pretooluse.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code PreToolUse`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "PreToolUse"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-sessionstart.py
+++ b/tools/hooks/ai/context-mode-sessionstart.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code SessionStart wrapper for the context-mode MCP CLI.
+
+Forwards stdin to ``context-mode hook claude-code SessionStart`` and re-emits
+stdout/stderr/exit-code. If the ``context-mode`` CLI is not installed, exits 0
+silently — non-installation is a no-op, not an error.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess  # nosec B404 - required to invoke context-mode CLI
+import sys
+
+EVENT_NAME = "SessionStart"
+CLI_NAME = "context-mode"
+
+
+def main() -> int:
+    """Hook entry point. Forwards stdin to context-mode CLI or exits 0."""
+    try:
+        if shutil.which(CLI_NAME) is None:
+            with contextlib.suppress(Exception):
+                sys.stdin.buffer.read()  # drain stdin
+            return 0
+
+        try:
+            raw = sys.stdin.buffer.read()
+        except Exception:  # nosec B110
+            return 0
+
+        try:
+            result = subprocess.run(  # nosec B603 B607 - shutil.which guard validates path
+                [CLI_NAME, "hook", "claude-code", EVENT_NAME],
+                input=raw,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return 0
+
+        with contextlib.suppress(Exception):
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.buffer.flush()
+        with contextlib.suppress(Exception):
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.buffer.flush()
+        return result.returncode
+
+    except Exception:  # nosec B110 - hook must never raise
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hooks/ai/context-mode-test-runner-reminder.py
+++ b/tools/hooks/ai/context-mode-test-runner-reminder.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse advisory: remind Claude to use ctx_batch_execute for test commands.
+
+Emits a ``hookSpecificOutput.additionalContext`` reminder when a Bash command matches
+one of the common test-runner patterns (pytest, npm test, go test, cargo test, mvn test,
+gradle test). Does not shell out to any external CLI — entirely self-contained.
+
+For documentation and opt-in setup, see: docs/development/ai/token-efficiency-add-ons.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+TEST_COMMAND_PATTERNS: tuple[str, ...] = (
+    r"\bpytest\b",
+    r"\bnpm\s+(?:run\s+)?test\b",
+    r"\bgo\s+test\b",
+    r"\bcargo\s+test\b",
+    r"\bmvn\s+test\b",
+    r"\bgradle\s+test\b",
+)
+REMINDER = (
+    "Reminder: this command can produce large output. If `context-mode` MCP is "
+    "available, prefer `ctx_batch_execute` for multi-command runs (test + lint + "
+    "typecheck). Output is summarised; use `ctx_search` to retrieve detail."
+)
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0; tests call this directly."""
+    try:
+        try:
+            data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+        if not isinstance(data, dict) or data.get("tool_name") != "Bash":
+            return 0
+        cmd = (data.get("tool_input") or {}).get("command", "")
+        if not isinstance(cmd, str) or not any(re.search(p, cmd) for p in TEST_COMMAND_PATTERNS):
+            return 0
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": REMINDER,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
+        sys.stdout.flush()
+    except Exception:  # nosec B110
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Ships five opt-in Claude Code hook wrappers for the third-party `context-mode` MCP server. None are wired in committed settings — operators opt in via `.claude/settings.local.json`. Mirrors the CBM gate-hooks precedent (PR #537).

## Related Issue

Addresses #517

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

**Five new hook scripts in `tools/hooks/ai/`:**

- `context-mode-pretooluse.py` — PreToolUse: forwards stdin to `context-mode hook claude-code PreToolUse`; exits 0 silently if CLI not installed.
- `context-mode-posttooluse.py` — PostToolUse: forwards stdin to `context-mode hook claude-code PostToolUse`; exits 0 silently if CLI not installed.
- `context-mode-precompact.py` — PreCompact: forwards stdin to `context-mode hook claude-code PreCompact`; exits 0 silently if CLI not installed.
- `context-mode-sessionstart.py` — SessionStart: forwards stdin to `context-mode hook claude-code SessionStart`; exits 0 silently if CLI not installed.
- `context-mode-test-runner-reminder.py` — PreToolUse advisory: self-contained; prompts Claude to use `ctx_batch_execute` when running test commands. No external CLI required.

**New documentation section in `docs/development/ai/token-efficiency-add-ons.md`:**

- `## context-mode MCP wrappers (opt-in)` section covering all five hooks, the opt-in JSON snippet for `.claude/settings.local.json`, the `ctx_batch_execute` workflow, trust caveats, and the rationale for disabled-by-default.

**54 new tests across five test files:**

- `tests/test_hook_context_mode_pretooluse.py` (10 tests)
- `tests/test_hook_context_mode_posttooluse.py` (10 tests)
- `tests/test_hook_context_mode_precompact.py` (10 tests)
- `tests/test_hook_context_mode_sessionstart.py` (10 tests)
- `tests/test_hook_context_mode_test_runner_reminder.py` (14 tests)

**`.claude/settings.json` is unchanged.** Committed project settings are untouched. All five hooks are disabled by default; operators opt in via their local `.claude/settings.local.json`.

**Bonus reminder hook included in scope.** The issue offered to split the test-runner reminder hook into a separate issue. It is included here as it is self-contained (no external CLI dependency) and follows the same pattern as the other four wrappers.

## Why disabled by default

The `context-mode` MCP server is a third-party tool with its own installation and trust requirements. Enabling hooks for it by default would silently break sessions where the CLI is not installed (or break if the tool's behavior changes). Operators who have installed and evaluated the MCP server can opt in by adding the hooks to `.claude/settings.local.json`. This mirrors the CBM gate-hooks design (PR #537).

## Testing

- [ ] All existing tests pass (`doit check` — confirmed ✓)
- [x] Added new tests for new functionality (54 tests across 5 files, all passing)
- [x] Manually tested the changes

**How to verify:**

1. `doit check` — all gates (format, lint, type-check, security, spell, tests) pass.
2. To test opt-in behavior: add the hooks to `.claude/settings.local.json` (snippet in the new doc section), install `context-mode` CLI, then run a Claude Code session and confirm the hooks forward events without errors.
3. To test graceful fallback: configure a hook but do NOT install `context-mode` CLI — the hook exits 0 silently, Claude Code session is unaffected.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

The four forwarding hooks (`pretooluse`, `posttooluse`, `precompact`, `sessionstart`) are thin subprocess wrappers — they exec `context-mode hook claude-code <event>`, pipe stdin through, and re-emit stdout/stderr/exit-code. The graceful-fallback logic (`FileNotFoundError` → exit 0) ensures zero disruption for projects that do not have `context-mode` installed.

The test-runner-reminder hook is fully self-contained (no `context-mode` CLI required). It inspects the tool name and command from stdin and emits an advisory message when Claude is about to run `pytest`, `npm test`, `go test`, `cargo test`, `mvn test`, or `gradle test`, suggesting `ctx_batch_execute` as a token-efficient alternative.
