### PR TITLE
fix: replace || echo swallow pattern with install_check_or_skip gate

### DIFF
--- a/tests/template/test_doit_base.py
+++ b/tests/template/test_doit_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess  # nosec B404 - test invokes bash deliberately to verify shell-snippet behaviour
+import sys
 from pathlib import Path
 
 import pytest
@@ -137,16 +138,14 @@ def _run_bash(action: str, env: dict[str, str]) -> subprocess.CompletedProcess[s
 
 
 class TestInstallCheckOrSkip:
-    """Structural and behavioural tests for ``install_check_or_skip``.
+    """Structural tests for ``install_check_or_skip`` (cross-platform).
 
-    Structural tests assert the generated snippet's shape; behavioural tests
-    drive the snippet through ``bash -c`` against a fake ``uv`` shim on PATH
-    to verify that the three relevant branches behave correctly. The
-    "installed + tool fails -> action exits non-zero" case is the bug fix
-    being verified (issue #527).
+    Asserts the generated snippet's shape: gate command, redirection, hint,
+    exit-0 branch, separator, and shell-safe quoting. Behavioural assertions
+    (snippet driven through ``bash``) live in
+    ``TestInstallCheckOrSkipShellBehavior`` below — those are POSIX-shell
+    specific and skipped on Windows.
     """
-
-    # --- Structural ---
 
     def test_snippet_contains_uv_pip_show_with_package(self) -> None:
         """The gate uses ``uv pip show <package>`` to detect installation."""
@@ -187,7 +186,25 @@ class TestInstallCheckOrSkip:
         # bash must echo back the original hint verbatim when the snippet runs.
         assert shlex.quote(hint) in snippet
 
-    # --- Behavioural (fake uv on PATH) ---
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Behavioural tests drive the snippet through bash -c with a fake "
+        "``uv`` shim on PATH. On GitHub's Windows runners, ``bash`` resolves "
+        "to ``wsl.exe`` and fails before the snippet is reached. The doit "
+        "task action only runs through POSIX shell in real use, so this "
+        "platform restriction matches reality."
+    ),
+)
+class TestInstallCheckOrSkipShellBehavior:
+    """Behavioural tests for ``install_check_or_skip`` (POSIX shells only).
+
+    Drive the snippet through ``bash -c`` against a fake ``uv`` shim on PATH
+    to verify that the three relevant branches behave correctly. The
+    "installed + tool fails -> action exits non-zero" case is the bug fix
+    being verified (issue #527).
+    """
 
     def _build_env(self, bindir: Path, *, installed: bool) -> dict[str, str]:
         """Build a minimal child env with the fake-uv directory ahead of system bins."""

--- a/tests/template/test_doit_base.py
+++ b/tests/template/test_doit_base.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import os
+import shlex
+import subprocess  # nosec B404 - test invokes bash deliberately to verify shell-snippet behaviour
 from pathlib import Path
 
 import pytest
 
-from tools.doit.base import optional_root_files
+from tools.doit.base import install_check_or_skip, optional_root_files
 
 
 def _touch(tmp_path: Path, rel: str) -> Path:
@@ -91,3 +94,155 @@ class TestOptionalRootFiles:
         (tmp_path / "bootstrap.py").mkdir()
 
         assert optional_root_files("bootstrap.py") == ""
+
+
+# ---------------------------------------------------------------------------
+# install_check_or_skip
+# ---------------------------------------------------------------------------
+
+
+def _write_fake_uv(tmp_path: Path) -> Path:
+    """Write a fake ``uv`` shim that gates ``pip show`` on the FAKE_INSTALLED env var.
+
+    Returns the directory containing the shim (suitable for prepending to PATH).
+    The shim accepts ``pip show <pkg>`` and exits 0 iff ``FAKE_INSTALLED=1``.
+    All other invocations exit 0 (we never actually run ``uv run`` in these
+    tests — the gate either skips or hands off to ``true`` / ``false``).
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    shim = bindir / "uv"
+    shim.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "pip" ] && [ "$2" = "show" ]; then\n'
+        '  [ "$FAKE_INSTALLED" = "1" ] && exit 0 || exit 1\n'
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    return bindir
+
+
+def _run_bash(action: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run ``bash -c <action>`` with a deliberately minimal env. Used by the
+    shell-level behavioural tests below."""
+    return subprocess.run(  # nosec B603 B607
+        ["bash", "-c", action],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+class TestInstallCheckOrSkip:
+    """Structural and behavioural tests for ``install_check_or_skip``.
+
+    Structural tests assert the generated snippet's shape; behavioural tests
+    drive the snippet through ``bash -c`` against a fake ``uv`` shim on PATH
+    to verify that the three relevant branches behave correctly. The
+    "installed + tool fails -> action exits non-zero" case is the bug fix
+    being verified (issue #527).
+    """
+
+    # --- Structural ---
+
+    def test_snippet_contains_uv_pip_show_with_package(self) -> None:
+        """The gate uses ``uv pip show <package>`` to detect installation."""
+        snippet = install_check_or_skip("bandit", "bandit not installed.")
+        assert "uv pip show bandit" in snippet
+
+    def test_snippet_silences_pip_show_output(self) -> None:
+        """The gate must redirect ``uv pip show`` output so it doesn't pollute task logs."""
+        snippet = install_check_or_skip("bandit", "bandit not installed.")
+        assert ">/dev/null 2>&1" in snippet
+
+    def test_snippet_contains_hint(self) -> None:
+        """The hint is embedded in the not-installed branch."""
+        snippet = install_check_or_skip(
+            "bandit", "bandit not installed. Run: uv sync --extra security"
+        )
+        assert "bandit not installed. Run: uv sync --extra security" in snippet
+
+    def test_snippet_exits_zero_in_not_installed_branch(self) -> None:
+        """The not-installed branch must exit 0 so doit ticks green for missing extras."""
+        snippet = install_check_or_skip("bandit", "bandit not installed.")
+        assert "exit 0" in snippet
+
+    def test_snippet_ends_with_separator_for_concatenation(self) -> None:
+        """The snippet ends with ``; `` so callers can plain-concatenate the rest of the action."""
+        snippet = install_check_or_skip("bandit", "bandit not installed.")
+        assert snippet.endswith("; ")
+
+    def test_hint_with_special_chars_is_shell_quoted(self) -> None:
+        """Hints containing single quotes / spaces are quoted via ``shlex.quote``.
+
+        Without quoting, an embedded ``'`` would terminate the shell-quoted
+        string and either break the snippet or, worse, allow injection.
+        """
+        hint = "don't break: run `uv sync --extra security`"
+        snippet = install_check_or_skip("bandit", hint)
+        # The hint is included via shlex.quote(); whatever its quoted form is,
+        # bash must echo back the original hint verbatim when the snippet runs.
+        assert shlex.quote(hint) in snippet
+
+    # --- Behavioural (fake uv on PATH) ---
+
+    def _build_env(self, bindir: Path, *, installed: bool) -> dict[str, str]:
+        """Build a minimal child env with the fake-uv directory ahead of system bins."""
+        # /usr/bin and /bin keep ``bash``, ``echo``, etc. resolvable; the fake
+        # ``uv`` wins because its directory comes first.
+        path = f"{bindir}:/usr/bin:/bin"
+        env = {"PATH": path, "FAKE_INSTALLED": "1" if installed else "0"}
+        # ``bash`` itself sometimes needs ``HOME`` etc; keep it minimal but viable.
+        if "HOME" in os.environ:
+            env["HOME"] = os.environ["HOME"]
+        return env
+
+    def test_not_installed_branch_exits_zero_and_prints_hint(self, tmp_path: Path) -> None:
+        """When ``uv pip show`` fails, the snippet prints the hint and exits 0."""
+        bindir = _write_fake_uv(tmp_path)
+        env = self._build_env(bindir, installed=False)
+
+        snippet = install_check_or_skip(
+            "bandit", "bandit not installed. Run: uv sync --extra security"
+        )
+        # The user's real command is ``false`` — if the gate failed to short
+        # the shell on the not-installed branch, the action would exit 1.
+        action = snippet + "false"
+
+        result = _run_bash(action, env)
+        assert result.returncode == 0
+        assert "bandit not installed. Run: uv sync --extra security" in result.stdout
+
+    def test_installed_and_tool_succeeds_exits_zero(self, tmp_path: Path) -> None:
+        """When ``uv pip show`` succeeds and the tool succeeds, the action exits 0."""
+        bindir = _write_fake_uv(tmp_path)
+        env = self._build_env(bindir, installed=True)
+
+        snippet = install_check_or_skip("bandit", "bandit not installed.")
+        action = snippet + "true"
+
+        result = _run_bash(action, env)
+        assert result.returncode == 0
+        # The hint must NOT appear on the happy path.
+        assert "not installed" not in result.stdout
+
+    def test_installed_and_tool_fails_propagates_nonzero(self, tmp_path: Path) -> None:
+        """When ``uv pip show`` succeeds and the tool fails, the action exits non-zero.
+
+        This is the bug fix from issue #527: previously the ``|| echo 'not
+        installed'`` form swallowed real failures by exiting 0. The gate must
+        let real failures through unmasked.
+        """
+        bindir = _write_fake_uv(tmp_path)
+        env = self._build_env(bindir, installed=True)
+
+        snippet = install_check_or_skip("bandit", "bandit not installed.")
+        action = snippet + "false"
+
+        result = _run_bash(action, env)
+        assert result.returncode != 0
+        # The "not installed" hint must NOT appear when the failure is real.
+        assert "not installed" not in result.stdout

--- a/tests/template/test_doit_git.py
+++ b/tests/template/test_doit_git.py
@@ -1,0 +1,47 @@
+"""Tests for tools/doit/git.py task wiring.
+
+Verifies that ``task_commit``, ``task_bump``, and ``task_changelog`` gate
+their ``cz`` invocations on ``uv pip show commitizen`` (via
+``install_check_or_skip``) so real failures — pre-commit hook rejections,
+tag/version bump failures, changelog generation failures — propagate
+instead of being swallowed by the legacy ``|| echo 'not installed'`` pattern.
+
+Addresses issue #527.
+"""
+
+from __future__ import annotations
+
+from tools.doit.git import task_bump, task_changelog, task_commit
+
+
+class TestGitTaskGates:
+    """Each git task gates ``cz`` via ``uv pip show commitizen``.
+
+    The package name is ``commitizen`` (CLI is ``cz``). All three tasks
+    share the same gating package; the underlying ``cz`` subcommand differs.
+    """
+
+    def test_commit_gates_on_commitizen_package(self) -> None:
+        action = task_commit()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show commitizen" in action
+        assert "commitizen not installed. Run: uv sync" in action
+        assert "uv run cz commit" in action
+        # Bug-fix invariant: the bare-swallow pattern must be gone.
+        assert "|| echo 'commitizen not installed" not in action
+
+    def test_bump_gates_on_commitizen_package(self) -> None:
+        action = task_bump()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show commitizen" in action
+        assert "commitizen not installed. Run: uv sync" in action
+        assert "uv run cz bump" in action
+        assert "|| echo 'commitizen not installed" not in action
+
+    def test_changelog_gates_on_commitizen_package(self) -> None:
+        action = task_changelog()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show commitizen" in action
+        assert "commitizen not installed. Run: uv sync" in action
+        assert "uv run cz changelog" in action
+        assert "|| echo 'commitizen not installed" not in action

--- a/tests/template/test_doit_security.py
+++ b/tests/template/test_doit_security.py
@@ -1,8 +1,14 @@
-"""Tests for tools/doit/security.py ``task_security`` wiring around ``bootstrap.py``.
+"""Tests for tools/doit/security.py task wiring.
 
-Verifies that the security task (bandit) includes ``bootstrap.py`` when it
-exists at the cwd (template repo) and excludes it when it has been removed
-(spawned consumer project). Addresses issue #469.
+Covers two concerns:
+
+1. ``task_security`` includes ``bootstrap.py`` iff it exists at cwd (template
+   repo) and excludes it when removed (spawned consumer project). Addresses
+   issue #469.
+2. All four security tasks gate their underlying tool on ``uv pip show
+   <package>`` (via ``install_check_or_skip``) so real failures (bandit
+   findings, pip-audit CVEs, etc.) propagate instead of being swallowed by
+   the legacy ``|| echo 'not installed'`` pattern. Addresses issue #527.
 """
 
 from __future__ import annotations
@@ -11,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.doit.security import task_security
+from tools.doit.security import task_audit, task_licenses, task_sbom, task_security
 
 
 def _touch(tmp_path: Path, rel: str) -> Path:
@@ -51,3 +57,53 @@ class TestTaskSecurity:
         assert "bandit" in action
         assert "src/" in action
         assert "tools/" in action
+
+
+class TestSecurityTaskGates:
+    """Each security task gates its tool via ``uv pip show <package>``.
+
+    The gate replaces the swallow-prone ``cmd || echo 'not installed'``
+    pattern. We assert: (a) the gate is present, (b) the install hint is
+    preserved, (c) the original tool invocation is still part of the action,
+    and (d) the broken-swallow pattern is gone.
+    """
+
+    def test_audit_gates_on_pip_audit_package(self) -> None:
+        action = task_audit()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show pip-audit" in action
+        assert "pip-audit not installed. Run: uv sync --extra security" in action
+        assert "uv run pip-audit --skip-editable" in action
+        # Bug-fix invariant: the bare-swallow pattern must be gone.
+        assert "|| echo 'pip-audit not installed" not in action
+
+    def test_security_gates_on_bandit_package(self) -> None:
+        action = task_security()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show bandit" in action
+        assert "bandit not installed. Run: uv sync --extra security" in action
+        assert "uv run bandit -c pyproject.toml -r src/ tools/" in action
+        assert "|| echo 'bandit not installed" not in action
+
+    def test_licenses_gates_on_pip_licenses_package(self) -> None:
+        action = task_licenses()["actions"][0]
+        assert isinstance(action, str)
+        assert "uv pip show pip-licenses" in action
+        assert "pip-licenses not installed. Run: uv sync --extra security" in action
+        assert "uv run pip-licenses --format=markdown --order=license" in action
+        assert "|| echo 'pip-licenses not installed" not in action
+
+    def test_sbom_gates_on_cyclonedx_bom_package(self) -> None:
+        # task_sbom has TWO actions: ``mkdir -p tmp`` (untouched) and the
+        # cyclonedx invocation (gated). Inspect the second.
+        actions = task_sbom()["actions"]
+        assert len(actions) == 2
+        assert actions[0] == "mkdir -p tmp"
+        action = actions[1]
+        assert isinstance(action, str)
+        # CLI is ``cyclonedx-py`` but the package name is ``cyclonedx-bom``.
+        assert "uv pip show cyclonedx-bom" in action
+        assert "cyclonedx-py not installed. Run: uv sync --extra security" in action
+        assert "uv run cyclonedx-py environment --of JSON -o tmp/sbom.json" in action
+        assert "uv run cyclonedx-py environment --of XML -o tmp/sbom.xml" in action
+        assert "|| echo 'cyclonedx-py not installed" not in action

--- a/tools/doit/base.py
+++ b/tools/doit/base.py
@@ -1,6 +1,7 @@
 """Base utilities and configuration for doit tasks."""
 
 import os
+import shlex
 import subprocess  # nosec B404 - subprocess is required to run doit sub-tasks
 import sys
 from collections.abc import Mapping
@@ -57,6 +58,40 @@ def optional_root_files(*names: str) -> str:
     if not survivors:
         return ""
     return " " + " ".join(survivors)
+
+
+def install_check_or_skip(package: str, hint: str) -> str:
+    """Build a shell prefix that gates a doit action on ``package`` being installed.
+
+    Emits a shell snippet that exits 0 with ``hint`` printed when
+    ``uv pip show <package>`` reports the package missing, and otherwise lets
+    the rest of the action run so its real exit code reaches the operator
+    unmasked. Replaces the ``cmd || echo 'not installed'`` pattern, which
+    always swallowed real failures by exiting 0 regardless of why ``cmd``
+    failed. See issue #527.
+
+    The emitted snippet uses the form::
+
+        uv pip show <package> >/dev/null 2>&1 || { echo <hint>; exit 0; };
+
+    If ``uv pip show`` succeeds (package present), the brace group is skipped
+    and the caller's real command runs; its exit code propagates unmasked.
+    If ``uv pip show`` fails (package absent), the brace group prints the hint
+    and ``exit 0`` terminates the shell before the real command is reached.
+
+    Args:
+        package: The package name as known to ``uv pip show`` (e.g.
+            ``"bandit"``, ``"commitizen"``, ``"cyclonedx-bom"``).
+        hint: Human-readable install instruction printed when the package is
+            absent (e.g. ``"bandit not installed. Run: uv sync --extra
+            security"``). Shell-quoted via ``shlex.quote`` so embedded spaces
+            and special characters are safe.
+
+    Returns:
+        A shell fragment ending with ``"; "`` suitable for prepending to the
+        rest of a doit action string via plain string concatenation.
+    """
+    return f"uv pip show {package} >/dev/null 2>&1 || {{ echo {shlex.quote(hint)}; exit 0; }}; "
 
 
 def _child_env(env: Mapping[str, str] | None) -> dict[str, str]:

--- a/tools/doit/git.py
+++ b/tools/doit/git.py
@@ -4,11 +4,19 @@ from typing import Any
 
 from doit.tools import title_with_actions
 
+from .base import install_check_or_skip
+
 
 def task_commit() -> dict[str, Any]:
     """Interactive commit with commitizen (ensures conventional commit format)."""
     return {
-        "actions": ["uv run cz commit || echo 'commitizen not installed. Run: uv sync'"],
+        "actions": [
+            install_check_or_skip(
+                "commitizen",
+                "commitizen not installed. Run: uv sync",
+            )
+            + "uv run cz commit"
+        ],
         "title": title_with_actions,
     }
 
@@ -16,7 +24,13 @@ def task_commit() -> dict[str, Any]:
 def task_bump() -> dict[str, Any]:
     """Bump version automatically based on conventional commits."""
     return {
-        "actions": ["uv run cz bump || echo 'commitizen not installed. Run: uv sync'"],
+        "actions": [
+            install_check_or_skip(
+                "commitizen",
+                "commitizen not installed. Run: uv sync",
+            )
+            + "uv run cz bump"
+        ],
         "title": title_with_actions,
     }
 
@@ -24,7 +38,13 @@ def task_bump() -> dict[str, Any]:
 def task_changelog() -> dict[str, Any]:
     """Generate CHANGELOG from conventional commits."""
     return {
-        "actions": ["uv run cz changelog || echo 'commitizen not installed. Run: uv sync'"],
+        "actions": [
+            install_check_or_skip(
+                "commitizen",
+                "commitizen not installed. Run: uv sync",
+            )
+            + "uv run cz changelog"
+        ],
         "title": title_with_actions,
     }
 

--- a/tools/doit/security.py
+++ b/tools/doit/security.py
@@ -4,15 +4,18 @@ from typing import Any
 
 from doit.tools import title_with_actions
 
-from .base import optional_root_files
+from .base import install_check_or_skip, optional_root_files
 
 
 def task_audit() -> dict[str, Any]:
     """Run security audit with pip-audit (requires security extras)."""
     return {
         "actions": [
-            "uv run pip-audit --skip-editable || "
-            "echo 'pip-audit not installed. Run: uv sync --extra security'"
+            install_check_or_skip(
+                "pip-audit",
+                "pip-audit not installed. Run: uv sync --extra security",
+            )
+            + "uv run pip-audit --skip-editable"
         ],
         "title": title_with_actions,
     }
@@ -22,9 +25,12 @@ def task_security() -> dict[str, Any]:
     """Run security checks with bandit (requires security extras)."""
     return {
         "actions": [
-            "uv run bandit -c pyproject.toml -r src/ tools/"
+            install_check_or_skip(
+                "bandit",
+                "bandit not installed. Run: uv sync --extra security",
+            )
+            + "uv run bandit -c pyproject.toml -r src/ tools/"
             + optional_root_files("bootstrap.py")
-            + " || echo 'bandit not installed. Run: uv sync --extra security'"
         ],
         "title": title_with_actions,
         "verbosity": 0,
@@ -35,8 +41,11 @@ def task_licenses() -> dict[str, Any]:
     """Check licenses of dependencies (requires security extras)."""
     return {
         "actions": [
-            "uv run pip-licenses --format=markdown --order=license || "
-            "echo 'pip-licenses not installed. Run: uv sync --extra security'"
+            install_check_or_skip(
+                "pip-licenses",
+                "pip-licenses not installed. Run: uv sync --extra security",
+            )
+            + "uv run pip-licenses --format=markdown --order=license"
         ],
         "title": title_with_actions,
     }
@@ -47,9 +56,12 @@ def task_sbom() -> dict[str, Any]:
     return {
         "actions": [
             "mkdir -p tmp",
-            "uv run cyclonedx-py environment --of JSON -o tmp/sbom.json && "
-            "uv run cyclonedx-py environment --of XML -o tmp/sbom.xml || "
-            "echo 'cyclonedx-py not installed. Run: uv sync --extra security'",
+            install_check_or_skip(
+                "cyclonedx-bom",
+                "cyclonedx-py not installed. Run: uv sync --extra security",
+            )
+            + "uv run cyclonedx-py environment --of JSON -o tmp/sbom.json && "
+            "uv run cyclonedx-py environment --of XML -o tmp/sbom.xml",
         ],
         "title": title_with_actions,
         "verbosity": 2,


### PR DESCRIPTION
## Description

Seven `doit` tasks used `cmd || echo 'not installed...'` to handle optional
security/git extras. Because `echo` exits 0, this pattern swallowed real failures:
bandit security findings, pip-audit CVEs, pre-commit hook rejections, and version
bump errors all ticked green locally while CI surfaced them directly. This created
a local/CI divergence that undermined the safety net these tasks are meant to provide.

The fix introduces a new helper `install_check_or_skip(package, hint)` in
`tools/doit/base.py` that emits a shell prefix
`uv pip show <pkg> >/dev/null 2>&1 || { echo <hint>; exit 0; };`. When the
package is absent the snippet exits 0 (preserving the friendly fallback); when
present, the real command runs and its exit code propagates unmasked. All 7
affected tasks now use it.

## Related Issue

Addresses #527

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement

## Changes Made

- `tools/doit/base.py`: Added `install_check_or_skip(package, hint) -> str` helper.
- `tools/doit/security.py`: Replaced `|| echo` fallback in `task_audit`,
  `task_security`, `task_licenses`, and `task_sbom` with `install_check_or_skip`.
- `tools/doit/git.py`: Replaced `|| echo` fallback in `task_commit`, `task_bump`,
  and `task_changelog` with `install_check_or_skip`.
- `tests/template/test_doit_base.py`: Added `TestInstallCheckOrSkip` — structural
  assertions on snippet shape plus three bash-level behavioral tests with a fake
  `uv` shim on PATH.
- `tests/template/test_doit_security.py`: Added `TestSecurityTaskGates` — structural
  assertions that all four security tasks use the gate and the broken swallow pattern
  is gone.
- `tests/template/test_doit_git.py`: New file — `TestGitTaskGates` — same structural
  assertions for the three git tasks.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Regression guard:** `TestInstallCheckOrSkip::test_installed_and_tool_fails_propagates_nonzero`
drives `bash -c` with a fake `uv` shim that simulates an installed package, then
runs `false` as the tool. It asserts `returncode != 0`, directly verifying the
bug-fix invariant: real failures are no longer masked when the package is present.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

The task contract is unchanged: same task names, same user-visible install hints
when extras are absent. Only the failure mode changes — from "silent 0" to "real
exit code propagates". No user-facing documentation updates were required.

No ADR is needed: this is a bug fix in error reporting with no architectural
decision involved and the issue carries no `needs-adr` label.
