### PR TITLE
chore: parallelize CI pytest and reduce matrix-wide job duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,12 @@ jobs:
         run: uv run pip-audit --skip-editable
 
       - name: Run tests with coverage
+        if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
         run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
+
+      - name: Run tests
+        if: "!(matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest')"
+        run: uv run pytest -v --ignore=tests/benchmarks/
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
 
       - name: Run tests with coverage
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
-        run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
+        run: uv run pytest -n auto --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
 
       - name: Run tests
         if: "!(matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest')"
-        run: uv run pytest -v --ignore=tests/benchmarks/
+        run: uv run pytest -n auto -v --ignore=tests/benchmarks/
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,24 +110,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Check code formatting
-        run: uv run ruff format --check src/ tests/
-
-      - name: Run linting
-        run: uv run ruff check src/ tests/
-
-      - name: Run type checking
-        run: uv run mypy src/
-
-      - name: Run security scan
-        run: uv run bandit -c pyproject.toml -r src/
-
-      - name: Run spell check
-        run: uv run codespell src/ tests/ docs/ README.md
-
-      - name: Run dependency audit
-        run: uv run pip-audit --skip-editable
-
       - name: Run tests with coverage
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
         run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
@@ -179,19 +161,68 @@ jobs:
       - name: Build documentation
         run: uv run doit docs_build
 
+  lint:
+    needs: setup
+    if: ${{ needs.setup.outputs.matrix != '{"include":[]}' }}
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ needs.setup.outputs.newest }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Check code formatting
+        run: uv run doit format_check
+
+      - name: Run linting
+        run: uv run doit lint
+
+      - name: Run type checking
+        run: uv run doit type_check
+
+      - name: Run security scan
+        run: uv run doit security
+
+      - name: Run spell check
+        run: uv run doit spell_check
+
+      - name: Run dependency audit
+        run: uv run doit audit
+
   ci-complete:
     if: always()
-    needs: [setup, test, docs]
+    needs: [setup, test, lint, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI status
         run: |
           setup_result="${{ needs.setup.result }}"
           test_result="${{ needs.test.result }}"
+          lint_result="${{ needs.lint.result }}"
           docs_result="${{ needs.docs.result }}"
 
           echo "Setup result: $setup_result"
           echo "Test result: $test_result"
+          echo "Lint result: $lint_result"
           echo "Docs result: $docs_result"
 
           # Setup must succeed
@@ -203,6 +234,12 @@ jobs:
           # Test must succeed or be skipped (skipped = no middle versions)
           if [[ "$test_result" != "success" && "$test_result" != "skipped" ]]; then
             echo "Test job failed"
+            exit 1
+          fi
+
+          # Lint must succeed or be skipped (skipped = no middle versions)
+          if [[ "$lint_result" != "success" && "$lint_result" != "skipped" ]]; then
+            echo "Lint job failed"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: uv run pip-audit --skip-editable
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v
+        run: uv run pytest --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Description

Four independent CI-only changes to `.github/workflows/ci.yml` that reduce
wall time and eliminate duplicated work across the OS × Python matrix.
No user-facing API, CLI, or configuration changes. No test-semantics changes.

Addresses #560

## Related Issue

Addresses #560

## Type of Change

- [x] Performance improvement

## Changes Made

Commits in lowest-risk-first order:

1. **Skip benchmark tests in regular CI** — adds `--ignore=tests/benchmarks/`
   to the CI pytest invocation. `pyproject.toml` already sets
   `--benchmark-disable`, but that only disables the timing loop; test bodies
   still executed. The dedicated `benchmark.yml` workflow still runs them with
   `--benchmark-enable --benchmark-only`, so no coverage is lost.

2. **Conditional `--cov` on the uploading cell only** — coverage flags
   (`--cov`, `--cov-report`) are now present only on the single matrix cell
   that uploads to Codecov (`ubuntu-latest` × newest Python). The other five
   cells ran pytest with full coverage collection and then discarded it
   (typically 30–50 % overhead, worst on Windows). Upload still occurs from
   the same cell as before; only the throwaway computation is removed.

3. **Extract platform-independent checks into a new `lint` job** — `ruff
   format`, `ruff check`, `mypy`, `bandit`, `codespell`, and `pip-audit` were
   running inside the test matrix (6 jobs = 3 OS × 2 Python) despite being
   platform-independent. They now run once in a single `lint` job on
   `ubuntu-latest` × newest Python, using the `doit` task wrappers
   (`doit format_check`, `doit lint`, `doit type_check`, `doit security`,
   `doit spell_check`, `doit audit`). The `ci-complete` fan-in job now gates
   on `lint` in addition to `test` and `docs`.

4. **Parallelize CI pytest with `-n auto`** — adds `-n auto` to all pytest
   invocations in the `test` job. `pytest-xdist>=3.5` is already a dev dep
   and local `doit test` already passes `-n auto`; CI was the only place not
   using it.

## Upstream template note

This is the upstream template repository. The `ci.yml` changes propagate to
all downstream consumers on their next template sync.

**Branch-protection consideration for downstream consumers:** if a downstream
repo currently requires the `test` job by name as a required check, the new
`lint` job should also be added to the required-checks list after syncing.
For this repository, the gating check is `ci-complete` (unchanged), so no
branch-protection update is needed here.

## Testing

- [x] All existing tests pass
- [x] `doit check` passes cleanly (all 4 commits passed `doit check` during
  implementation; final validation confirmed above)
- [x] CI-only change — no new unit tests required (no Python logic changed)

See the [implementation plan comment on issue #560](https://github.com/endavis/pyproject-template/issues/560)
for full per-commit detail and rationale.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] My changes generate no new warnings

## Additional Notes

- No documentation changes required (CI-only change, no user-facing behavior).
- No ADR required (`needs-adr` label is not present; no architectural-level
  decision — this is CI configuration optimization).
- Risk profiles differ by commit; the separate-commit structure preserves a
  clean revert path if any individual change misbehaves in CI.
