### PR TITLE
chore: switch .gemini/rules/ pattern to per-file @-imports

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -130,7 +130,7 @@ four CLIs even though the file format and load mechanism differ:
 | CLI | Directory | Load mechanism |
 | :--- | :--- | :--- |
 | Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
-| Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
 | GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
 | Codex CLI | `.agents/skills/<name>/` | `description:` frontmatter is the skill-gate trigger |
 

--- a/.gemini/rules/README.md
+++ b/.gemini/rules/README.md
@@ -50,23 +50,27 @@ Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, spli
 
 ## How to load
 
-Uncomment the `<!-- @./.gemini/rules/*.md -->` line in `GEMINI.md`:
+When you author a rule file (e.g., `codegen.md`), add a literal `@`-import for it to `GEMINI.md`:
 
 ```markdown
 @./AGENTS.md
-<!-- Uncomment when you add rule files. See .gemini/rules/README.md for the pattern. -->
-<!-- @./.gemini/rules/*.md -->
+@./.gemini/rules/codegen.md
+
+# Gemini CLI Instructions
+...
 ```
 
-becomes:
+Add one line per rule file. Do **not** use a glob like `@./.gemini/rules/*.md` — Gemini CLI's
+[Memory Import Processor](https://geminicli.com/docs/reference/memport/) only supports literal
+relative or absolute paths to specific files. Globs work in practice via undocumented behavior but
+emit a spurious `[ERROR] [ImportProcessor] Failed to import .../*.md: ENOENT` log on every run
+(the processor calls `access()` on the literal pattern before expanding it).
 
-```markdown
-@./AGENTS.md
-@./.gemini/rules/*.md
-```
+This is the inverse of Claude Code's `.claude/CLAUDE.md`, which does support glob imports — the two
+CLIs differ here despite using the same `@`-import syntax.
 
-Note: the line stays commented out in this template repository. Downstream consumers uncomment it
-after authoring their first rule file.
+Note: this template ships with no import line in `GEMINI.md`. Add the first line when you author
+your first rule file.
 
 ## Discipline: build from observed failures, not generic best-practices
 

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -117,7 +117,7 @@ Claude Code, Gemini CLI, and GitHub Copilot even though the file format differs:
 | CLI | Directory | Load mechanism |
 | :--- | :--- | :--- |
 | Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
-| Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
 | GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
 
 See [`.claude/rules/README.md`](../../.claude/rules/README.md) and

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,4 @@
 @./AGENTS.md
-<!-- Uncomment when you add rule files. See .gemini/rules/README.md for the pattern. -->
-<!-- @./.gemini/rules/*.md -->
 
 # Gemini CLI Instructions
 

--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -559,8 +559,10 @@ API contract changes, etc.).
 
 Each rule file is skill-gated, capped at 30 lines, and built from documented observed failures —
 not from generic advice. The template ships a commented-out `@import` placeholder in
-`.claude/CLAUDE.md` and a commented-out `@` placeholder in `GEMINI.md`; downstream consumers
-uncomment them and add their own rule files.
+`.claude/CLAUDE.md` (which Claude Code honors as a no-op until uncommented). For Gemini, the
+template ships **no** `@`-import in `GEMINI.md` — Gemini's Memory Import Processor doesn't honor
+HTML comments and only supports literal file paths (not globs), so consumers add a literal
+`@./.gemini/rules/<name>.md` line per rule file when they author one.
 
 See [`.claude/rules/README.md`](../../../.claude/rules/README.md) and
 [`.gemini/rules/README.md`](../../../.gemini/rules/README.md) for the pattern, file structure, and
@@ -575,7 +577,7 @@ Gemini variants. The key contrast with those variants is the load mechanism:
 | CLI | Directory | Load mechanism |
 | :--- | :--- | :--- |
 | Claude Code | `.claude/rules/` | `@./rules/*.md` in `.claude/CLAUDE.md` |
-| Gemini CLI | `.gemini/rules/` | `@./.gemini/rules/*.md` in `GEMINI.md` |
+| Gemini CLI | `.gemini/rules/` | One `@./.gemini/rules/<name>.md` line per rule file in `GEMINI.md` (literal paths only) |
 | GitHub Copilot | `.github/instructions/` | Native auto-discovery (no directive needed) |
 | Codex CLI | `.agents/skills/<name>/` | `description:` frontmatter is the skill-gate trigger |
 


### PR DESCRIPTION
## Description

Switch `.gemini/rules/` activation from a commented-out glob `@`-import scaffold to per-file literal `@`-imports added when consumers author rules.

Per [Gemini CLI's Memory Import Processor docs](https://geminicli.com/docs/reference/memport/), `@`-imports only support relative or absolute *file* paths — globs are undocumented. The pattern shipped in PR #543 (`<!-- @./.gemini/rules/*.md -->` in `GEMINI.md`) emitted a spurious `[ERROR] [ImportProcessor] Failed to import ./.gemini/rules/*.md: ENOENT` on every Gemini invocation. The HTML-comment "toggle" also never worked — Gemini processes the directive regardless of HTML comments.

Empirically verified: Gemini does **not** auto-discover `.gemini/rules/`, unlike Codex's `.agents/skills/` and Copilot's `.github/instructions/`. The literal per-file `@`-import is required for rules to load at all.

## Related Issue

Addresses #552

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- `GEMINI.md` — delete the two-line scaffold (`<!-- Uncomment ... -->` + `<!-- @./.gemini/rules/*.md -->`). This is the change that actually silences the ENOENT log.
- `.gemini/rules/README.md` — rewrite "How to load" section: per-file literal `@`-imports, with explicit "do not use a glob" guidance and a link to the upstream Gemini docs explaining why.
- `docs/development/ai/token-efficiency-add-ons.md` — update the prose paragraph (template no longer ships a Gemini scaffold) and the load-mechanism table row.
- `.github/instructions/README.md` and `.agents/skills/README.md` — update their identical load-mechanism table rows for consistency.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] Manually tested the changes (`gemini -y -p "Output OK"` now produces clean output with no `ImportProcessor`/`ENOENT` line)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works (manual `gemini -y -p` reproduction is the test; no automated test added because reproducing requires invoking the Gemini CLI binary, which is not part of this project's test environment)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (no CHANGELOG.md is maintained in this template; release notes are auto-generated from conventional commits)
- [x] My changes generate no new warnings

## Additional Notes

This corrects a pattern that was cargo-culted from Claude Code's `.claude/CLAUDE.md` (which *does* support glob `@`-imports). The two CLIs use the same `@`-import syntax but have different capabilities — Gemini documents only literal-path support.

Empirical findings during investigation are documented in the issue thread on #552.
