### PR TITLE
chore: add uv-lock-check pre-commit hook for uv.lock consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,6 +191,24 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      # Validate uv.lock is in sync with pyproject.toml when pyproject.toml is staged
+      - id: uv-lock-check
+        name: Validate uv.lock matches pyproject.toml
+        entry: |
+          bash -c '
+          uv lock --check || {
+            echo ""
+            echo "❌ ERROR: uv.lock is out of sync with pyproject.toml"
+            echo ""
+            echo "Run: uv lock"
+            echo "Then re-stage: git add uv.lock"
+            exit 1
+          }'
+        language: system
+        pass_filenames: false
+        files: ^pyproject\.toml$
+        stages: [pre-commit]
+
       # Auto-sync dependencies when uv.lock changes after git pull
       - id: uv-sync-on-pull
         name: Auto uv sync after pull (lock changed)

--- a/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
+++ b/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
@@ -18,6 +18,7 @@ Ensures bad code never enters the repository, provides fast feedback loop (secon
 - Issue #128: Align pre-commit, CI, and doit check to use consistent checks
 - Issue #19: Fix resolve pre-commit hook failures in template files
 - Issue #415: Add actionlint hook for GitHub Actions workflow validation
+- Issue #556: Validate uv.lock consistency on pyproject.toml changes
 
 ## Related Documentation
 

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -363,6 +363,7 @@ uv run pre-commit autoupdate
 | `no-commit-to-main` | Prevent direct commits to main branch |
 | `no-local-config` | Prevent committing local config files |
 | `protect-dynamic-version` | Protect `dynamic = ["version"]` in `pyproject.toml` |
+| `uv-lock-check` | Validate `uv.lock` is in sync with `pyproject.toml` when `pyproject.toml` is staged |
 
 **Commit-msg stage** (validates commit messages):
 

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -1138,6 +1138,7 @@ The following hooks run automatically on `git commit`:
 | `no-commit-to-main` | Prevent direct commits to main |
 | `no-local-config` | Prevent committing local config files |
 | `protect-dynamic-version` | Protect version configuration |
+| `uv-lock-check` | Validate `uv.lock` is in sync with `pyproject.toml` when `pyproject.toml` is staged |
 | `conventional-pre-commit` | Enforce conventional commit format |
 
 ### Dynamic Version Protection


### PR DESCRIPTION
## Description

Adds a `uv-lock-check` pre-commit hook that runs `uv lock --check` whenever `pyproject.toml` is staged. This catches the case where a developer changes `pyproject.toml` (adds/removes a dependency) but forgets to regenerate `uv.lock` before committing, preventing lock-file drift.

Addresses #556

## Type of Change

- [x] Code refactoring

## Changes Made

- `.pre-commit-config.yaml`: add `uv-lock-check` hook (pre-commit stage, `files: ^pyproject\.toml$`)
- `docs/development/ci-cd-testing.md`: add hook to pre-commit stage hook table
- `docs/development/doit-tasks-reference.md`: add hook to hook reference table
- `docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md`: link Issue #556 in Related Issues

**Implementation note:** `entry:` uses a YAML block scalar (`|`) rather than an inline `bash -c '…'` string because the recovery error message contains `: ` which is a YAML key indicator and breaks inline form. Behavior is identical; the pattern matches the existing `protect-dynamic-version` hook.

## Testing

- [x] All existing tests pass (`doit check`)
- [x] `pre-commit run uv-lock-check --all-files` passed on a clean repo
- [x] Functional drift test: hook fails with both uv's native message and the wrapped recovery message when `uv.lock` is out of sync

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

No new ADR required (no `needs-adr` label; this is a tooling/hook addition, not an architectural decision).
