### PR TITLE
feat: split usage-segment coloring into per-field semantic colors

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -8,6 +8,9 @@ COLOR="blue"
 C_RESET='\033[0m'
 C_GRAY='\033[38;5;245m'  # explicit gray for default text
 C_BAR_EMPTY='\033[38;5;238m'
+C_DIM="$C_BAR_EMPTY"  # semantic alias for dim separators (e.g., the `@` in usage segment)
+C_PCT='\033[38;5;71m'  # green: percentage values in usage segment (theme-independent)
+C_TIME='\033[38;5;136m'  # gold: reset-time values in usage segment (theme-independent)
 case "$COLOR" in
     orange)   C_ACCENT='\033[38;5;173m' ;;
     blue)     C_ACCENT='\033[38;5;74m' ;;
@@ -196,10 +199,21 @@ output+="\n${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
 if [[ -n "$CLAUDE_USAGE_STATUSLINE" ]]; then
     usage=$(bash "$CLAUDE_PROJECT_DIR/tools/statusline/claude-usage.sh" 2>/dev/null)
     if [[ -n "$usage" && "$usage" != "?" ]]; then
-        # Accent the bucket labels; insert middle-dot separator between gauges.
-        colored="${usage//5h:/${C_ACCENT}5h:${C_GRAY}}"
-        colored="${colored// wk:/ · ${C_ACCENT}wk:${C_GRAY}}"
-        output+="${C_GRAY} | ${colored}${C_RESET}"
+        # Parse the helper's plain-text output (5h:N%@HHMM wk:N%@aaa-HHMM) and
+        # rebuild it with per-field colors: labels accent, percent green,
+        # `@` dim, time gold. Middle-dot separator between gauges.
+        if [[ "$usage" =~ ^5h:([0-9]+)%@([^ ]+)\ wk:([0-9]+)%@(.+)$ ]]; then
+            fh_pct="${BASH_REMATCH[1]}"
+            fh_time="${BASH_REMATCH[2]}"
+            wk_pct="${BASH_REMATCH[3]}"
+            wk_time="${BASH_REMATCH[4]}"
+            colored="${C_ACCENT}5h:${C_PCT}${fh_pct}%${C_DIM}@${C_TIME}${fh_time}"
+            colored+="${C_GRAY} · ${C_ACCENT}wk:${C_PCT}${wk_pct}%${C_DIM}@${C_TIME}${wk_time}"
+            output+="${C_GRAY} | ${colored}${C_RESET}"
+        else
+            # Unexpected format from the helper — emit uncolored as a safe fallback.
+            output+="${C_GRAY} | ${usage}${C_RESET}"
+        fi
     fi
 fi
 

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -72,6 +72,17 @@ COLOR="blue"
 | slate    | 60        | Dark blue-gray |
 | cyan     | 37        | Bright, tech |
 
+The usage segment (opt-in, see below) uses three additional fixed colors that are independent
+of the `COLOR` theme:
+
+| Field | Variable | ANSI Code | Description |
+|-------|----------|-----------|-------------|
+| Percent value | `C_PCT` | 71 (green) | "value" semantics — current consumption |
+| `@` separator | `C_DIM` | 238 (dark gray) | dim join between percent and time |
+| Reset time | `C_TIME` | 136 (gold) | "schedule" semantics — when the bucket ends |
+
+Edit `.claude/statusline-command.sh` to change these.
+
 ### Removing Features
 
 Comment out or remove lines in the "Build output" section of the script:


### PR DESCRIPTION
## Description

Follow-up refinement to PR #581 (the initial #580 implementation, already merged). Issue #580
was reopened for this round of color improvements.

The previous round colored only the label fields (`5h:`, `wk:`), leaving the value portion
(`18%@2240`, `Mon-1500`) in a single uniform gray. Users reported that the values "kinda run
together". This PR splits the value portion into three semantically distinct colors:

- **Percent** (`C_PCT`, ANSI 71 green) — "value" semantics: current consumption
- **`@` separator** (`C_DIM`, ANSI 238 dark gray) — dim join, visually recedes
- **Reset time** (`C_TIME`, ANSI 136 gold) — "schedule" semantics: when the bucket ends

The three fixed colors are **theme-independent**: they do not track the `COLOR` setting that
controls accent hue for labels, branch names, and bullets. This ensures consistent readability
across all ten theme choices.

A graceful fallback branch is added: if the helper output does not match the expected
`<label><pct>@<time>` pattern, the segment is emitted uncolored rather than broken.

Representative output (blue theme, `COLOR=blue`):

```
Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens | 5h:25%@1800 · wk:6%@Mon-2000
                                                      ^   ^^ ^    ^   ^^ ^
                                                      |   || |    |   || time (gold 136)
                                                      |   || @    |   @ (dim 238)
                                                      |   |pct    |  pct (green 71)
                                                      label(accent 74)
```

## Related Issue

Addresses #580

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `.claude/statusline-command.sh`: added `C_PCT` (ANSI 71), `C_TIME` (ANSI 136), `C_DIM`
  (alias of existing `C_BAR_EMPTY` 238); replaced string-substitution coloring with a
  `BASH_REMATCH` regex parse that colors each field independently; added uncolored fallback
  branch for unexpected helper output format.
- `docs/development/ai/statusline.md`: added sub-table under "Color Reference" documenting
  the three new theme-independent semantic colors (`C_PCT`, `C_DIM`, `C_TIME`).

## Testing

- [x] All existing tests pass
- [x] Manually tested the changes

No new tests required: the existing substring assertions (`5h:`, `wk:`, ` · `, no `7d:`) still
hold because the raw text content produced by the helper is unchanged; only ANSI escape sequences
wrap the fields differently.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

This is a shell-only change; no Python modules were touched. The regex used in
`statusline-command.sh` matches the full helper output and binds four capture groups
(both percentages and both timestamps):

```bash
[[ "$usage" =~ ^5h:([0-9]+)%@([^ ]+)\ wk:([0-9]+)%@(.+)$ ]]
```
