### PR TITLE
chore: add daily doit check workflow with issue-on-failure

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -1,0 +1,77 @@
+name: Daily Check
+
+on:
+  schedule:
+    - cron: "17 6 * * *"  # Daily at 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: daily-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: pv
+        uses: ./.github/actions/python-versions
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ steps.pv.outputs.newest }}
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run doit check
+        run: uv run doit check
+
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          today="$(date -u +%Y-%m-%d)"
+          existing="$(gh issue list --state open --label automated --json number,title \
+            --jq '[.[] | select(.title | contains("Daily doit check failed"))][0].number // empty')"
+          {
+            echo "Scheduled \`doit check\` failed on \`main\`."
+            echo
+            echo "- Run: ${RUN_URL}"
+            echo "- Seen: ${today} (UTC)"
+            echo
+            echo "Runs \`uv run doit check\` (format, lint, type, security, audit, spell, tests)."
+            echo "See the run log for the failing step. Close this issue once the check passes again."
+          } > "${RUNNER_TEMP}/issue-body.md"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" \
+              --body "Still failing as of ${today} (UTC). Run: ${RUN_URL}"
+          else
+            gh issue create --title "🚨 Daily doit check failed on main" \
+              --label automated --label needs-triage \
+              --assignee "${OWNER}" \
+              --body-file "${RUNNER_TEMP}/issue-body.md"
+          fi


### PR DESCRIPTION
## Description

Adds a scheduled GitHub Actions workflow (`.github/workflows/daily-check.yml`) that runs
`doit check` daily against `main` and opens (or updates) a tracking issue on failure. This
catches breakage that lands **outside** PR CI — a newly published CVE flagged by `pip-audit`
(as with msgpack in #620), a dependency yank, or environment drift — without waiting for the
next PR to go red.

## Related Issue

Addresses #622

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- New workflow `.github/workflows/daily-check.yml`:
  - Daily `schedule` (06:17 UTC) + `workflow_dispatch`.
  - Environment mirrors the `ci.yml` lint job (uv, `python-versions` action, `uv sync --all-extras --dev`), then `uv run doit check`.
  - On failure: find-or-update a single tracking issue via `gh` (labels `automated` + `needs-triage`, assigned to the owner). No secrets — built-in `GITHUB_TOKEN` with `issues: write`.

## Testing

- [x] `actionlint` passes (pre-commit "Lint GitHub Actions workflow files")
- [x] `doit check` passes locally

No pytest test: this is a workflow YAML with no Python unit to test. Post-merge, a `workflow_dispatch` run verifies the happy path; the issue path can be smoke-tested on a scratch branch.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run linting checks (actionlint via pre-commit)
- [x] All new and existing tests pass (`doit check`)
- [x] My changes generate no new warnings

## Additional Notes

Notification reaches you via issue subscription (the issue is assigned to you), so no SMTP or
secrets are needed. On a recurring failure the workflow comments on the existing open issue
rather than filing duplicates; close it once the check is green again.
