### PR TITLE
refactor: remove piped-truncator block from bash-ban-raw-tools hook

### DIFF
--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -199,7 +199,6 @@ raw output bypasses every other token-efficiency control and lands in context un
 **What it blocks:**
 
 - Leading banned commands: `cat`, `head`, `tail`, `find`, `grep`, `rg`, `wc`
-- Piped truncators: `... | head`, `... | tail` (regardless of arguments)
 
 Each block message names the offending command, suggests the native replacement, and reminds the
 agent about the escape hatch.

--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -109,6 +109,26 @@ def test_banned_word_as_non_leading_non_pipe_token_is_allowed(
     assert exc_info.value.code == 0
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls | head",
+        "ls | tail -100",
+        "cmd | head -n 5",
+    ],
+)
+def test_piped_truncator_is_allowed(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Piped truncators (``... | head``, ``... | tail``) are allowed — no native replacement."""
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0
+
+
 # ---------------------------------------------------------------------------
 # Block: banned leading commands
 # ---------------------------------------------------------------------------
@@ -132,31 +152,6 @@ def test_banned_leading_command_exits_2(
     command: str,
 ) -> None:
     """Each banned leading command is blocked with exit code 2."""
-    _set_stdin(monkeypatch, _bash_payload(command))
-    with pytest.raises(SystemExit) as exc_info:
-        sys.exit(hook.main())
-    assert exc_info.value.code == 2
-
-
-# ---------------------------------------------------------------------------
-# Block: piped truncators
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "ls | head",
-        "ls | tail -100",
-        "cmd | head -n 5",
-    ],
-)
-def test_piped_truncator_exits_2(
-    hook: types.ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-    command: str,
-) -> None:
-    """Piped truncators (``... | head``, ``... | tail``) are blocked with exit code 2."""
     _set_stdin(monkeypatch, _bash_payload(command))
     with pytest.raises(SystemExit) as exc_info:
         sys.exit(hook.main())

--- a/tools/hooks/ai/bash-ban-raw-tools.py
+++ b/tools/hooks/ai/bash-ban-raw-tools.py
@@ -7,7 +7,6 @@ should be using native file tools for instead (Read, Grep, Glob, Edit, Write).
 
 Blocks:
   - Leading banned commands: cat, head, tail, find, grep, rg, wc
-  - Piped truncators: ... | head, ... | tail (regardless of args)
 
 Escape hatch:
   Touch /tmp/bash-raw-unlock (or the configured UNLOCK_FILE) to allow banned
@@ -31,9 +30,6 @@ from pathlib import Path
 
 # Commands that AI agents should never use via Bash when native tools are available
 BANNED_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "find", "grep", "rg", "wc"})
-
-# Commands that are banned when they appear after a pipe (regardless of arguments)
-PIPE_TRUNCATORS: frozenset[str] = frozenset({"head", "tail"})
 
 # Escape hatch: touch this file to allow banned commands for UNLOCK_WINDOW_SECONDS
 UNLOCK_FILE: str = "/tmp/bash-raw-unlock"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
@@ -86,18 +82,6 @@ def find_banned_leading(tokens: list[str]) -> str | None:
     return None
 
 
-def find_banned_pipe(tokens: list[str]) -> str | None:
-    """
-    Scan for a pipe token immediately followed by a PIPE_TRUNCATOR.
-
-    Returns the truncator name if found, else None.
-    """
-    for i, token in enumerate(tokens):
-        if token == "|" and i + 1 < len(tokens) and tokens[i + 1] in PIPE_TRUNCATORS:  # nosec B105 - "|" is the shell pipe character, not a credential.
-            return tokens[i + 1]
-    return None
-
-
 def _build_reason(offending: str) -> str:
     """Build a human-readable block reason for the given offending command."""
     suggestion = _SUGGESTIONS.get(offending, "a native tool")
@@ -139,12 +123,6 @@ def main() -> int:
 
     # Check for banned leading command
     offending = find_banned_leading(tokens)
-    if offending is not None:
-        print(_build_reason(offending), file=sys.stderr)
-        return 2
-
-    # Check for banned pipe-truncator
-    offending = find_banned_pipe(tokens)
     if offending is not None:
         print(_build_reason(offending), file=sys.stderr)
         return 2


### PR DESCRIPTION
## Description

Removes the piped-truncator block from `bash-ban-raw-tools.py`. The hook was
blocking `head` and `tail` when they appeared after a pipe operator (e.g.
`grep foo | head -20`), but that use is legitimate: the AI agent is not
*reading* a file via `head`/`tail` (which the `Read` tool handles), it is
truncating a stream that another command already produced. Stream-mode
`head`/`tail` consumes no extra I/O, provides no native-tool replacement, and
frustrates legitimate pipeline patterns.

Direct/leading use of `head` and `tail` (file-read mode) remains banned, as
the `Read` tool is the correct replacement for that pattern.

This is a follow-up correction to the hook introduced in #515.

Addresses #578

## Type of Change

- [x] Code refactoring

## Changes Made

- `tools/hooks/ai/bash-ban-raw-tools.py` — removed `PIPE_TRUNCATORS` constant,
  `find_banned_pipe()` function, the pipe-truncator block in `main()`, and the
  matching docstring bullet
- `tests/test_bash_ban_raw_tools.py` — converted `test_piped_truncator_exits_2`
  (expected exit 2) to `test_piped_truncator_is_allowed` (expected exit 0) for
  the same three commands; removed the now-empty "Block: piped truncators"
  section header
- `docs/development/ai/token-efficiency-add-ons.md` — removed the "Piped
  truncators" bullet from the "What it blocks" section

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passed (format, lint, type-check, security, audit, spell, tests).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

No ADR is needed: this is a behavior correction to an existing opt-in hook,
not an architectural decision.

## Additional Notes

The distinction the previous code missed: `head`/`tail` have two modes.

- **File mode** (`head somefile`): AI agent is reading a file. The `Read` tool
  is a better replacement. Still banned.
- **Stream mode** (`some-cmd | head -20`): AI agent is truncating a stream it
  did not produce. No native-tool replacement exists. Now allowed.
