### PR TITLE
chore: resolve Gemini CLI command conflicts by disabling redundant skills

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -31,5 +31,14 @@
   "security": {
     "enablePermanentToolApproval": true,
     "autoAddToPolicyByDefault": true
+  },
+  "skills": {
+    "disabled": [
+      "restore",
+      "ghissue-plan",
+      "ghissue-implement",
+      "ghissue-finalize",
+      "checkpoint"
+    ]
   }
 }

--- a/.geminiignore
+++ b/.geminiignore
@@ -1,1 +1,0 @@
-.agents/skills/


### PR DESCRIPTION
## Description

Resolved naming conflicts between workspace commands in `.gemini/commands/` and agent skills in `.agents/skills/` by explicitly disabling redundant skills in the project settings. This ensures workspace commands like `/restore` and `/checkpoint` are correctly prioritized without being renamed by the CLI core.

## Related Issue

Addresses #540

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [x] Chore (tooling/maintenance)

## Changes Made

- Updated `.gemini/settings.json` to disable `restore`, `ghissue-plan`, `ghissue-implement`, `ghissue-finalize`, and `checkpoint` skills.
- Removed the `.geminiignore` file as it was ineffective for skill discovery and no longer needed after explicit disabling of skills.

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes (verified `gemini skills list` output)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
