### PR TITLE
feat: add .gemini/rules/ scaffold mirroring .claude/rules/ pattern

### DIFF
--- a/.gemini/rules/README.md
+++ b/.gemini/rules/README.md
@@ -1,0 +1,89 @@
+# Per-Stack Rule Files (Gemini)
+
+## Purpose
+
+Rule files in this directory capture **narrow, recurring footguns** that Gemini CLI keeps getting
+wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md` carries
+broad workflow and architectural rules for the whole project. A rule file carries three to ten
+numbered self-checks for one specific failure mode — small enough to survive a context window, sharp
+enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+## When to author a rule file
+
+Write a rule file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File structure
+
+Each rule file must have three parts:
+
+```
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+- **`Skill: <name>`** — the first line, no heading. Names the capability gate so the model can
+  self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, split it.
+
+## How to load
+
+Uncomment the `<!-- @./.gemini/rules/*.md -->` line in `GEMINI.md`:
+
+```markdown
+@./AGENTS.md
+<!-- Uncomment when you add rule files. See .gemini/rules/README.md for the pattern. -->
+<!-- @./.gemini/rules/*.md -->
+```
+
+becomes:
+
+```markdown
+@./AGENTS.md
+@./.gemini/rules/*.md
+```
+
+Note: the line stays commented out in this template repository. Downstream consumers uncomment it
+after authoring their first rule file.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule files must be derived from documented failures, not
+from intuition or generic advice. A checklist written in advance of any failure will drift into
+noise — the model will pattern-match the checklist language and satisfy it superficially. A
+checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the rule
+file is not ready to be written yet.
+
+## What NOT to put in a rule file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Rule files are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the rule file is not ready to be written.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 | CLI | Config Directory | Notes |
 | :--- | :--- | :--- |
 | Claude Code | `.claude/` | Commands, agents, rules, settings. Primary source of slash commands. |
-| Gemini CLI | `.gemini/` | Commands and settings. Supports a standalone workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`) and Claude-orchestrated dual-agent flows. |
+| Gemini CLI | `.gemini/` | Commands, settings, and rules/ subdirectory for per-stack rule files. Supports a standalone workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`) and Claude-orchestrated dual-agent flows. |
 | GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
 | Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. |
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,7 @@
+@./AGENTS.md
+<!-- Uncomment when you add rule files. See .gemini/rules/README.md for the pattern. -->
+<!-- @./.gemini/rules/*.md -->
+
 # Gemini CLI Instructions
 
 ## Context

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -146,6 +146,7 @@ Run `/ghissue-status`. It is read-only, has no side effects, and will tell you t
 - [AI Agent Setup](../AI_SETUP.md) — per-CLI configuration, permissions, and hooks.
 - [Architectural Conventions](architectural-conventions.md) — imperative rules for AI-generated code.
 - [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
-- [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for downstream consumers who need narrow, skill-gated self-checks beyond what `AGENTS.md` covers.
+- [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for Claude Code.
+- [`.gemini/rules/` scaffold](../../../.gemini/rules/README.md) — per-stack rule-file pattern for Gemini CLI.
 - <!-- TODO: wire this link up properly when #342 lands -->
   For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -551,17 +551,20 @@ verbosity here works against the goal.
 ### Per-stack rule files (third mechanism)
 
 A third application of the same pattern is **small per-stack rule files** imported into
-`.claude/CLAUDE.md` via the `@import` directive. Where per-turn injection is best for style rules
-that must survive every autocompact event, per-stack rule files are best for **narrow, domain-
-specific self-checks** that only apply when the agent is doing a specific class of work (code
-generation, database migrations, API contract changes, etc.).
+`.claude/CLAUDE.md` via the `@import` directive (for Claude) or into `GEMINI.md` via the `@`
+directive (for Gemini). Where per-turn injection is best for style rules that must survive every
+autocompact event, per-stack rule files are best for **narrow, domain-specific self-checks** that
+only apply when the agent is doing a specific class of work (code generation, database migrations,
+API contract changes, etc.).
 
 Each rule file is skill-gated, capped at 30 lines, and built from documented observed failures —
 not from generic advice. The template ships a commented-out `@import` placeholder in
-`.claude/CLAUDE.md`; downstream consumers uncomment it and add their own rule files.
+`.claude/CLAUDE.md` and a commented-out `@` placeholder in `GEMINI.md`; downstream consumers
+uncomment them and add their own rule files.
 
-See [`.claude/rules/README.md`](../../../.claude/rules/README.md) for the pattern, file structure,
-and a worked example.
+See [`.claude/rules/README.md`](../../../.claude/rules/README.md) and
+[`.gemini/rules/README.md`](../../../.gemini/rules/README.md) for the pattern, file structure, and
+a worked example.
 
 ## Related primitives in this template
 


### PR DESCRIPTION
## Description

This PR mirrors the "Per-Stack Rule Files" pattern established for Claude Code into the Gemini CLI configuration. This allows Gemini to benefit from narrow, skill-gated rule files based on observed failures, following the same discipline as Claude.

## Related Issue

Addresses #521

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Created `.gemini/rules/README.md` to document the purpose and structure of rule files.
- Updated `GEMINI.md` to include auto-loading instructions for `AGENTS.md` and the new rules scaffold.
- Updated `AGENTS.md` to include the `rules/` subdirectory for Gemini CLI.
- Added cross-links to `.gemini/rules/README.md` in `docs/development/ai/token-efficiency-add-ons.md` and `docs/development/ai/first-5-minutes.md`.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes (verified link resolution in built docs)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings
