### PR TITLE
feat: add -h short alias for --help in example CLI

### DIFF
--- a/src/package_name/cli.py
+++ b/src/package_name/cli.py
@@ -22,7 +22,7 @@ import click
 from package_name.core import greet as _greet
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(package_name="package_name")
 def main() -> None:
     """package_name command-line interface."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,15 @@ def test_top_level_help() -> None:
     assert "greet" in result.output
 
 
+def test_top_level_help_short_option() -> None:
+    """-h is the short alias for --help on the top-level group."""
+    runner = CliRunner()
+    long_result = runner.invoke(main, ["--help"])
+    short_result = runner.invoke(main, ["-h"])
+    assert short_result.exit_code == 0
+    assert short_result.output == long_result.output
+
+
 def test_greet_help() -> None:
     """greet --help documents the --name option without executing the command."""
     runner = CliRunner()
@@ -45,6 +54,15 @@ def test_greet_help() -> None:
     assert result.exit_code == 0
     assert "--name" in result.output
     assert "Hello, Python!" not in result.output
+
+
+def test_greet_help_short_option() -> None:
+    """-h is the short alias for --help on subcommands."""
+    runner = CliRunner()
+    long_result = runner.invoke(main, ["greet", "--help"])
+    short_result = runner.invoke(main, ["greet", "-h"])
+    assert short_result.exit_code == 0
+    assert short_result.output == long_result.output
 
 
 def test_version_option() -> None:


### PR DESCRIPTION
## Description

Set `help_option_names=["-h", "--help"]` on the top-level Click group so the
example CLI accepts the `-h` short flag in addition to `--help`. Click
propagates this setting to subcommands automatically, so both the group and
`greet` honor it. This eliminates a small papercut for users typing the
near-universal `-h` convention (git, gh, curl, ls, etc.) and improves the
template that downstream projects copy.

## Related Issue

Addresses #568

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `src/package_name/cli.py`: added `context_settings={"help_option_names": ["-h", "--help"]}` to the top-level `@click.group(...)` decorator.
- `tests/test_cli.py`: added `test_top_level_help_short_option` and `test_greet_help_short_option`, each asserting `-h` produces identical output to `--help`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

Documentation and CHANGELOG.md were not updated — the change is internal to
the example CLI scaffold and not user-visible behavior of the template
itself. Happy to add CHANGELOG entry if reviewer prefers.
