### PR TITLE
fix: make get_recommended_action() pure by injecting template_downloaded flag

### DIFF
--- a/tests/template/test_pyproject_template_main.py
+++ b/tests/template/test_pyproject_template_main.py
@@ -374,7 +374,9 @@ class TestMainModule:
         settings = ProjectSettings()
         template_state = TemplateState()
 
-        result = get_recommended_action(context, settings, template_state, None)
+        result = get_recommended_action(
+            context, settings, template_state, None, template_downloaded=False
+        )
         assert result == 2  # Configure project (has placeholders)
 
     def test_get_recommended_action_placeholder_values(self) -> None:
@@ -388,7 +390,9 @@ class TestMainModule:
         )
         template_state = TemplateState()
 
-        result = get_recommended_action(context, settings, template_state, None)
+        result = get_recommended_action(
+            context, settings, template_state, None, template_downloaded=False
+        )
         assert result == 2  # Re-run configuration
 
     def test_get_recommended_action_outdated_template(self) -> None:
@@ -409,7 +413,11 @@ class TestMainModule:
         template_state = TemplateState(commit="oldcommit123", commit_date="2025-01-01")
 
         result = get_recommended_action(
-            context, settings, template_state, ("newcommit456", "2025-01-15")
+            context,
+            settings,
+            template_state,
+            ("newcommit456", "2025-01-15"),
+            template_downloaded=False,
         )
         assert result == 3  # Check for template updates
 
@@ -431,9 +439,39 @@ class TestMainModule:
         template_state = TemplateState(commit="samecommit12", commit_date="2025-01-15")
 
         result = get_recommended_action(
-            context, settings, template_state, ("samecommit12", "2025-01-15")
+            context,
+            settings,
+            template_state,
+            ("samecommit12", "2025-01-15"),
+            template_downloaded=False,
         )
         assert result is None  # No recommendation, up to date
+
+    def test_get_recommended_action_template_downloaded(self) -> None:
+        """Test recommended action when template has been downloaded and reviewed."""
+        from tools.pyproject_template.manage import get_recommended_action
+
+        context = ProjectContext(has_git=True, has_pyproject=True)
+        settings = ProjectSettings(
+            project_name="My Project",
+            package_name="my_project",
+            pypi_name="my-project",
+            author_name="Test Author",
+            author_email="test@example.com",
+            github_user="testuser",
+            github_repo="my-project",
+            description="A project",
+        )
+        template_state = TemplateState(commit="samecommit12", commit_date="2025-01-15")
+
+        result = get_recommended_action(
+            context,
+            settings,
+            template_state,
+            ("samecommit12", "2025-01-15"),
+            template_downloaded=True,
+        )
+        assert result == 5  # Mark as synced
 
 
 class TestConfigureModule:

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -151,6 +151,8 @@ def get_recommended_action(
     settings: ProjectSettings,
     template_state: TemplateState,
     latest_commit: tuple[str, str] | None,
+    *,
+    template_downloaded: bool,
 ) -> int | None:
     """Determine the recommended action based on context."""
     # No git repo - need to create new project
@@ -162,8 +164,7 @@ def get_recommended_action(
         return 2  # Configure project
 
     # Template already downloaded and reviewed - recommend marking as synced
-    template_commit_file = Path("tmp/extracted/pyproject-template-main/.template_commit")
-    if template_commit_file.exists():
+    if template_downloaded:
         return 5  # Mark as synced
 
     # Existing repo with outdated template
@@ -763,7 +764,13 @@ def interactive_menu(manager: SettingsManager, dry_run: bool = False, *, yes: bo
 
         # Get recommended action
         recommended = get_recommended_action(
-            manager.context, manager.settings, manager.template_state, latest_commit
+            manager.context,
+            manager.settings,
+            manager.template_state,
+            latest_commit,
+            template_downloaded=Path(
+                "tmp/extracted/pyproject-template-main/.template_commit"
+            ).exists(),
         )
 
         # Show menu
@@ -896,7 +903,13 @@ def main(argv: list[str] | None = None) -> int:
         # Run recommended action non-interactively
         latest_commit = get_template_latest_commit()
         recommended = get_recommended_action(
-            manager.context, manager.settings, manager.template_state, latest_commit
+            manager.context,
+            manager.settings,
+            manager.template_state,
+            latest_commit,
+            template_downloaded=Path(
+                "tmp/extracted/pyproject-template-main/.template_commit"
+            ).exists(),
         )
         if recommended:
             return run_action(recommended, manager, args.dry_run, yes=True)


### PR DESCRIPTION
## Description

`get_recommended_action()` previously read `Path("tmp/extracted/pyproject-template-main/.template_commit").exists()` internally, coupling the decision function to the local filesystem. This made unit tests non-hermetic: tests produced different results depending on whether a developer had run `manage.py check` and happened to have that file present.

The fix extracts the filesystem check to both call sites (`interactive_menu()` and `main()`) and passes the result as a required keyword-only argument `template_downloaded: bool`. The function is now pure and fully testable without filesystem side effects. Behavior at the call sites is identical — only internal wiring moved.

## Related Issue

Addresses #629

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- `tools/pyproject_template/manage.py`: Added required keyword-only parameter `template_downloaded: bool` to `get_recommended_action()`. Replaced internal `Path(...).exists()` call with a branch on the new parameter. Both call sites (`interactive_menu()` and `main()`) now compute the `.exists()` check inline before passing the flag.
- `tests/template/test_pyproject_template_main.py`: Updated all existing calls to `get_recommended_action()` to pass `template_downloaded=False`. Added `test_get_recommended_action_template_downloaded` to assert that `template_downloaded=True` returns 5 ("Mark as synced"), covering the previously untestable branch.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Key test additions:
- `test_get_recommended_action_template_downloaded`: Verifies `template_downloaded=True` returns action 5 without touching the filesystem. This branch was previously unreachable in CI (the file never exists in a fresh checkout).
- All four pre-existing `get_recommended_action` tests pass `template_downloaded=False`, which matches the prior implicit behavior (file absent in CI).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A — internal logic change; no UI or CLI output affected.

## Additional Notes

- `tmp/` is gitignored; the `.template_commit` file only exists locally after running `manage.py check`. CI never had this file, so the `template_downloaded=True` path was untested before this fix.
- No user-visible behavior changes: both call sites compute the same `.exists()` expression that was previously inside the function.
- No ADR required: plain bug fix with no architectural decision; issue has no `needs-adr` label.
- No documentation updates required: `docs/template/ai-sync-checklist.md` describes the external `check`/`sync` workflow correctly; it does not document `get_recommended_action()` internals.
