### PR TITLE
docs: add AI agent guide for the LSP tool and diagnostic noise

### DIFF
--- a/.claude/lsp-setup.md
+++ b/.claude/lsp-setup.md
@@ -1,208 +1,71 @@
-# Claude LSP Setup Guide
+# Claude LSP Setup
 
-This guide explains how to set up Language Server Protocol (LSP) support for Claude Code, enabling fast code navigation and intelligent code understanding.
+This project ships LSP support for Claude Code via the `pyright-lsp@claude-plugins-official` plugin. The LSP server (pyright) gives AI agents go-to-definition, find-references, hover, and workspace symbol search.
 
-## ⚠️ Known Issues
-
-**LSP requests currently hang and do not return responses.** The pyright language server starts successfully but does not respond to LSP protocol requests from Claude Code. This appears to be a bug in the Claude Code LSP integration (released December 2025) or the pyright-lsp plugin.
-
-- ✅ Pyright CLI works perfectly (tested and confirmed)
-- ✅ Configuration is correct and validated
-- ✅ Language server starts successfully
-- ❌ LSP requests hang indefinitely (e.g., `textDocument/definition`)
-
-**Status:** Configuration is ready for when this issue is resolved. For now, use traditional file reading/searching.
-
-If you find that LSP works for you, please report your setup!
-
-## What is LSP?
-
-LSP (Language Server Protocol) provides Claude with semantic code understanding:
-- **Jump to definitions** - Navigate directly to function/class definitions
-- **Find references** - See where symbols are used across the codebase
-- **Type information** - Get instant type hints and signatures
-- **Error detection** - See type errors and diagnostics
-
-With LSP, Claude can navigate code in ~50ms instead of ~45 seconds using traditional text search.
+This file covers **installation only**. For what the `LSP` tool actually exposes, where the noisy stale "errors" after edits come from, and the two opt-ins an agent can flip on itself, see [`docs/development/ai/lsp-tool.md`](../docs/development/ai/lsp-tool.md).
 
 ## Prerequisites
 
-- Claude Code version 2.0.74 or later
-- Python 3.12+ environment
-- This project installed with dev dependencies
+- Claude Code 2.0.74 or later (LSP is enabled by default in 2.0.74+; older versions need `ENABLE_LSP_TOOL=1`)
+- Python 3.12+
+- This project installed with dev dependencies (`uv sync`) — pyright comes in via the dev group
 
-## Installation Steps
+## Install Steps
 
-### 1. Enable LSP Tool
+### 1. Install the plugin
 
-**Option A: Using .envrc.local (Recommended)**
-
-This project uses direnv for environment management:
-
-```bash
-# Copy the example file if you haven't already
-cp .envrc.local.example .envrc.local
-
-# Uncomment the ENABLE_LSP_TOOL line in .envrc.local
-# Change: # export ENABLE_LSP_TOOL=1
-# To:     export ENABLE_LSP_TOOL=1
-
-# direnv will automatically load it when you cd into the project
-```
-
-**Option B: Global Shell Profile**
-
-Alternatively, add this to your shell profile (`~/.bashrc`, `~/.zshrc`, or `~/.profile`):
-
-```bash
-export ENABLE_LSP_TOOL=1
-```
-
-Then reload your shell:
-
-```bash
-source ~/.bashrc  # or ~/.zshrc
-```
-
-### 2. Install Pyright LSP Plugin
-
-In Claude Code, run:
+In Claude Code:
 
 ```
 /plugin install pyright-lsp@claude-plugins-official
 ```
 
-### 3. Install Pyright Language Server
+### 2. Confirm `pyright-langserver` is on PATH
 
-Choose one installation method:
-
-**Via pip (recommended for Python projects):**
-```bash
-pip install pyright
-```
-
-**Via npm:**
-```bash
-npm install -g pyright
-```
-
-**Via Homebrew (macOS):**
-```bash
-brew install pyright
-```
-
-### 4. Verify Installation
-
-Check that pyright is in your PATH:
+`uv sync` installs pyright into `.venv/bin/`. Verify:
 
 ```bash
-pyright --version
+uv run pyright --version
+# → pyright 1.1.x
 ```
 
-Expected output:
+If running outside `uv run`, make sure the venv is on PATH (this project uses direnv).
+
+### 3. (Optional, Claude Code < 2.0.74) Enable the LSP tool
+
+Older Claude Code releases gate the LSP tool behind an env var. Add to `.envrc.local`:
+
+```bash
+export ENABLE_LSP_TOOL=1
 ```
-pyright 1.1.x
-```
+
+Or your shell profile. **Skip this step on 2.0.74+** — the tool is enabled by default.
 
 ## Configuration
 
-This project is already configured for LSP via `pyproject.toml`:
+Already done — `[tool.pyright]` in `pyproject.toml` sets `include`, `exclude`, `pythonVersion`, and the venv path. No additional setup needed.
 
-```toml
-[tool.pyright]
-include = ["src", "tests", "*.py", "tools", ".github"]
-exclude = ["**/__pycache__", "**/.venv", "**/tmp", ...]
-pythonVersion = "3.12"
-typeCheckingMode = "basic"
+## Verifying It Works
+
+Ask an agent to use the `LSP` tool against a known symbol:
+
+```
+Use the LSP tool's goToDefinition on the `greet` symbol in src/.
 ```
 
-No additional configuration needed!
-
-## Testing LSP
-
-Ask Claude to test LSP functionality:
-
-1. **Jump to definition:**
-   ```
-   Jump to the definition of the greet function
-   ```
-
-2. **Find references:**
-   ```
-   Find all references to the __version__ variable
-   ```
-
-3. **Type information:**
-   ```
-   What's the return type of the greet function?
-   ```
-
-If LSP is working, Claude will provide instant, accurate responses with file paths and line numbers.
+A working setup returns the file path and line number near-instantly. A broken setup falls back to `Grep`.
 
 ## Troubleshooting
 
-### "No LSP server available"
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `No LSP server available` | `pyright-langserver` not on PATH | `uv sync`; or `pip install pyright`; or `npm install -g pyright` |
+| `Executable not found in $PATH` | Plugin installed but binary missing | Same as above |
+| Plugin not loading at all | Plugin not installed at user scope | `/plugin install pyright-lsp@claude-plugins-official` then restart Claude Code |
+| Noisy or stale "errors" after every edit | Pyright diagnostic side-channel staleness — working as designed | See [`docs/development/ai/lsp-tool.md`](../docs/development/ai/lsp-tool.md) for the two documented opt-ins |
 
-**Cause:** Pyright binary not found in PATH
+## Related
 
-**Solution:**
-```bash
-# Check if pyright is installed
-which pyright
-
-# If not found, install it
-pip install pyright
-```
-
-### "Executable not found in $PATH"
-
-**Cause:** Pyright language server not installed
-
-**Solution:** Follow step 3 above to install the pyright binary
-
-### LSP not responding
-
-**Cause:** Plugin not installed or ENABLE_LSP_TOOL not set
-
-**Solution:**
-1. Verify environment variable: `echo $ENABLE_LSP_TOOL` (should output "1")
-2. Reinstall plugin: `/plugin install pyright-lsp@claude-plugins-official`
-3. Restart Claude Code
-
-### "pyright-langserver not found"
-
-**Cause:** Some installations use different binary names
-
-**Solution:**
-```bash
-# If installed via npm, it might be:
-which pyright-langserver
-
-# Or try reinstalling via pip
-pip install --force-reinstall pyright
-```
-
-## Performance Benefits
-
-Without LSP:
-- Code navigation: ~45 seconds (requires reading multiple files)
-- High token usage for exploration
-
-With LSP:
-- Code navigation: ~50ms (direct symbol lookup)
-- Minimal token usage for navigation
-- Better type understanding
-- Faster development iterations
-
-## Related Documentation
-
-- [AI_SETUP.md](../docs/development/AI_SETUP.md) - Complete AI development setup
+- [LSP Tool and Diagnostic Noise](../docs/development/ai/lsp-tool.md) — what agents see, why diagnostics arrive stale, and how to opt out
+- [AI Setup](../docs/development/AI_SETUP.md) — broader AI agent setup for this template
 - [Pyright Documentation](https://microsoft.github.io/pyright/)
-- [Claude Code Plugin Docs](https://code.claude.com/docs/en/discover-plugins)
-
-## Need Help?
-
-If you encounter issues:
-1. Check the troubleshooting section above
-2. Verify all prerequisites are met
-3. Open an issue at: https://github.com/username/package_name/issues

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -49,6 +49,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
 - [GitHub Repository Settings](development/github-repository-settings.md) - Complete reference for all GitHub repository settings the template expects
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
+- [LSP Tool and Diagnostic Noise](development/ai/lsp-tool.md) - What the LSP tool gives an AI agent, why pyright diagnostics arrive stale, and the two opt-outs agents can flip on themselves
 - [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more
 - [Production Deployment Guide](deployment/production.md) - Comprehensive guide for deploying Python applications to production
 - [Python Project Coding Standards](development/coding-standards.md) - Guidelines for exceptions, typing, structure, testing, and documentation
@@ -70,6 +71,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [Auto-Checkpoint and Session-Restore Hooks](development/ai/auto-checkpoint-hook.md) - PreCompact and SessionStart hooks that preserve context across autocompact events
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [First 5 Minutes with an AI Agent](development/ai/first-5-minutes.md) - Narrative walkthrough of the AI agent workflow from issue to merge
+- [LSP Tool and Diagnostic Noise](development/ai/lsp-tool.md) - What the LSP tool gives an AI agent, why pyright diagnostics arrive stale, and the two opt-outs agents can flip on themselves
 - [Ruff Auto-Fix on Edit Hook](development/ai/ruff-fix-hook.md) - PostToolUse hook that runs ruff --fix on edited Python files
 - [Slash Commands and Workflows](development/ai/slash-commands.md) - Reference for the slash commands and dual-agent workflow this template ships with
 - [Tooling Roles and Architectural Boundaries](development/tooling-roles.md) - What each tool is for, who uses it, and where runtime code ends and dev tooling begins
@@ -119,6 +121,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [install_tools Framework](development/install-tools-framework.md)
 - [Installation Guide](getting-started/installation.md) - How to install and set up your project
 - [Keeping Up to Date](template/updates.md) - Stay in sync with improvements to the pyproject-template
+- [LSP Tool and Diagnostic Noise](development/ai/lsp-tool.md) - What the LSP tool gives an AI agent, why pyright diagnostics arrive stale, and the two opt-outs agents can flip on themselves
 - [Migration Guide](template/migration.md) - Migrate existing Python projects to use this template
 - [New Project Setup](template/new-project.md) - Create a new Python project from this template
 - [Optional Extensions](development/extensions.md) - Additional tools and extensions for testing, security, and more

--- a/docs/development/ai/lsp-tool.md
+++ b/docs/development/ai/lsp-tool.md
@@ -1,0 +1,116 @@
+---
+title: LSP Tool and Diagnostic Noise
+description: What the LSP tool gives an AI agent, why pyright diagnostics arrive stale, and the two opt-outs agents can flip on themselves
+audience:
+  - contributors
+  - ai-agents
+tags:
+  - ai
+  - lsp
+  - pyright
+---
+
+# LSP Tool and Diagnostic Noise
+
+Claude Code (v2.0.74+) ships an `LSP` tool backed by the `pyright-lsp@claude-plugins-official` plugin. The tool itself is a navigation aid; the plugin layered on top of it is also responsible for a *separate* side channel that auto-injects pyright diagnostics into conversation context after edits. The two flows have very different cost profiles, and conflating them is what produces the "agent keeps chasing errors that aren't really errors" pattern.
+
+## What the `LSP` Tool Actually Exposes
+
+The `LSP` tool surfaces nine operations. **None of them return diagnostics.**
+
+| Operation | Use |
+|---|---|
+| `goToDefinition` | Jump to the file/line where a symbol is defined |
+| `findReferences` | Find every reference to a symbol across the workspace |
+| `hover` | Get the type signature and docstring at a position |
+| `documentSymbol` | List every symbol declared in a file |
+| `workspaceSymbol` | Search the entire workspace by symbol name |
+| `goToImplementation` | Jump from an interface/abstract member to its implementations |
+| `prepareCallHierarchy` | Anchor a call-hierarchy query at a position |
+| `incomingCalls` | List functions that call the anchored target |
+| `outgoingCalls` | List functions called by the anchored target |
+
+Every one of these answers from pyright's symbol index in milliseconds. The index is updated lazily but always responds with whatever it currently has. **Navigation is not where the slowness comes from.**
+
+## Where the Slow / Stale Errors Come From
+
+Diagnostics (type errors, lint warnings) are *not* an `LSP` tool operation. They reach the model through a separate side channel: the pyright-lsp plugin pushes pyright's `publishDiagnostics` output into conversation context after `Edit`/`Write` tool calls. This is the source of the noise:
+
+- **Stale diagnostics** — pyright re-analyzes the file (and its dependents) after every change. On a non-trivial graph this takes 1–4 seconds. The diagnostic snapshot is taken before re-analysis settles, so the model sees errors against line numbers that no longer exist or symbols that were just renamed. Tracked upstream as [anthropics/claude-code#17979](https://github.com/anthropics/claude-code/issues/17979) and [#21297](https://github.com/anthropics/claude-code/issues/21297).
+- **Hint-level noise promoted to errors** — pyright emits `DiagnosticTag.Unnecessary` (e.g., a never-used parameter) at *hint* severity. The plugin currently surfaces these as if they were diagnostics worth acting on. Tracked as [anthropics/claude-code#26634](https://github.com/anthropics/claude-code/issues/26634).
+
+mypy via `doit check` is the authoritative type checker for this repo. Pyright's role is purely to back the LSP tool — its diagnostics are advisory, and they are cheap to ignore by default.
+
+## Default Stance
+
+LSP stays on. The navigation operations are valuable, and the diagnostic noise is something an agent can tune out once it knows the shape of the problem (symptom: errors against line numbers that don't match the just-edited file; cure: re-read the file or run `doit check` rather than chase the diagnostic).
+
+If an agent (or the human running it) wants to silence the noise more aggressively, two opt-outs are below. Pick one or the other — running both is redundant.
+
+## Opt-Out A: Make Diagnostics Wait Until Pyright Catches Up
+
+Add a `PostToolUse` sleep hook to `.claude/settings.local.json` (gitignored, per-clone):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sleep 3",
+            "statusMessage": "Letting pyright catch up to prevent stale diagnostics"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+| | |
+|---|---|
+| **What it does** | Delays the next tool call by 3 seconds, giving pyright time to settle before the diagnostic snapshot fires. |
+| **Keeps diagnostics?** | Yes — the goal is fresher diagnostics, not fewer. |
+| **Cost** | ~3 s of pure wait per `Edit`/`Write`/`MultiEdit`. A 30-edit session pays ~90 s of dead time. |
+| **Caveats** | 1 s is often not enough on real codebases; 3 s is a safer floor but still won't survive a cold cache or a large refactor. The hook fires on every edit regardless of whether diagnostics would have been stale. Whether Claude Code reads diagnostics synchronously with PostToolUse return is undocumented — the hook is a community-known workaround, not a guaranteed fix. |
+| **Pick this when** | You actively use pyright's diagnostics and just want them to be correct. |
+
+## Opt-Out B: Turn Off Pyright Diagnostics Entirely
+
+Edit `pyproject.toml`:
+
+```toml
+[tool.pyright]
+typeCheckingMode = "off"   # was "basic"
+```
+
+| | |
+|---|---|
+| **What it does** | Pyright still indexes the workspace (so navigation works) but emits no type-check diagnostics, so there is nothing for the side channel to push into context. |
+| **Keeps diagnostics?** | No — pyright's diagnostics go silent. mypy via `doit check` remains authoritative. |
+| **Cost** | Zero runtime overhead. |
+| **Caveats** | You lose pyright's interactive view of type errors. If you were using pyright as a second opinion against mypy, you'd lose that signal until you flip it back. |
+| **Pick this when** | mypy via `doit check` is already your source of truth and pyright's running commentary is noise you'd rather not have. |
+
+## Future Direction
+
+Both [pyrefly (Meta)](https://pyrefly.org/) and [ty (Astral)](https://astral.sh/blog/ty) ship full LSP implementations backed by Rust analyzers, with re-analysis times measured in milliseconds rather than seconds. Either would collapse the staleness window enough that neither opt-out above would be necessary. Both are still beta as of May 2026; pyrefly is further along on Python typing conformance, ty is closer aligned with this repo's `uv`/`ruff` toolchain.
+
+A future migration would replace the `pyright-lsp@claude-plugins-official` plugin with a local plugin pointing `lspServers.<name>.command` at `pyrefly lsp` or `ty server`. No such plugin is in the official Claude Code marketplace yet; a local one is straightforward to author when the time is right.
+
+## Files
+
+| File | Description |
+|---|---|
+| [`.claude/lsp-setup.md`](../../../.claude/lsp-setup.md) | Earlier pyright-lsp installation notes (now partially superseded — LSP requests no longer hang) |
+| [`pyproject.toml`](../../../pyproject.toml) | `[tool.pyright]` block; flip `typeCheckingMode` here for opt-out B |
+| `.claude/settings.local.json` | Per-clone Claude settings; wire opt-out A here |
+
+## Related
+
+- [Ruff Auto-Fix on Edit Hook](ruff-fix-hook.md) — sibling `PostToolUse` hook that runs ruff `--fix` on edited Python files
+- [AI Command Blocking](command-blocking.md) — `PreToolUse` hook reference
+- [AI Architectural Conventions](architectural-conventions.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
           - Architectural Conventions: development/ai/architectural-conventions.md
           - Enforcement Principles: development/ai/enforcement-principles.md
           - Command Blocking: development/ai/command-blocking.md
+          - LSP Tool and Diagnostics: development/ai/lsp-tool.md
           - Token-Efficiency Add-Ons: development/ai/token-efficiency-add-ons.md
   - Deployment:
       - Development: deployment/development.md


### PR DESCRIPTION
## Description

Adds `docs/development/ai/lsp-tool.md` — a guide for AI agents working in this template explaining what the `LSP` tool actually exposes (nine navigation operations, no diagnostics), where the noisy stale "errors" actually come from (a separate side channel that auto-injects pyright diagnostics into context after `Edit`/`Write`), and two opt-ins an agent can flip on itself if it wants quieter sessions:

1. A `PostToolUse` sleep hook on `Edit`/`Write`/`MultiEdit` that gives pyright time to settle before the diagnostic snapshot fires (keeps diagnostics, costs ~3s per edit).
2. `[tool.pyright] typeCheckingMode = "off"` in `pyproject.toml` (drops pyright diagnostics entirely; navigation still works; mypy via `doit check` remains the authoritative type checker).

Default stance is unchanged: LSP stays on. The doc exists so agents can self-select an opt-out if they're getting bitten by the staleness pattern.

Cross-links the upstream Claude Code issues documenting the underlying behavior: [anthropics/claude-code#17979](https://github.com/anthropics/claude-code/issues/17979) and [#21297](https://github.com/anthropics/claude-code/issues/21297) (stale diagnostics after file changes), [#26634](https://github.com/anthropics/claude-code/issues/26634) (hint-level "Unnecessary" tags promoted to errors).

Also notes pyrefly and ty as the likely future replacement for pyright as the LSP backend, without committing to a switch.

## Related Issue

Addresses #566

## Type of Change

- [x] Documentation update

## Changes Made

- New: `docs/development/ai/lsp-tool.md`
- `mkdocs.yml` — adds the doc under the `AI` nav section
- `docs/TABLE_OF_CONTENTS.md` — auto-regenerated by `python tools/generate_doc_toc.py`

## Testing

- [x] All existing tests pass (`doit check` — format, lint, type-check, security, spell-check, test)
- [ ] Added new tests for new functionality (n/a — docs only)
- [x] Manually tested the changes (`doit docs_build` succeeds; the two link warnings on `lsp-tool.md` follow the same cross-tree-link pattern that `ruff-fix-hook.md` and `command-blocking.md` already use — no new warning class)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a — docs only)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (n/a — docs-only addition; no behavior change)
- [x] My changes generate no new warnings

## Additional Notes

`.claude/lsp-setup.md` (project-scoped Claude config note, separate from the docs tree) is partially superseded by this guide — it still claims "LSP requests currently hang and do not return responses," which is no longer the failure mode. Updating that file was not in scope for this PR; worth a follow-up.