### PR TITLE
refactor: make codeql-action version tests resilient to dependabot bumps

### DIFF
--- a/tests/test_codeql_workflow.py
+++ b/tests/test_codeql_workflow.py
@@ -180,23 +180,41 @@ class TestAnalyzeJob:
             f"expected actions/checkout pinned to a major-version tag, got {uses!r}"
         )
 
-    def test_analyze_uses_codeql_init_v4(self) -> None:
-        """``github/codeql-action/init`` should be pinned to ``@v4``."""
+    def test_analyze_pins_codeql_init_major_version(self) -> None:
+        """``github/codeql-action/init`` must be pinned to a major-version tag (``@vN``).
+
+        The exact major version is intentionally not asserted. Dependabot bumps
+        ``github/codeql-action`` routinely; pinning this test to a specific
+        number turns every such bump into a false CI failure (see #626). The
+        repo convention this guards is that the action is pinned to a version
+        tag, not a floating ref/branch.
+        """
         steps = _analyze_steps()
         init_steps = [
             s for s in steps if s.get("uses", "").startswith("github/codeql-action/init@")
         ]
         assert init_steps, "expected a github/codeql-action/init step"
-        assert init_steps[0]["uses"] == "github/codeql-action/init@v4"
+        uses = init_steps[0]["uses"]
+        assert re.fullmatch(r"github/codeql-action/init@v\d+", uses), (
+            f"expected github/codeql-action/init pinned to a major-version tag, got {uses!r}"
+        )
 
-    def test_analyze_uses_codeql_analyze_v4(self) -> None:
-        """``github/codeql-action/analyze`` should be pinned to ``@v4``."""
+    def test_analyze_pins_codeql_analyze_major_version(self) -> None:
+        """``github/codeql-action/analyze`` must be pinned to a major-version tag (``@vN``).
+
+        See ``test_analyze_pins_codeql_init_major_version`` for the rationale
+        (#626): the exact major version is intentionally not asserted so routine
+        dependabot bumps don't turn into false CI failures.
+        """
         steps = _analyze_steps()
         analyze_steps = [
             s for s in steps if s.get("uses", "").startswith("github/codeql-action/analyze@")
         ]
         assert analyze_steps, "expected a github/codeql-action/analyze step"
-        assert analyze_steps[0]["uses"] == "github/codeql-action/analyze@v4"
+        uses = analyze_steps[0]["uses"]
+        assert re.fullmatch(r"github/codeql-action/analyze@v\d+", uses), (
+            f"expected github/codeql-action/analyze pinned to a major-version tag, got {uses!r}"
+        )
 
     def test_analyze_init_passes_matrix_language(self) -> None:
         """The init step must receive the matrix language via ``with.languages``."""


### PR DESCRIPTION
## Description

The `github/codeql-action/init` and `analyze` tests asserted the exact pinned version (`@v4`).
Because dependabot bumps `github/codeql-action` routinely, the next bump (`v4` → `v5`) would update
`codeql.yml` but leave these tests asserting the old version, reddening all 8 test-matrix jobs on
stale assertions — the same failure mode fixed for `actions/checkout` in #625/#627. This loosens
both to accept any major-version tag while still guarding that the actions are pinned.

## Related Issue

Addresses #626

## Type of Change

- [x] Code refactoring
- [x] Test improvement

## Changes Made

- Renamed `test_analyze_uses_codeql_init_v4` → `test_analyze_pins_codeql_init_major_version`;
  assertion now `re.fullmatch(r"github/codeql-action/init@v\d+", uses)`.
- Renamed `test_analyze_uses_codeql_analyze_v4` → `test_analyze_pins_codeql_analyze_major_version`;
  assertion now `re.fullmatch(r"github/codeql-action/analyze@v\d+", uses)`.
- Both assertions still fail on an unpinned/floating ref; docstrings cite #626.

## Testing

- [x] All existing tests pass (`doit check` — 997 tests, plus lint, type, security)
- [x] Assertions still fail if a step is unpinned/floating (regex requires `@vN`)

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly (n/a — no behavior or doc change)
- [ ] I have updated the CHANGELOG.md (n/a — internal test-only change, changelog is release-generated)
- [x] My changes generate no new warnings

## Additional Notes

Completes the version-pinning cleanup started in #625/#627; all three `analyze` action-version
tests now guard "pinned to a major-version tag" rather than an exact number.
