### PR TITLE
refactor: make codeql checkout-version test resilient to dependabot bumps

### DIFF
--- a/tests/test_codeql_workflow.py
+++ b/tests/test_codeql_workflow.py
@@ -10,6 +10,7 @@ GitHub's "default setup" to this advanced workflow file).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -162,12 +163,22 @@ class TestAnalyzeJob:
         job = workflow["jobs"]["analyze"]
         assert job["strategy"]["fail-fast"] is False
 
-    def test_analyze_uses_checkout_v6(self) -> None:
-        """``actions/checkout`` should be pinned to ``@v6`` (repo convention)."""
+    def test_analyze_pins_checkout_major_version(self) -> None:
+        """``actions/checkout`` must be pinned to a major-version tag (``@vN``).
+
+        The exact major version is intentionally not asserted. Dependabot bumps
+        ``actions/checkout`` routinely; pinning this test to a specific number
+        turns every such bump into a false CI failure (see #625). The repo
+        convention this guards is that the action is pinned to a version tag,
+        not a floating ref/branch.
+        """
         steps = _analyze_steps()
         checkout_steps = [s for s in steps if s.get("uses", "").startswith("actions/checkout@")]
         assert checkout_steps, "expected an actions/checkout step"
-        assert checkout_steps[0]["uses"] == "actions/checkout@v6"
+        uses = checkout_steps[0]["uses"]
+        assert re.fullmatch(r"actions/checkout@v\d+", uses), (
+            f"expected actions/checkout pinned to a major-version tag, got {uses!r}"
+        )
 
     def test_analyze_uses_codeql_init_v4(self) -> None:
         """``github/codeql-action/init`` should be pinned to ``@v4``."""


### PR DESCRIPTION
## Description

`tests/test_codeql_workflow.py` asserted the exact `actions/checkout` version (`@v6`). Because
dependabot bumps this action routinely, every bump updated `codeql.yml` but left the test asserting
the old version, turning all 8 `test` matrix jobs red on a single stale assertion (observed on
PR #612, `v6` → `v7`). This loosens the assertion to accept any major-version tag while still
guarding that the action is pinned.

## Related Issue

Addresses #625

## Type of Change

- [x] Code refactoring
- [x] Test improvement

## Changes Made

- Renamed `test_analyze_uses_checkout_v6` → `test_analyze_pins_checkout_major_version`.
- Replaced the exact-match assertion with `re.fullmatch(r"actions/checkout@v\d+", uses)`, which
  accepts any major-version tag but still fails on a floating ref/branch or unpinned step.
- Added `import re`; updated the docstring to explain the rationale and cite #625.

## Testing

- [x] All existing tests pass (`doit check` — 997 tests, plus lint, type, security)
- [x] Assertion still fails if the checkout step is unpinned/floating (regex requires `@vN`)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (n/a — no behavior or doc change)
- [ ] I have updated the CHANGELOG.md (n/a — internal test-only change, changelog is release-generated)
- [x] My changes generate no new warnings

## Additional Notes

The sibling `codeql-action/init@v4` and `analyze@v4` assertions share the same latent brittleness;
hardening them is tracked separately in #626 to keep this PR focused.

Once merged, PR #612 (`actions/checkout` v6 → v7) needs `@dependabot rebase` to pick up this test
and go green.
