### PR TITLE
docs: document .github/instructions/ rule pattern for Copilot CLI

### DIFF
--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -24,10 +24,25 @@ The `implement-worker` subagent used by `/ghissue-implement` is defined in `.cla
 
 Agents must write temporary files to `tmp/agents/copilot/` (not `/tmp/`). Include a context identifier (issue number, PR number, or task ID) in the filename to avoid collisions.
 
+## Per-Stack Instructions
+
+GitHub Copilot natively discovers instruction files placed in `.github/instructions/` and named
+`NAME.instructions.md`. Each file begins with YAML frontmatter (`applyTo: '<glob>'`) that gates
+it to a specific path scope, followed by a skill-gated, numbered self-check body (≤30 lines) and
+an `Observed failures:` footer.
+
+This is the Copilot equivalent of `.claude/rules/` (loaded via `@import` in `.claude/CLAUDE.md`)
+and `.gemini/rules/` (loaded via `@` directive in `GEMINI.md`). The discipline — build from
+observed failures, not generic advice — is shared across all three CLIs.
+
+See [`.github/instructions/README.md`](../.github/instructions/README.md) for the full pattern,
+file structure, and a worked example.
+
 ## See Also
 
 - `.claude/commands/` — slash command definitions (auto-discovered by Copilot CLI)
 - `.claude/agents/implement-worker.md` — implement-worker subagent definition
 - `.github/hooks/copilot-hooks.json` — dangerous command hook wiring
+- `.github/instructions/README.md` — per-stack instruction file pattern for Copilot
 - `docs/development/ai/slash-commands.md` — full workflow and command reference
 - `docs/development/ai/command-blocking.md` — hook documentation

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -1,0 +1,135 @@
+# Per-Stack Instruction Files (GitHub Copilot)
+
+## Purpose
+
+Instruction files in this directory capture **narrow, recurring footguns** that GitHub Copilot
+keeps getting wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`.
+`AGENTS.md` carries broad workflow and architectural rules for the whole project. An instruction
+file carries three to ten numbered self-checks for one specific failure mode — small enough to
+survive a context window, sharp enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+> **Copilot-native format:** Files in this directory are consumed by GitHub Copilot via its native
+> auto-discovery mechanism. Claude Code and Gemini CLI **cannot** read `.github/instructions/`
+> files. For the Claude equivalent use `.claude/rules/`; for the Gemini equivalent use
+> `.gemini/rules/`.
+
+## When to author an instruction file
+
+Write an instruction file when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to belong to a single skill gate (e.g., `codegen`, `db-migrations`,
+   `api-contracts`).
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File naming and location
+
+Files must be placed directly in `.github/instructions/` and named `NAME.instructions.md`.
+Copilot auto-discovers all `*.instructions.md` files in this directory — no explicit import or
+directive is required.
+
+## File structure
+
+Each instruction file must begin with YAML frontmatter that gates the file to a path scope,
+followed by three required sections:
+
+```
+---
+applyTo: 'src/**/*.py'
+---
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+### `applyTo:` frontmatter
+
+The `applyTo:` field is **required**. It is a glob pattern that gates the file to specific paths:
+
+- `applyTo: '**'` — applies repo-wide (equivalent to Claude's `@./rules/*.md` with no path filter)
+- `applyTo: 'src/**/*.py'` — scopes to Python source files only
+- `applyTo: 'tests/**'` — scopes to test files only
+
+Use a narrow glob when the self-checks are only relevant for a specific subtree.
+
+### Body sections
+
+- **`Skill: <name>`** — the first line after frontmatter, no heading. Names the capability gate so
+  the model can self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A rule with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per instruction file (excluding frontmatter). If a file grows past
+30 lines, split it.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that instruction files must be derived from documented
+failures, not from intuition or generic advice. A checklist written in advance of any failure will
+drift into noise — the model will pattern-match the checklist language and satisfy it
+superficially. A checklist written because a specific PR broke a specific invariant three times is
+sharp enough to change behavior. If you cannot fill in the `Observed failures:` footer with real
+links, the instruction file is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen.instructions.md` file might look like for a
+downstream project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an
+ADR (ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual
+instruction files belong in downstream repos, not in this template.
+
+```
+---
+applyTo: 'src/**/*.py'
+---
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## Shared discipline across CLIs
+
+The **discipline** (≤30 lines, numbered self-checks, observed-failures footer) is shared across
+Claude Code, Gemini CLI, and GitHub Copilot even though the file format differs:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+
+See [`.claude/rules/README.md`](../../.claude/rules/README.md) and
+[`.gemini/rules/README.md`](../../.gemini/rules/README.md) for the Claude and Gemini variants.
+
+## What NOT to put in an instruction file
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`"
+  belong in `AGENTS.md`, not here. Instruction files are for stack-specific self-checks, not
+  universal workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing
+  behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
+  was violated, the instruction file is not ready to be written.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,7 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 | :--- | :--- | :--- |
 | Claude Code | `.claude/` | Commands, agents, rules, settings. Primary source of slash commands. |
 | Gemini CLI | `.gemini/` | Commands, settings, and rules/ subdirectory for per-stack rule files. Supports a standalone workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`) and Claude-orchestrated dual-agent flows. |
-| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. |
+| GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. Per-stack instruction files live in `.github/instructions/` (Copilot-native; Claude/Gemini cannot read them). See `.github/instructions/README.md`. |
 | Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. |
 
 Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`, etc.) works out of the box.

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -209,7 +209,7 @@ To opt out or tune values for your local environment, override them in `.claude/
 
 > **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
-GitHub Copilot CLI reads `AGENTS.md` directly and auto-discovers project skills from `.claude/commands/`, so the full slash-command workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`, `/ghissue-close`, `/ghissue-status`, etc.) is available in Copilot sessions without any parallel command files. The `implement-worker` subagent used by `/ghissue-implement` is shared with Claude (defined in `.claude/agents/implement-worker.md`).
+GitHub Copilot CLI reads `AGENTS.md` directly and auto-discovers project skills from `.claude/commands/`, so the full slash-command workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`, `/ghissue-close`, `/ghissue-status`, etc.) is available in Copilot sessions without any parallel command files. It also natively discovers per-stack instruction files from `.github/instructions/*.instructions.md`; see [`.github/instructions/README.md`](../../.github/instructions/README.md) for the scaffold and format. The `implement-worker` subagent used by `/ghissue-implement` is shared with Claude (defined in `.claude/agents/implement-worker.md`).
 
 **Hook wiring:**
 
@@ -240,6 +240,8 @@ copilot
 **Files:**
 - `.copilot/README.md` - Description of the Copilot CLI config directory
 - `.github/hooks/copilot-hooks.json` - `preToolUse` hook wiring
+- `.github/instructions/*.instructions.md` - Copilot-native per-stack instruction files (auto-discovered)
+- `.github/instructions/README.md` - Instruction-file scaffold and format reference
 - `.claude/commands/*.md` - Slash commands (auto-discovered by Copilot CLI)
 - `.claude/agents/implement-worker.md` - Shared subagent definition
 
@@ -284,7 +286,7 @@ This template ships several files that influence agent behavior. They fall into 
 - **`AGENTS.md`** (project root, ~20 KB) — universal source of truth for architecture, workflow, tooling hierarchy, and security rules. Read directly by Codex CLI, Gemini CLI, and GitHub Copilot CLI; imported by Claude Code via `@../AGENTS.md` in `.claude/CLAUDE.md`.
 - **`.claude/CLAUDE.md`** (~2 KB) — Claude-specific complement. First line is `@../AGENTS.md`, which imports the universal rules; the rest adds Claude-specific layers (token-efficiency guidance, the mandatory TodoWrite plan-test-code loop, the development workflow reminder, and the commit workflow reminder).
 - **`GEMINI.md`** (project root, ~1 KB) — Gemini-specific complement. Covers Gemini's stdout-only collaboration mode (so Claude handles GitHub writes), the output signing footer, and Gemini's tool-usage rules. Read alongside `AGENTS.md` by Gemini CLI, not instead of it.
-- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly and auto-discovers slash commands from `.claude/commands/`; no Copilot-specific context markdown is required.
+- **`.copilot/README.md`** — describes the Copilot CLI config directory. Copilot CLI reads `AGENTS.md` directly, auto-discovers slash commands from `.claude/commands/`, and uses `.github/instructions/*.instructions.md` for Copilot-native per-stack instruction files.
 - **`.codex/config.toml`** — Codex approval policy file (TOML). Not a context file; configures permissions only. Codex reads `AGENTS.md` directly for instructions.
 - **`.claude/settings.json`** — Claude PreToolUse hooks and statusline configuration. Committed.
 - **`.claude/settings.local.json`** — local Claude permissions overlay. Not committed.
@@ -447,7 +449,8 @@ gemini --yolo
 
 **`.copilot/` auto-detection:**
 - The `.copilot/` directory exists primarily to document Copilot-specific wiring; Copilot CLI does not require any config files there
-- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root and the hook from `.github/hooks/copilot-hooks.json`
+- Copilot CLI also auto-discovers `.github/instructions/*.instructions.md` without any import or directive
+- If you move the repository, Copilot CLI still loads `AGENTS.md` from the repo root, the hook from `.github/hooks/copilot-hooks.json`, and instruction files from `.github/instructions/`
 
 ## Resources
 

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -148,5 +148,6 @@ Run `/ghissue-status`. It is read-only, has no side effects, and will tell you t
 - [AGENTS.md](../../../AGENTS.md) — universal context file and workflow reference.
 - [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for Claude Code.
 - [`.gemini/rules/` scaffold](../../../.gemini/rules/README.md) — per-stack rule-file pattern for Gemini CLI.
+- [`.github/instructions/` scaffold](../../../.github/instructions/README.md) — per-stack instruction-file pattern for GitHub Copilot.
 - <!-- TODO: wire this link up properly when #342 lands -->
   For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -566,6 +566,22 @@ See [`.claude/rules/README.md`](../../../.claude/rules/README.md) and
 [`.gemini/rules/README.md`](../../../.gemini/rules/README.md) for the pattern, file structure, and
 a worked example.
 
+GitHub Copilot has a native equivalent: **`.github/instructions/NAME.instructions.md`** files with
+`applyTo:` YAML frontmatter for path-based gating. No import directive is needed — Copilot
+auto-discovers all `*.instructions.md` files in `.github/instructions/`. The body format (skill
+gate, numbered self-checks, observed-failures footer, ≤30 lines) is identical to the Claude and
+Gemini variants. The key contrast with those variants is the load mechanism:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+
+Claude Code and Gemini CLI cannot read `.github/instructions/` files; this format is
+Copilot-native only. See [`.github/instructions/README.md`](../../../.github/instructions/README.md)
+for the full pattern and a worked example.
+
 ## Related primitives in this template
 
 These are not add-ons (they ship with the template) but they interact with the tools above:


### PR DESCRIPTION
## Description

Document GitHub Copilot's `.github/instructions/` rule pattern and cross-link the scaffold from the Copilot configuration and AI workflow docs.

## Related Issue

Addresses #522

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `.github/instructions/README.md` describing Copilot-native `*.instructions.md` files, required structure, and the observed-failures discipline
- Linked the new scaffold from `.copilot/README.md`, `AGENTS.md`, `docs/development/ai/token-efficiency-add-ons.md`, and `docs/development/ai/first-5-minutes.md`
- Updated `docs/development/AI_SETUP.md` so the Copilot setup docs mention `.github/instructions/` discovery and the related reference files

## Testing

- [ ] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

Validation run:
- Ran `doit check`; reproduced the known pre-existing `mypy` failure in `bootstrap.py` (`tomli` import) and the known pre-existing `codespell` `ctypes` ImportError
- Ran `doit test` separately because `doit check` stops at `mypy`; the current environment also hit a Python segmentation fault in `tests/test_logging.py`

## Checklist

- [ ] My code follows the code style of this project (ran `doit format`)
- [ ] I have run linting checks (`doit lint`)
- [ ] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [ ] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

This is a docs-only scaffold change. No ADR update is needed for issue #522.
