### PR TITLE
feat: include pip-audit in 'doit check' so dependency CVEs fail locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ doit coverage      # Run tests with coverage report
 doit format        # Format code with ruff
 doit lint          # Run linting
 doit type_check    # Run type checking with mypy
-doit check         # Run ALL checks (format, lint, type check, test)
+doit check         # Run ALL checks (format, lint, type check, security, audit, spell, test)
 
 # Security
 doit security      # Run security scan with bandit

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -98,7 +98,7 @@ uv run doit lint
 # Run type checking
 uv run doit type_check
 
-# Run all checks (format, lint, type check, test)
+# Run all checks (format, lint, type check, security, audit, spell, test)
 uv run doit check
 ```
 

--- a/tests/template/test_doit_quality.py
+++ b/tests/template/test_doit_quality.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from tools.doit.quality import (
+    task_check,
     task_format,
     task_format_check,
     task_lint,
@@ -103,6 +104,28 @@ class TestTaskFormatCheck:
         assert isinstance(action, str)
         assert "bootstrap.py" not in action
         assert "ruff format --check" in action
+
+
+class TestTaskCheck:
+    """``task_check`` aggregates the pre-PR check tasks via ``task_dep``."""
+
+    def test_task_dep_includes_audit(self) -> None:
+        """``audit`` must run as part of ``doit check`` so dep CVEs fail locally."""
+        task = task_check()
+        assert "audit" in task["task_dep"]
+
+    def test_task_dep_covers_full_check_set(self) -> None:
+        """``task_check`` must depend on every pre-PR quality/security task."""
+        task = task_check()
+        assert set(task["task_dep"]) == {
+            "format_check",
+            "lint",
+            "type_check",
+            "security",
+            "audit",
+            "spell_check",
+            "test",
+        }
 
 
 class TestTaskTypeCheck:

--- a/tools/doit/quality.py
+++ b/tools/doit/quality.py
@@ -73,9 +73,17 @@ def task_maintainability() -> dict[str, Any]:
 
 
 def task_check() -> dict[str, Any]:
-    """Run all checks (format, lint, type check, security, spelling, test)."""
+    """Run all checks (format, lint, type check, security, audit, spelling, test)."""
     return {
         "actions": [success_message],
-        "task_dep": ["format_check", "lint", "type_check", "security", "spell_check", "test"],
+        "task_dep": [
+            "format_check",
+            "lint",
+            "type_check",
+            "security",
+            "audit",
+            "spell_check",
+            "test",
+        ],
         "title": title_with_actions,
     }


### PR DESCRIPTION
## Description

Adds `audit` to `task_check`'s `task_dep` so `pip-audit` runs as part of `doit check`. Dependency CVEs now surface during local pre-PR checks instead of only in CI after pushing.

`doit audit` already exists and uses `install_check_or_skip`, so it skips gracefully when the `security` extras aren't installed — same pattern as the existing `security` (bandit) and `spell_check` (codespell) deps.

## Related Issue

Addresses #570

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `tools/doit/quality.py` — add `audit` to `task_check.task_dep`; update docstring.
- `tests/template/test_doit_quality.py` — add `TestTaskCheck` covering both `audit` membership and the full expected dep set.
- `README.md`, `docs/usage/basics.md` — refresh the `doit check` summary line to list security/audit/spell.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` ran end-to-end including the new `audit` step; `pip-audit` reported "No known vulnerabilities found".

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG entry intentionally omitted — this is a developer-tooling change (no user-visible API/CLI surface), consistent with prior `doit check` adjustments.

## Additional Notes

No new dependency added; `pip-audit` is already part of the optional `security` extras.
