### PR TITLE
fix: scope bash-ban-raw-tools unlock file to project directory

### DIFF
--- a/docs/development/ai/token-efficiency-add-ons.md
+++ b/docs/development/ai/token-efficiency-add-ons.md
@@ -238,11 +238,17 @@ Do **not** add it to the committed `.claude/settings.json`.
 **Escape hatch:**
 
 ```bash
-touch /tmp/bash-raw-unlock
+mkdir -p tmp/agents/claude && touch tmp/agents/claude/bash-raw-unlock
 ```
 
-Allows all banned commands for 10 minutes. The file auto-expires — no cleanup needed. Useful when
-you need a one-off raw shell command without disabling the hook permanently.
+Run this from the project root. Allows all banned commands for 10 minutes. The file auto-expires —
+no cleanup needed. Useful when you need a one-off raw shell command without disabling the hook
+permanently.
+
+The unlock file is scoped to the project directory, so enabling the escape hatch in one project
+does not affect any other project running concurrently on the same machine. If you work across
+multiple projects, you must re-touch the file in each project root where you want raw commands
+allowed.
 
 **Why disabled by default:** humans share the repo. Raw shell commands are legitimate in human
 workflows. The hook is only beneficial when an AI agent is the primary operator of the terminal.

--- a/tests/test_bash_ban_raw_tools.py
+++ b/tests/test_bash_ban_raw_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 import sys
 import time
 import types
@@ -50,14 +51,29 @@ def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
     monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
 
 
-def _bash_payload(command: str) -> str:
-    """Build a Bash tool payload for the given command."""
-    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+def _bash_payload(command: str, cwd: str | None = None) -> str:
+    """Build a Bash tool payload for the given command.
+
+    If *cwd* is provided it is included in the payload so the hook can resolve
+    the per-project unlock path without relying on ``CLAUDE_PROJECT_DIR``.
+    """
+    data: dict[str, object] = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd is not None:
+        data["cwd"] = cwd
+    return json.dumps(data)
 
 
 def _non_bash_payload(tool_name: str) -> str:
     """Build a non-Bash tool payload."""
     return json.dumps({"tool_name": tool_name, "tool_input": {"file_path": "README.md"}})
+
+
+def _make_unlock(project_root: Path) -> Path:
+    """Create the per-project unlock file and return its path."""
+    unlock = project_root / "tmp" / "agents" / "claude" / "bash-raw-unlock"
+    unlock.parent.mkdir(parents=True, exist_ok=True)
+    unlock.touch()
+    return unlock
 
 
 # ---------------------------------------------------------------------------
@@ -169,11 +185,10 @@ def test_fresh_unlock_file_allows_banned_command(
     tmp_path: Path,
 ) -> None:
     """When unlock file exists and mtime is within window, banned commands are allowed."""
-    unlock = tmp_path / "unlock"
-    unlock.touch()
-    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    _make_unlock(tmp_path)
 
-    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
     with pytest.raises(SystemExit) as exc_info:
         sys.exit(hook.main())
     assert exc_info.value.code == 0
@@ -185,16 +200,13 @@ def test_stale_unlock_file_blocks_banned_command(
     tmp_path: Path,
 ) -> None:
     """When unlock file mtime is older than UNLOCK_WINDOW_SECONDS, command is blocked."""
-    unlock = tmp_path / "unlock"
-    unlock.touch()
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    unlock = _make_unlock(tmp_path)
     # Set mtime to well past the window
     stale_mtime = time.time() - (hook.UNLOCK_WINDOW_SECONDS + 60)
-    import os
-
     os.utime(str(unlock), (stale_mtime, stale_mtime))
-    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
 
-    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
     with pytest.raises(SystemExit) as exc_info:
         sys.exit(hook.main())
     assert exc_info.value.code == 2
@@ -206,11 +218,10 @@ def test_missing_unlock_file_blocks_banned_command(
     tmp_path: Path,
 ) -> None:
     """When unlock file does not exist, banned commands are blocked."""
-    unlock = tmp_path / "unlock"
-    # Do NOT create the file
-    monkeypatch.setattr(hook, "UNLOCK_FILE", str(unlock))
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    # Do NOT create the file; just pass a valid cwd so path resolution works
 
-    _set_stdin(monkeypatch, _bash_payload("grep pattern file.py"))
+    _set_stdin(monkeypatch, _bash_payload("grep pattern file.py", cwd=str(tmp_path)))
     with pytest.raises(SystemExit) as exc_info:
         sys.exit(hook.main())
     assert exc_info.value.code == 2
@@ -228,8 +239,8 @@ def test_stderr_reason_mentions_offending_command(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The stderr block reason mentions the offending command."""
-    monkeypatch.setattr(hook, "UNLOCK_FILE", str(tmp_path / "unlock"))
-    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
 
     with pytest.raises(SystemExit):
         sys.exit(hook.main())
@@ -244,13 +255,80 @@ def test_stderr_reason_mentions_unlock_file(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """The stderr block reason mentions the escape hatch (UNLOCK_FILE path)."""
-    unlock_path = str(tmp_path / "unlock")
-    monkeypatch.setattr(hook, "UNLOCK_FILE", unlock_path)
-    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+    """The stderr block reason mentions the escape hatch (per-project unlock path)."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(tmp_path)))
 
     with pytest.raises(SystemExit):
         sys.exit(hook.main())
 
     captured = capsys.readouterr()
-    assert unlock_path in captured.err
+    expected_path = str(tmp_path / "tmp" / "agents" / "claude" / "bash-raw-unlock")
+    assert expected_path in captured.err
+
+
+# ---------------------------------------------------------------------------
+# New tests: per-project isolation, fail-closed, env precedence
+# ---------------------------------------------------------------------------
+
+
+def test_unlock_file_in_one_project_does_not_unlock_another(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unlock file in project_a does NOT unlock commands run with cwd=project_b."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    project_a = tmp_path / "project_a"
+    project_b = tmp_path / "project_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    # Touch unlock in project_a only
+    _make_unlock(project_a)
+
+    # Run hook as if we're in project_b — should still be blocked
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(project_b)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 2
+
+
+def test_no_project_dir_blocks_with_unlock_unavailable_message(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No CLAUDE_PROJECT_DIR and no cwd: command is blocked; stderr says hatch unavailable."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    # No cwd in payload
+    _set_stdin(monkeypatch, _bash_payload("cat README.md"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "unavailable" in captured.err.lower() or "project root" in captured.err.lower()
+
+
+def test_claude_project_dir_env_overrides_cwd(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CLAUDE_PROJECT_DIR env var wins over cwd in the payload."""
+    project_a = tmp_path / "project_a"
+    project_b = tmp_path / "project_b"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    # Unlock only in project_a; env points to project_a; cwd points to project_b
+    _make_unlock(project_a)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_a))
+
+    # Even though cwd is project_b, env var should win → allowed
+    _set_stdin(monkeypatch, _bash_payload("cat README.md", cwd=str(project_b)))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+    assert exc_info.value.code == 0

--- a/tools/hooks/ai/bash-ban-raw-tools.py
+++ b/tools/hooks/ai/bash-ban-raw-tools.py
@@ -9,8 +9,11 @@ Blocks:
   - Leading banned commands: cat, head, tail, find, grep, rg, wc
 
 Escape hatch:
-  Touch /tmp/bash-raw-unlock (or the configured UNLOCK_FILE) to allow banned
-  commands for 10 minutes. The file auto-expires — no cleanup needed.
+  Touch <project>/tmp/agents/claude/bash-raw-unlock (where <project> is resolved
+  from the CLAUDE_PROJECT_DIR env var or the cwd field in the hook's stdin payload)
+  to allow banned commands for 10 minutes. The file auto-expires — no cleanup needed.
+  The unlock file is scoped to the project so one project's unlock does not affect
+  any other project running concurrently.
 
 Exit codes:
   0 - Allow command
@@ -23,6 +26,7 @@ For documentation, see: docs/development/ai/token-efficiency-add-ons.md
 """
 
 import json
+import os
 import shlex
 import sys
 import time
@@ -31,8 +35,8 @@ from pathlib import Path
 # Commands that AI agents should never use via Bash when native tools are available
 BANNED_COMMANDS: frozenset[str] = frozenset({"cat", "head", "tail", "find", "grep", "rg", "wc"})
 
-# Escape hatch: touch this file to allow banned commands for UNLOCK_WINDOW_SECONDS
-UNLOCK_FILE: str = "/tmp/bash-raw-unlock"  # nosec B108 - well-known path is intentional; operators must be able to touch it from any shell. Configurable via this constant.
+# Relative path (from project root) of the per-project escape-hatch file
+UNLOCK_FILE_RELATIVE: str = "tmp/agents/claude/bash-raw-unlock"
 
 # How long the escape hatch stays valid after the file is touched (seconds)
 UNLOCK_WINDOW_SECONDS: int = 600
@@ -65,11 +69,26 @@ def tokenize(command: str) -> list[str]:
             return command.split()
 
 
-def is_unlocked() -> bool:
-    """Return True iff UNLOCK_FILE exists and was modified within UNLOCK_WINDOW_SECONDS."""
-    path = Path(UNLOCK_FILE)
+def _resolve_unlock_path(input_data: dict[str, object]) -> Path | None:
+    """
+    Resolve the per-project unlock file path.
+
+    Reads CLAUDE_PROJECT_DIR env var first; falls back to the ``cwd`` field in
+    *input_data*.  Returns ``None`` when neither is available (project root
+    cannot be determined).
+    """
+    project_dir: str = os.environ.get("CLAUDE_PROJECT_DIR", "") or str(input_data.get("cwd", ""))
+    if not project_dir:
+        return None
+    return Path(project_dir) / UNLOCK_FILE_RELATIVE
+
+
+def is_unlocked(unlock_path: Path | None) -> bool:
+    """Return True iff *unlock_path* exists and was modified within UNLOCK_WINDOW_SECONDS."""
+    if unlock_path is None:
+        return False
     try:
-        mtime = path.stat().st_mtime
+        mtime = unlock_path.stat().st_mtime
         return (time.time() - mtime) <= UNLOCK_WINDOW_SECONDS
     except OSError:
         return False
@@ -82,15 +101,26 @@ def find_banned_leading(tokens: list[str]) -> str | None:
     return None
 
 
-def _build_reason(offending: str) -> str:
+def _build_reason(offending: str, unlock_path: Path | None) -> str:
     """Build a human-readable block reason for the given offending command."""
     suggestion = _SUGGESTIONS.get(offending, "a native tool")
+    if unlock_path is not None:
+        hatch_line = (
+            f"Escape hatch: `touch {unlock_path}` (run from any shell) to allow "
+            f"raw commands for {UNLOCK_WINDOW_SECONDS // 60} minutes. "
+            f"The unlock is scoped to this project."
+        )
+    else:
+        hatch_line = (
+            "Escape hatch unavailable: project root could not be determined "
+            "(CLAUDE_PROJECT_DIR is unset and no cwd was provided). "
+            "Set CLAUDE_PROJECT_DIR to the project root to enable the escape hatch."
+        )
     return (
         f"Blocked: `{offending}` is a raw shell command.\n"
         f"Use the native `{suggestion}` tool instead — it produces a better result "
         f"with fewer tokens.\n"
-        f"Escape hatch: `touch {UNLOCK_FILE}` to allow raw commands for "
-        f"{UNLOCK_WINDOW_SECONDS // 60} minutes."
+        f"{hatch_line}"
     )
 
 
@@ -115,8 +145,10 @@ def main() -> int:
     if not isinstance(command, str) or not command:
         return 0
 
+    unlock_path = _resolve_unlock_path(input_data)
+
     # Escape hatch: allow if unlock file is fresh
-    if is_unlocked():
+    if is_unlocked(unlock_path):
         return 0
 
     tokens = tokenize(command)
@@ -124,7 +156,7 @@ def main() -> int:
     # Check for banned leading command
     offending = find_banned_leading(tokens)
     if offending is not None:
-        print(_build_reason(offending), file=sys.stderr)
+        print(_build_reason(offending, unlock_path), file=sys.stderr)
         return 2
 
     return 0


### PR DESCRIPTION
## Description

The `bash-ban-raw-tools.py` escape-hatch unlock file was stored at the global path
`/tmp/bash-raw-unlock`, causing it to leak across projects on the same machine. Any project
that touched the unlock file would disable the raw-tool ban for every other project running
concurrently.

## Related Issue

Addresses #585

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement

## Changes Made

- `tools/hooks/ai/bash-ban-raw-tools.py` — scoped unlock file to
  `<project>/tmp/agents/claude/bash-raw-unlock`, where `<project>` is resolved from the
  `CLAUDE_PROJECT_DIR` env var, falling back to the `cwd` field on the hook's stdin payload.
  Fails closed (no unlock honored, banned commands stay blocked) if neither is set.
- `tests/test_bash_ban_raw_tools.py` — refactored 5 existing tests to use the new path;
  added 3 new tests: cross-project isolation, fail-closed behaviour, env-var precedence
- `docs/development/ai/token-efficiency-add-ons.md` — updated escape-hatch snippet to the
  new path and added a note that the unlock file is scoped to the project directory

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Manually tested the changes (covered by automated tests; manual end-to-end check left to reviewer)

Tests added:
- Cross-project isolation: unlock in project A does not unlock project B
- Fail-closed: hook blocks all raw commands when the project root cannot be determined
- Env-var precedence: `CLAUDE_PROJECT_DIR` is preferred over the `cwd` from stdin

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

No ADR required — this is a scoped bug fix to a single existing hook, not an architectural
change. ADR-9005 (AI agent command restrictions) does not need updating.
