### PR TITLE
fix: anchor Addresses regex in pr_merge to start of line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,7 +405,7 @@ Before creating a PR, verify:
 - [ ] Branch name follows convention: `<type>/<issue>-<description>`
 - [ ] Commits follow conventional format: `<type>: <subject>`
 - [ ] PR title follows conventional format: `<type>: <subject>`
-- [ ] PR description references the issue: "Addresses #XX"
+- [ ] PR description references the issue: "Addresses #XX" (at start of line)
 - [ ] If issue has `needs-adr` label: ADR created and included in PR
 - [ ] If implementing architectural decision: Related ADR updated with issue link
 - [ ] If ADR created/updated: Links to documentation in `docs/` included

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -674,7 +674,7 @@ doit pr_merge --auto-close
 **Options:**
 - `--pr`: PR number to merge (defaults to PR for current branch)
 - `--delete-branch`: Delete the source branch after merge (default: `true`)
-- `--auto-close`: Close linked issues (parsed from `Addresses #XX` in the PR body) after a successful merge (default: `false`)
+- `--auto-close`: Close linked issues (parsed from `Addresses #XX` at the start of a line in the PR body) after a successful merge (default: `false`)
 
 ### `adr`
 

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -422,6 +422,9 @@ In your PR body, use the `Addresses` keyword to link issues:
 |---------|--------|----------|
 | `Addresses #XX` | Included as `addresses #XX` in merge commit | PR relates to the issue |
 
+> [!NOTE]
+> The `Addresses #XX` keyword is case-sensitive and must be placed at the start of a line to be correctly parsed by `doit pr_merge`. Mid-sentence references or different capitalizations are ignored to prevent misattribution.
+
 **Example PR body:**
 ```markdown
 ## Summary

--- a/tests/template/test_doit_github.py
+++ b/tests/template/test_doit_github.py
@@ -40,27 +40,33 @@ class TestExtractLinkedIssues:
         result = _extract_linked_issues(body)
         assert result == ["123"]
 
-    def test_addresses_lowercase(self) -> None:
-        """Test extraction of lowercase 'addresses #XX' pattern."""
+    def test_addresses_lowercase_ignored(self) -> None:
+        """Test that lowercase 'addresses #XX' is ignored."""
         body = "addresses #456"
         result = _extract_linked_issues(body)
-        assert result == ["456"]
+        assert result == []
 
-    def test_addresses_uppercase(self) -> None:
-        """Test extraction of uppercase 'ADDRESSES #XX' pattern."""
+    def test_addresses_uppercase_ignored(self) -> None:
+        """Test that uppercase 'ADDRESSES #XX' is ignored."""
         body = "ADDRESSES #789"
         result = _extract_linked_issues(body)
-        assert result == ["789"]
+        assert result == []
+
+    def test_mid_sentence_ignored(self) -> None:
+        """Test that mid-sentence 'Addresses #XX' is ignored."""
+        body = "This PR Addresses #123"
+        result = _extract_linked_issues(body)
+        assert result == []
 
     def test_multiple_addresses(self) -> None:
-        """Test extraction of multiple addresses patterns."""
+        """Test extraction of multiple addresses patterns at line starts."""
         body = "Addresses #123\nAddresses #456"
         result = _extract_linked_issues(body)
         assert result == ["123", "456"]
 
     def test_duplicate_issues(self) -> None:
         """Test that duplicate issues are removed."""
-        body = "Addresses #123\nAlso addresses #123"
+        body = "Addresses #123\nAddresses #123"
         result = _extract_linked_issues(body)
         assert result == ["123"]
 

--- a/tools/doit/github.py
+++ b/tools/doit/github.py
@@ -544,8 +544,8 @@ def _extract_linked_issues(body: str) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
 
-    pattern = r"addresses\s+#(\d+)"
-    for match in re.finditer(pattern, body, re.IGNORECASE):
+    pattern = r"^Addresses\s+#(\d+)"
+    for match in re.finditer(pattern, body, re.MULTILINE):
         issue = match.group(1)
         if issue not in seen:
             seen.add(issue)


### PR DESCRIPTION
## Description

This PR fixes a bug in the `pr_merge` task where `Addresses #N` patterns were being parsed from anywhere in the PR body, including mid-sentence or within bullet points. This led to misattribution of scope in merge commit subjects and potential false closures when using `--auto-close`.

The regex is now anchored to the start of the line and enforces capitalization (`Addresses`), aligning the implementation with the existing documentation and docstrings.

## Related Issue

Addresses #530

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Updated `_extract_linked_issues` in `tools/doit/github.py` to use an anchored, case-sensitive regex: `r"^Addresses\s+#(\d+)"` with `re.MULTILINE`.
- Updated `tests/template/test_doit_github.py` to verify the new anchored behavior and ensure mid-sentence or incorrectly capitalized references are ignored.
- Updated `docs/development/release-and-automation.md`, `docs/development/doit-tasks-reference.md`, and `AGENTS.md` to explicitly state the formatting requirements.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality (updated existing test suite to cover anchored behavior)
- [x] Manually tested the changes with a reproduction script

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (Not needed for this internal tool fix)
- [x] My changes generate no new warnings
