### PR TITLE
chore: convert custom commands to native Gemini CLI TOML format

### DIFF
--- a/.gemini/commands/checkpoint.toml
+++ b/.gemini/commands/checkpoint.toml
@@ -1,10 +1,12 @@
+description = "Capture a resumption prompt for picking up the current work later."
+prompt = """
 # Checkpoint (Gemini)
 
 Capture a resumption prompt for picking up the current work later.
 
 When invoked, write a self-contained prompt to `tmp/checkpoints/` so the user (or a future agent session via `/restore`) can pick up where they left off without re-reading the current conversation. This is the **save** side of the checkpoint/restore pair — `/restore` is the load side.
 
-Argument: `$ARGUMENTS` — optional kebab-case slug describing the topic. If empty, infer a 3-5 word descriptive slug from the conversation context.
+Argument: {{args}} — optional kebab-case slug describing the topic. If empty, infer a 3-5 word descriptive slug from the conversation context.
 
 ## Instructions
 
@@ -58,3 +60,4 @@ Report:
 - If invoked multiple times in one session, write a new file each time. The user may want separate resumption-points for separate work threads.
 - The prefix uses 10 digits because epoch will exceed 10 digits in the year 2286; that's fine for foreseeable use. If you ever need to extend, bump to 11+ digits.
 - The companion `/restore` command loads a captured checkpoint in a future session — point users to it.
+"""

--- a/.gemini/commands/ghissue-finalize.toml
+++ b/.gemini/commands/ghissue-finalize.toml
@@ -1,3 +1,5 @@
+description = "Finalize the current branch: update documentation, commit changes, and create a PR."
+prompt = """
 # Finalize (Gemini)
 
 Finalize the current branch: update documentation, commit changes, and create a PR.
@@ -81,3 +83,4 @@ Execute the finalization steps directly in the current context:
 4. **Report the PR URL to the user.**
 
 **IMPORTANT:** Do NOT commit or create the PR without explicit user confirmation.
+"""

--- a/.gemini/commands/ghissue-implement.toml
+++ b/.gemini/commands/ghissue-implement.toml
@@ -1,6 +1,8 @@
+description = "Implement the plan for GitHub issue {{args}}."
+prompt = """
 # Implement Issue (Gemini)
 
-Implement the plan for GitHub issue #$ARGUMENTS.
+Implement the plan for GitHub issue #{{args}}.
 
 ## Instructions
 
@@ -10,17 +12,17 @@ This command performs the implementation of an approved plan for the specified i
 
 1. **Verify the issue exists and is open:**
    ```bash
-   gh issue view $ARGUMENTS --json number,title,state,labels
+   gh issue view {{args}} --json number,title,state,labels
    ```
    - If the issue does not exist or is closed, tell the user and stop.
 
 2. **Verify a plan comment exists:**
    Fetch all comments and search for the plan header:
    ```bash
-   gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
+   gh api repos/{owner}/{repo}/issues/{{args}}/comments --jq '.[].body' | grep -E "^#+ Implementation Plan for"
    ```
    - If no plan comment is found, tell the user:
-     > "No implementation plan found for issue #$ARGUMENTS. Run `/ghissue-plan $ARGUMENTS` first."
+     > "No implementation plan found for issue #{{args}}. Run `/ghissue-plan {{args}}` first."
    - Stop and wait for the user.
 
 3. **Check current branch state:**
@@ -28,7 +30,7 @@ This command performs the implementation of an approved plan for the specified i
    git branch --show-current
    git status --short
    ```
-   - If already on a branch matching `*/$ARGUMENTS-*` (e.g., `feat/$ARGUMENTS-description`):
+   - If already on a branch matching `*/{{args}}-*` (e.g., `feat/{{args}}-description`):
      - Tell the user you're resuming work on the existing branch
      - Skip branch creation (Step 2)
      - If there are uncommitted changes, warn the user and ask how to proceed
@@ -40,7 +42,7 @@ Only if not already on the correct branch:
 
 1. Fetch the issue to determine the branch type:
    ```bash
-   gh issue view $ARGUMENTS --json title,labels
+   gh issue view {{args}} --json title,labels
    ```
 2. Determine branch type from labels:
    - `enhancement` → `feat`
@@ -52,7 +54,7 @@ Only if not already on the correct branch:
 3. Create and switch to branch:
    ```bash
    git checkout main && git pull
-   git checkout -b <type>/$ARGUMENTS-<short-description>
+   git checkout -b <type>/{{args}}-<short-description>
    ```
 
 ### Step 3: Implementation
@@ -85,3 +87,4 @@ Tell the user:
 - Review the changes and test as needed
 - Discuss any fixes directly in conversation
 - When satisfied, use `/ghissue-finalize` to commit and create a PR
+"""

--- a/.gemini/commands/ghissue-plan-stdout.toml
+++ b/.gemini/commands/ghissue-plan-stdout.toml
@@ -1,6 +1,8 @@
+description = "Create an implementation plan for GitHub issue {{args}} and emit it to stdout."
+prompt = """
 # Plan Issue – Stdout (Gemini)
 
-Create an implementation plan for GitHub issue #$ARGUMENTS and emit it to stdout.
+Create an implementation plan for GitHub issue #{{args}} and emit it to stdout.
 
 ## Instructions
 
@@ -17,7 +19,7 @@ that variant posts the approved plan to GitHub for you.
 ### Step 1: Fetch the issue details
 
 ```bash
-gh issue view $ARGUMENTS --json title,body,labels,assignees
+gh issue view {{args}} --json title,body,labels,assignees
 ```
 
 - Parse the issue body to understand what needs to be done
@@ -73,3 +75,4 @@ Brief description of what will be done.
 - Be specific about file paths and function names
 - Include concrete test cases, not vague descriptions
 - Note any risks or alternative approaches worth considering
+"""

--- a/.gemini/commands/ghissue-plan.toml
+++ b/.gemini/commands/ghissue-plan.toml
@@ -1,7 +1,5 @@
-# Plan Issue (Gemini)
-
-Plan the implementation for GitHub issue #$ARGUMENTS.
-
+description = "Plan the implementation for GitHub issue {{args}}."
+prompt = """
 ## Instructions
 
 This command runs in the main conversation context so the user can ask questions,
@@ -16,17 +14,17 @@ emits the plan to stdout without posting, which is what the orchestrator needs.
 
 1. **Verify the issue exists and is open:**
    ```bash
-   gh issue view $ARGUMENTS --json number,title,state,labels
+   gh issue view {{args}} --json number,title,state,labels
    ```
    - If the issue does not exist, tell the user and stop.
    - If the issue is closed, tell the user and ask if they want to reopen it or stop.
 
 2. **Check for an existing plan comment:**
    ```bash
-   gh issue view $ARGUMENTS --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
+   gh issue view {{args}} --json comments --jq '.comments[].body' | grep -lE "^#+ Implementation Plan for"
    ```
    - If a plan comment already exists, warn the user:
-     > "Issue #$ARGUMENTS already has an implementation plan comment. Continuing will post a new one. Proceed?"
+     > "Issue #{{args}} already has an implementation plan comment. Continuing will post a new one. Proceed?"
    - Wait for user confirmation before continuing.
 
 ### Step 2: Read the project rules
@@ -37,7 +35,7 @@ emits the plan to stdout without posting, which is what the orchestrator needs.
 ### Step 3: Fetch the issue details
 
 ```bash
-gh issue view $ARGUMENTS --json title,body,labels,assignees
+gh issue view {{args}} --json title,body,labels,assignees
 ```
 
 - Parse the issue body to understand what needs to be done.
@@ -95,15 +93,16 @@ Then:
 Only after the user explicitly approves the plan, post it as a comment:
 
 ```bash
-gh issue comment $ARGUMENTS --body "<approved plan>"
+gh issue comment {{args}} --body "<approved plan>"
 ```
 
 Tell the user:
-- The plan has been posted as a comment on issue #$ARGUMENTS.
-- When ready, use `/ghissue-implement $ARGUMENTS` to start implementation.
+- The plan has been posted as a comment on issue #{{args}}.
+- When ready, use `/ghissue-implement {{args}}` to start implementation.
 
 ## See Also
 
-- `/ghissue-implement $ARGUMENTS` — implement the approved plan.
+- `/ghissue-implement {{args}}` — implement the approved plan.
 - `/ghissue-finalize` — commit changes and create a PR.
-- `/ghissue-plan-stdout $ARGUMENTS` — orchestration-only variant (output to stdout, no posting).
+- `/ghissue-plan-stdout {{args}}` — orchestration-only variant (output to stdout, no posting).
+"""

--- a/.gemini/commands/ghissue-review-pr.toml
+++ b/.gemini/commands/ghissue-review-pr.toml
@@ -1,3 +1,5 @@
+description = "Review the pull request for the current branch."
+prompt = """
 # Review PR (Gemini)
 
 Review the pull request for the current branch.
@@ -88,3 +90,4 @@ Brief justification for the verdict.
 - Be specific: reference file paths and line ranges
 - Distinguish between critical issues (must fix) and suggestions (nice to have)
 - If the code looks good, say so — don't invent issues to fill space
+"""

--- a/.gemini/commands/restore.toml
+++ b/.gemini/commands/restore.toml
@@ -1,10 +1,12 @@
+description = "Load a previously captured checkpoint prompt and continue the work it describes."
+prompt = """
 # Restore (Gemini)
 
 Load a previously captured checkpoint prompt from `tmp/checkpoints/` and continue the work it describes.
 
 When invoked, find the right checkpoint file, read it, and **treat its contents as the user's initial instructions for this session.** This is the **load** side of the checkpoint/restore pair — `/checkpoint` is the save side.
 
-Argument: `$ARGUMENTS` — optional kebab-case slug to filter by. If empty, picks the most recent checkpoint regardless of slug.
+Argument: {{args}} — optional kebab-case slug to filter by. If empty, picks the most recent checkpoint regardless of slug.
 
 ## Instructions
 
@@ -16,16 +18,16 @@ Files live in `tmp/checkpoints/` with names like `{inv_epoch}-{slug}.md`. The `i
 mkdir -p tmp/checkpoints  # idempotent
 ```
 
-**If `$ARGUMENTS` is empty:** pick the lexically first file in the directory (newest).
+**If {{args}} is empty:** pick the lexically first file in the directory (newest).
 
 ```bash
 ls tmp/checkpoints/*.md 2>/dev/null | head -1
 ```
 
-**If `$ARGUMENTS` is provided:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-${ARGUMENTS}*.md`.
+**If {{args}} is provided:** treat it as a slug fragment. Pick the lexically first file whose name matches `*-${{args}}*.md`.
 
 ```bash
-ls tmp/checkpoints/*-${ARGUMENTS}*.md 2>/dev/null | head -1
+ls tmp/checkpoints/*-{{args}}*.md 2>/dev/null | head -1
 ```
 
 (Lexically-first = newest, because of the inv_epoch convention.)
@@ -52,3 +54,4 @@ Checkpoints typically capture decisions and preferences from the prior session. 
 - Checkpoints are immutable once written. If the situation has changed since capture (a referenced PR landed, an issue closed, etc.), verify before acting on stale references — `gh issue view <n>`, `git log`, etc.
 - The companion `/checkpoint` command writes new checkpoints — point users to it if they want to capture something for later in this session.
 - The `inv_epoch` prefix is a sort-only artifact; the user reads the slug, not the number. Always show the slug (or full filename) in confirmation messages, not just the prefix.
+"""

--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,1 @@
+.agents/skills/


### PR DESCRIPTION
## Description

Converted legacy Markdown-based custom commands in `.gemini/commands/` to the native Gemini CLI TOML format. Added `.geminiignore` to resolve naming conflicts with agent skills by excluding `.agents/skills/` from discovery.

## Related Issue

Addresses #531

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [x] Chore (tooling/maintenance)

## Changes Made

- Created `.geminiignore` to exclude `.agents/skills/`.
- Converted all `.md` files in `.gemini/commands/` to `.toml`.
- Replaced `$ARGUMENTS` with `{{args}}` in prompt instructions.
- Added `description` field to all converted commands.
- Removed legacy `.md` files.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes (verified `gemini --help` output)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
