### PR TITLE
docs: document .agents/skills/ as rule-pattern equivalent for Codex CLI

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,151 @@
+# Per-Stack Rule-Shaped Skills (Codex CLI)
+
+## Purpose
+
+Rule-shaped skills in this directory capture **narrow, recurring footguns** that Codex CLI keeps
+getting wrong for a specific stack or domain. They are not a second copy of `AGENTS.md`. `AGENTS.md`
+carries broad workflow and architectural rules for the whole project. A rule-shaped skill carries
+three to ten numbered self-checks for one specific failure mode — small enough to survive a context
+window, sharp enough to change behavior.
+
+The pattern works because a short, skill-gated checklist is more likely to be honored late in a
+session than a paragraph buried in a large reference file.
+
+> **Codex-native loading:** Codex auto-loads a skill when the task description matches the skill's
+> `description:` frontmatter. The `description:` field IS the skill-gate trigger — there is no
+> `@import` directive or glob-import mechanism. Write the `description:` so that it matches only the
+> tasks where the self-checks apply (e.g., "Use when generating typed Python from a YANG schema").
+>
+> This is the Codex equivalent of `.claude/rules/` (Claude Code) and `.gemini/rules/` (Gemini CLI).
+> For the Claude and Gemini variants, see those directories. For the GitHub Copilot variant, see
+> [`.github/instructions/README.md`](../../.github/instructions/README.md).
+
+## When to author a rule-shaped skill
+
+Write a rule-shaped skill when all three conditions hold:
+
+1. The same mistake has recurred in at least two separate sessions or PRs.
+2. The failure can be expressed as a numbered checklist a model can self-check before acting.
+3. The scope is narrow enough to match a single, focused `description:` gate.
+
+If the rule is broad (applies everywhere) or is not tied to an observed failure, put it in
+`AGENTS.md` instead — or leave it out entirely.
+
+## File location and naming
+
+Each rule-shaped skill lives in its own subdirectory:
+
+```
+.agents/skills/<name>/SKILL.md
+```
+
+Use a short, lowercase, hyphenated name that reflects the domain (e.g., `codegen`, `db-migrations`,
+`api-contracts`). Keep rule-shaped skills in separate directories from the workflow skills that
+already exist here (`ghissue-plan`, `ghissue-implement`, etc.).
+
+## File structure
+
+Each rule-shaped skill's `SKILL.md` must have YAML frontmatter followed by three required sections:
+
+```
+---
+name: <name>
+description: <task-match trigger — the sentence Codex uses to decide when to load this skill>
+---
+
+Skill: <name>
+
+Self-check before <action>:
+1. <First check — concrete and verifiable>
+2. <Second check>
+3. <Third check>
+...
+
+Observed failures: <PR or issue URL>, <PR or issue URL>
+```
+
+### `description:` frontmatter
+
+The `description:` field controls when Codex loads the skill. Write it as a sentence that matches
+only the tasks where the self-checks apply:
+
+- `description: Use when generating typed Python from a YANG schema` — task-specific
+- `description: Use when writing or modifying database migration files` — task-specific
+
+Avoid broad descriptions like `description: Use when writing Python` — that turns the skill into
+ambient context, not a gate.
+
+### Body sections
+
+- **`Skill: <name>`** — the first line after frontmatter, no heading. Names the capability gate so
+  the model can self-identify when to apply the file.
+- **Numbered self-check list** — imperative, specific. Each item must be falsifiable: the model
+  should be able to answer "yes" or "no".
+- **`Observed failures:` footer** — links to the PRs or issues where the failure was documented.
+  This is mandatory. A skill with no observed-failure link is a guess, not a discipline.
+
+Target: **30 lines or fewer** per skill body (excluding frontmatter). If a body grows past 30 lines,
+split it into two skills.
+
+## Discipline: build from observed failures, not generic best-practices
+
+The central rule of this pattern is that rule-shaped skills must be derived from documented
+failures, not from intuition or generic advice. A checklist written in advance of any failure will
+drift into noise — the model will pattern-match the checklist language and satisfy it superficially.
+A checklist written because a specific PR broke a specific invariant three times is sharp enough to
+change behavior. If you cannot fill in the `Observed failures:` footer with real links, the
+rule-shaped skill is not ready to be written yet.
+
+## Worked example
+
+The following sketch illustrates what a `codegen/SKILL.md` rule-shaped skill might look like for a
+downstream project (`pynetappfoundry`) that generates typed Python from a YANG schema and has an ADR
+(ADR-0008) documenting a round-trip invariant. **This example is illustrative only** — actual
+rule-shaped skills belong in downstream repos, not in this template.
+
+```
+---
+name: codegen
+description: Use when generating typed Python from a YANG schema in pynetappfoundry
+---
+
+Skill: codegen
+
+Self-check before committing generated code:
+1. Run `make roundtrip` and confirm exit 0 — the generated types must deserialize
+   what the serializer produces without loss (ADR-0008).
+2. Confirm no hand-edited lines remain in `src/generated/` — regenerate from schema
+   if any exist.
+3. Confirm the schema version in `src/generated/_version.py` matches the YANG source
+   revision header.
+
+Observed failures: endavis/pynetappfoundry#104, endavis/pynetappfoundry#117
+```
+
+## Shared discipline across CLIs
+
+The **discipline** (≤30 lines, numbered self-checks, observed-failures footer) is shared across all
+four CLIs even though the file format and load mechanism differ:
+
+| CLI | Directory | Load mechanism |
+| :--- | :--- | :--- |
+| Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
+| Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
+| GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+| Codex CLI | `.agents/skills/<name>/` | `description:` frontmatter is the skill-gate trigger |
+
+See [`.claude/rules/README.md`](../../.claude/rules/README.md),
+[`.gemini/rules/README.md`](../../.gemini/rules/README.md), and
+[`.github/instructions/README.md`](../../.github/instructions/README.md) for the other CLI variants.
+
+## What NOT to put in a rule-shaped skill
+
+- **Broad workflow rules** — things like "never commit to main" or "always run `doit check`" belong
+  in `AGENTS.md`, not here. Rule-shaped skills are for stack-specific self-checks, not universal
+  workflow.
+- **Generic best-practices** — "prefer composition over inheritance", "write type annotations" —
+  these are noise. They drift into checklists the model satisfies by rote without changing behavior.
+- **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule was
+  violated, the rule-shaped skill is not ready to be written yet.
+- **Workflow logic** — do not mix rule-shaped skills (self-check checklists) with workflow skills
+  (multi-step instructions like `ghissue-plan`). Keep them in separate subdirectories.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,13 +297,13 @@ Each supported AI CLI has a dedicated config directory at the repo root:
 | Claude Code | `.claude/` | Commands, agents, rules, settings. Primary source of slash commands. |
 | Gemini CLI | `.gemini/` | Commands, settings, and rules/ subdirectory for per-stack rule files. Supports a standalone workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`) and Claude-orchestrated dual-agent flows. |
 | GitHub Copilot CLI | `.copilot/` | Config directory. Skills auto-discovered from `.claude/commands/`. Hook wired in `.github/hooks/copilot-hooks.json`. Per-stack instruction files live in `.github/instructions/` (Copilot-native; Claude/Gemini cannot read them). See `.github/instructions/README.md`. |
-| Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. |
+| Codex CLI | `.codex/`, `.agents/skills/` | `config.toml` for approvals/hooks plus repo-scoped skills for the Codex workflow. No custom slash commands. Rule-shaped skills live in `.agents/skills/<name>/SKILL.md`; the `description:` frontmatter is the skill-gate trigger. See `.agents/skills/README.md`. |
 
 Copilot CLI does **not** need a `commands/` subdirectory: it discovers skills from `.claude/commands/` automatically, so the full workflow (`/ghissue-plan`, `/ghissue-implement`, `/ghissue-finalize`, etc.) works out of the box.
 
 Gemini CLI ships standalone implementations of `/ghissue-plan`, `/ghissue-implement`, and `/ghissue-finalize` under `.gemini/commands/`. They share the GitHub-artifact contract (plan comment header `## Implementation Plan for #<n>: <title>`, `<type>/<n>-<slug>` branch names, `Addresses #<n>` PR body) with the Claude versions, so users can switch agents mid-workflow without losing state.
 
-Codex CLI does **not** use repo-defined slash commands in this template. Its repo-native workflow is provided through checked-in skills under `.agents/skills/`, invoked with built-in Codex skill selection such as `/skills` or explicit mentions like `$ghissue-plan`.
+Codex CLI does **not** use repo-defined slash commands in this template. Its repo-native workflow is provided through checked-in skills under `.agents/skills/`, invoked with built-in Codex skill selection such as `/skills` or explicit mentions like `$ghissue-plan`. Rule-shaped skills (per-stack self-check checklists) follow the same discipline as `.claude/rules/`, `.gemini/rules/`, and `.github/instructions/` — ≤30 lines, numbered self-checks, observed-failures footer — with the key distinction that the `description:` frontmatter field acts as the skill-gate trigger instead of an import directive or glob. See `.agents/skills/README.md`.
 
 ### Temporary Files
 

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -149,5 +149,6 @@ Run `/ghissue-status`. It is read-only, has no side effects, and will tell you t
 - [`.claude/rules/` scaffold](../../../.claude/rules/README.md) — per-stack rule-file pattern for Claude Code.
 - [`.gemini/rules/` scaffold](../../../.gemini/rules/README.md) — per-stack rule-file pattern for Gemini CLI.
 - [`.github/instructions/` scaffold](../../../.github/instructions/README.md) — per-stack instruction-file pattern for GitHub Copilot.
+- [`.agents/skills/` scaffold](../../../.agents/skills/README.md) — per-stack rule-shaped skill pattern for Codex CLI.
 - <!-- TODO: wire this link up properly when #342 lands -->
   For an end-to-end example of the *coding* side of a feature (creating a module, CLI subcommand, tests, and docs), see [the add-a-feature example](../../examples/add-a-feature.md) (tracked in [#342](https://github.com/endavis/pyproject-template/issues/342)).

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -577,10 +577,16 @@ Gemini variants. The key contrast with those variants is the load mechanism:
 | Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
 | Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
 | GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
+| Codex CLI | `.agents/skills/<name>/` | `description:` frontmatter is the skill-gate trigger |
 
 Claude Code and Gemini CLI cannot read `.github/instructions/` files; this format is
 Copilot-native only. See [`.github/instructions/README.md`](../../../.github/instructions/README.md)
 for the full pattern and a worked example.
+
+Codex CLI uses a different mechanism: the `description:` field in a skill's YAML frontmatter acts
+as the skill-gate trigger — Codex auto-loads the skill when the task description matches. There is
+no `@import` directive. See [`.agents/skills/README.md`](../../../.agents/skills/README.md) for the
+full pattern and a worked example.
 
 ## Related primitives in this template
 


### PR DESCRIPTION
## Description

Add `.agents/skills/README.md` documenting **rule-shaped skills** as the Codex CLI equivalent of
the `.claude/rules/` and `.gemini/rules/` per-stack rule-file pattern. Cross-link from the
`token-efficiency-add-ons.md` per-stack rule files table and the `first-5-minutes.md` See also
section. Update `AGENTS.md` with rule-shaped skill guidance for the Codex row.

## Related Issue

Addresses #523

## Type of Change

- [x] Documentation update

## Changes Made

- `.agents/skills/README.md` — new reference doc: when to author, file structure (`description:`
  frontmatter as the skill-gate trigger), ≤30-line target, worked example, shared discipline table
  across all four CLIs, and what NOT to put in a rule-shaped skill
- `docs/development/ai/token-efficiency-add-ons.md` — added Codex CLI row to the per-stack rule
  files table; added explanatory paragraph and cross-link to `.agents/skills/README.md`
- `docs/development/ai/first-5-minutes.md` — added `.agents/skills/README.md` to See also section
- `AGENTS.md` — updated Codex CLI row to mention rule-shaped skills; expanded Codex paragraph to
  document the `description:` gate mechanism

## Testing

- [x] All existing tests pass (pre-existing failures on `main` are unchanged)
- [x] Manually verified cross-links resolve in the doc tree

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

Parent issue: #518 (Claude `.claude/rules/` version). This PR completes the four-CLI coverage
alongside `.claude/rules/README.md`, `.gemini/rules/README.md`, and `.github/instructions/README.md`.

Key Codex distinction documented: the `description:` frontmatter field is the skill-gate trigger —
Codex auto-loads a skill when the task description matches. There is no `@import` directive or glob
pattern, unlike Claude and Gemini.
