### PR TITLE
feat: add opt-in Claude Max usage helper for statusline

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -191,6 +191,13 @@ output="📁 ${dir}"
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 output+="\n${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
 
+# Opt-in: append Claude Max usage to the model/context line when CLAUDE_USAGE_STATUSLINE=1.
+# See docs/development/ai/statusline.md#opt-in-claude-max-usage-display
+if [[ -n "$CLAUDE_USAGE_STATUSLINE" ]]; then
+    usage=$(bash "$CLAUDE_PROJECT_DIR/tools/statusline/claude-usage.sh" 2>/dev/null)
+    [[ -n "$usage" && "$usage" != "?" ]] && output+="${C_GRAY} | ${usage}${C_RESET}"
+fi
+
 printf '%b\n' "$output"
 
 # Get user's last message (text only, not tool results, skip unhelpful messages)

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -85,6 +85,55 @@ output="📁 ${dir}"
 [[ -n "$branch" ]] && output+=" | 🔀 ${branch} ${git_status}"
 ```
 
+## Opt-In: Claude Max Usage Display
+
+For Claude Max subscribers, an optional helper at `tools/statusline/claude-usage.sh` displays
+weekly + 5-hour utilization. The default statusline runs the helper only when the
+`CLAUDE_USAGE_STATUSLINE` env var is set, so the default behavior is unchanged.
+
+> **Beta API**: This helper hits an undocumented OAuth endpoint (`/api/oauth/usage`)
+> gated by the `anthropic-beta: oauth-2025-04-20` header. Anthropic may change or remove
+> this endpoint without notice. When the official `claude --usage` flag ships
+> ([anthropics/claude-code#20399](https://github.com/anthropics/claude-code/issues/20399)),
+> prefer it.
+
+### Enable
+
+Set `CLAUDE_USAGE_STATUSLINE=1` in your shell environment:
+
+```bash
+# In ~/.zshrc, ~/.bashrc, or .envrc.local
+export CLAUDE_USAGE_STATUSLINE=1
+```
+
+Restart Claude Code. The statusline appends `5h:N% 7d:N%` to the model/context line.
+To disable temporarily: `unset CLAUDE_USAGE_STATUSLINE` and restart Claude Code.
+
+Example output (helper segment is the trailing portion of the third line):
+
+```
+📁 project | 🐍 .venv | Python: 3.12.12
+@username | 🔀 main (0 files uncommitted, synced 5m ago)
+Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens | 5h:25% 7d:6%
+```
+
+### Cache behavior
+
+Responses are cached at `${XDG_CACHE_HOME:-~/.cache}/claude-usage.json` for 60 seconds.
+Adjust `MAX_AGE` at the top of the script. To force a refresh: `rm ~/.cache/claude-usage.json`.
+
+### Helper requirements
+
+- Active Claude Code OAuth login (`${CLAUDE_CONFIG_DIR:-~/.claude}/.credentials.json`)
+- `curl` for HTTPS
+- `jq` (already required by base statusline)
+
+### Helper troubleshooting
+
+- **Outputs `?`**: missing/expired credentials, no network, beta endpoint changed schema, or
+  curl timeout (5s). Debug with `bash -x tools/statusline/claude-usage.sh`.
+- **Stale value**: cache has not expired. Delete the cache file or wait 60s.
+
 ## Requirements
 
 - `jq` - JSON processor (used for parsing Claude's input)

--- a/tests/test_statusline_claude_usage.py
+++ b/tests/test_statusline_claude_usage.py
@@ -1,0 +1,173 @@
+"""Tests for tools/statusline/claude-usage.sh opt-in helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "statusline" / "claude-usage.sh"
+STATUSLINE = REPO_ROOT / ".claude" / "statusline-command.sh"
+
+_STATUSLINE_INPUT = json.dumps(
+    {
+        "model": {"display_name": "Claude"},
+        "cwd": "/tmp",
+        "transcript_path": "",
+        "context_window": {"context_window_size": 200000},
+    }
+)
+
+
+def _make_env(tmp_path: Path) -> dict[str, str]:
+    """Build a minimal, network-safe environment for subprocess calls."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    creds_dir = tmp_path / "creds"
+    creds_dir.mkdir()
+    return {
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(cache_dir),
+        "CLAUDE_CONFIG_DIR": str(creds_dir),
+        "PATH": os.environ["PATH"],
+    }
+
+
+def test_script_exists_and_executable() -> None:
+    """Helper script must exist at the expected path and be executable."""
+    assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), f"Script not executable: {SCRIPT}"
+
+
+def test_script_syntax_valid() -> None:
+    """bash -n must report no syntax errors."""
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, f"Syntax error:\n{result.stderr}"
+
+
+def test_emits_fallback_when_credentials_missing(tmp_path: Path) -> None:
+    """No .credentials.json and no cache -> output is literal '?', exit 0."""
+    env = _make_env(tmp_path)
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_uses_fresh_cache_skips_network(tmp_path: Path) -> None:
+    """Pre-seeded fresh cache is parsed and returned without hitting the network."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {"five_hour": {"utilization": 42.7}, "seven_day": {"utilization": 7.3}}
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    # Ensure mtime is current (fresh cache)
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "5h:42% 7d:7%"
+
+
+def test_emits_fallback_on_malformed_cache(tmp_path: Path) -> None:
+    """Fresh cache that contains invalid JSON emits '?'."""
+    env = _make_env(tmp_path)
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    cache_file.write_text("not-json", encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+    # No credentials file either, so the script won't fall through to the network
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def test_emits_fallback_when_token_field_missing(tmp_path: Path) -> None:
+    """Credentials file present but missing claudeAiOauth.accessToken -> '?'."""
+    env = _make_env(tmp_path)
+    creds_file = Path(env["CLAUDE_CONFIG_DIR"]) / ".credentials.json"
+    creds_file.write_text(json.dumps({}), encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "?"
+
+
+def _seed_fresh_cache(env: dict[str, str]) -> None:
+    """Pre-write a parseable, fresh cache so the helper short-circuits curl."""
+    cache_file = Path(env["XDG_CACHE_HOME"]) / "claude-usage.json"
+    payload = {"five_hour": {"utilization": 42.7}, "seven_day": {"utilization": 7.3}}
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+    now = time.time()
+    os.utime(cache_file, (now, now))
+
+
+def test_statusline_invokes_helper_when_env_set(tmp_path: Path) -> None:
+    """With CLAUDE_USAGE_STATUSLINE=1 and a fresh cache, statusline shows usage."""
+    env = _make_env(tmp_path)
+    env["CLAUDE_USAGE_STATUSLINE"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+    _seed_fresh_cache(env)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE)],
+        input=_STATUSLINE_INPUT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "5h:42% 7d:7%" in result.stdout
+
+
+def test_statusline_skips_helper_when_env_unset(tmp_path: Path) -> None:
+    """Without CLAUDE_USAGE_STATUSLINE, statusline never invokes the helper."""
+    env = _make_env(tmp_path)
+    env["CLAUDE_PROJECT_DIR"] = str(REPO_ROOT)
+    # Fresh cache exists, so a bug that skipped the env check would still surface usage.
+    _seed_fresh_cache(env)
+
+    result = subprocess.run(
+        ["bash", str(STATUSLINE)],
+        input=_STATUSLINE_INPUT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "5h:" not in result.stdout
+    assert "7d:" not in result.stdout

--- a/tests/test_statusline_claude_usage.py
+++ b/tests/test_statusline_claude_usage.py
@@ -5,8 +5,19 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
+
+import pytest
+
+# The helper is a bash script targeting Linux/macOS; the Windows GitHub Actions
+# runner's `bash` resolves to wsl.exe (which has no installed distribution),
+# so subprocess invocations cannot exercise the real shell behavior.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash helper is Linux/macOS only; Windows runner has no usable bash",
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "tools" / "statusline" / "claude-usage.sh"

--- a/tools/statusline/claude-usage.sh
+++ b/tools/statusline/claude-usage.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Opt-in Claude Max usage helper for statusline display.
+# Outputs: 5h:N% 7d:N% on success, or literal ? on any failure.
+# Wire into .claude/statusline-command.sh manually — not called by default.
+#
+# Requirements: curl, jq, active Claude Code OAuth login
+# See: docs/development/ai/statusline.md#opt-in-claude-max-usage-display
+
+# Cache TTL in seconds
+MAX_AGE=60
+
+CREDS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CREDS_FILE="$CREDS_DIR/.credentials.json"
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/claude-usage.json"
+
+# Check cache freshness first — avoids a network call and a token read on every invocation
+if [[ -f "$CACHE" ]]; then
+    if stat -f %m "$CACHE" >/dev/null 2>&1; then
+        cache_mtime=$(stat -f %m "$CACHE" 2>/dev/null)
+    else
+        cache_mtime=$(stat -c %Y "$CACHE" 2>/dev/null)
+    fi
+    if [[ -n "$cache_mtime" ]] && [[ "$cache_mtime" =~ ^[0-9]+$ ]]; then
+        now=$(date +%s)
+        age=$((now - cache_mtime))
+        if [[ $age -lt $MAX_AGE ]]; then
+            # Try to parse the cached response
+            result=$(jq -r '"5h:\(.five_hour.utilization|floor)% 7d:\(.seven_day.utilization|floor)%"' "$CACHE" 2>/dev/null)
+            if [[ -n "$result" ]]; then
+                echo "$result"
+                exit 0
+            fi
+            # Cache parse failed — fall through to emit ? (no network attempt without a token)
+            echo "?"
+            exit 0
+        fi
+    fi
+fi
+
+# Read OAuth token from credentials
+token=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDS_FILE" 2>/dev/null)
+if [[ -z "$token" ]]; then
+    echo "?"
+    exit 0
+fi
+
+# Fetch fresh data
+response=$(curl -sf --max-time 5 \
+    -H "Authorization: Bearer $token" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+if [[ -z "$response" ]]; then
+    echo "?"
+    exit 0
+fi
+
+# Save to cache and parse
+echo "$response" > "$CACHE" 2>/dev/null
+result=$(jq -r '"5h:\(.five_hour.utilization|floor)% 7d:\(.seven_day.utilization|floor)%"' "$CACHE" 2>/dev/null)
+if [[ -n "$result" ]]; then
+    echo "$result"
+else
+    echo "?"
+fi


### PR DESCRIPTION
## Description

Adds an opt-in bash helper (`tools/statusline/claude-usage.sh`) that
queries the Anthropic OAuth usage API and appends `5h:N% 7d:N%` to the
statusline model/context line. The helper is disabled by default and only
runs when `CLAUDE_USAGE_STATUSLINE` is set.

Addresses #559

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `tools/statusline/claude-usage.sh` (new, executable) — reads OAuth
  token from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json`,
  caches API response at `${XDG_CACHE_HOME:-$HOME/.cache}/claude-usage.json`
  for 60 s, emits `5h:N% 7d:N%` on success or `?` on any failure.
  Uses an explicit `stat -f`/`stat -c` portability guard (the latent
  pattern in `statusline-command.sh:63` works only because `-f %m` exits
  non-zero on Linux; GNU `stat -f` prints to stdout regardless of exit
  code, so the stderr-redirect alone is not safe — the new helper
  disambiguates via `>/dev/null 2>&1`).
- `.claude/statusline-command.sh` — 7-line conditional block appends usage
  only when `CLAUDE_USAGE_STATUSLINE` is non-empty; no change to default
  output.
- `docs/development/ai/statusline.md` — new `## Opt-In: Claude Max Usage
  Display` section with beta-API caveat, enable instructions, cache info,
  requirements, and troubleshooting.
- `tests/test_statusline_claude_usage.py` — 8 pytest tests (see Testing).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Test cases in `tests/test_statusline_claude_usage.py`:

1. `test_script_exists_and_executable` — helper exists at expected path and is executable
2. `test_script_syntax_valid` — `bash -n` reports no syntax errors
3. `test_emits_fallback_when_credentials_missing` — no creds, no cache → `?`, exit 0
4. `test_uses_fresh_cache_skips_network` — fresh pre-seeded cache returns parsed values without network
5. `test_emits_fallback_on_malformed_cache` — fresh cache with invalid JSON → `?`
6. `test_emits_fallback_when_token_field_missing` — creds file present but no `claudeAiOauth.accessToken` → `?`
7. `test_statusline_invokes_helper_when_env_set` — `CLAUDE_USAGE_STATUSLINE=1` + fresh cache → usage in statusline output
8. `test_statusline_skips_helper_when_env_unset` — without env var, usage strings never appear in output

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

**Opt-in / Beta API caveat:** The helper calls
`https://api.anthropic.com/api/oauth/usage` with the
`anthropic-beta: oauth-2025-04-20` header. This is an undocumented beta
endpoint. It may change or be removed without notice. The feature is
deliberately opt-in (`CLAUDE_USAGE_STATUSLINE` unset by default) so that
a future API break silently becomes a no-op for all users who haven't
opted in, and shows `?` for those who have.

**No mkdocs.yml change needed:** `docs/development/ai/statusline.md` was
already an unlisted page (not in nav). This PR extends the existing file
rather than adding a new one.

**No ADR needed:** Issue #559 has no `needs-adr` label; this adds
opt-in tooling, not an architectural pattern change.
