### PR TITLE
refactor: make template tooling tests template-owned

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -97,6 +97,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9014: Use click for application CLI](decisions/9014-use-click-for-application-cli.md)
 - [ADR-9015: install_tools framework: archive extraction and custom URLs](decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md)
 - [ADR-9016: Unify ADR directories under docs/decisions](decisions/9016-unify-adr-directories.md)
+- [ADR-9017: Template tooling and its tests are template-owned](decisions/9017-template-tooling-and-its-tests-are-template-owned.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
 - [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Gemini, Copilot, and Codex for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template

--- a/docs/decisions/9017-template-tooling-and-its-tests-are-template-owned.md
+++ b/docs/decisions/9017-template-tooling-and-its-tests-are-template-owned.md
@@ -1,0 +1,57 @@
+# ADR-9017: Template tooling and its tests are template-owned
+
+## Status
+Accepted
+
+## Decision
+Template tooling tests (`tests/template/test_*.py` that test `tools/pyproject_template/`) are
+**template-owned**: they run only in the template's own CI, are excluded from the drift checker,
+and are shed from downstream projects by `cleanup --setup`.
+
+A single constant `TEMPLATE_OWNED_TEST_FILES` in `utils.py` is the authoritative list.
+Both `check_template_updates.py` and `cleanup.py` import from it; neither hardcodes the list.
+
+## Rationale
+Before this decision, tooling tests lived alongside skeleton tests with no distinction.
+The drift checker would present them as "please adopt" suggestions to downstream projects,
+and `cleanup --setup` left them in place — meaning a downstream project would carry
+template-CI tests that import `tools.pyproject_template.*` (a namespace that no longer
+exists after cleanup removes the tooling directory).
+
+A single source of truth avoids the shed-list and exclude-list diverging silently.
+
+The "straddler" file `tests/template/test_properties.py` was split:
+- `test_properties.py` — downstream-owned; contains only skeleton (`greet`) assertions.
+- `tests/template/test_utils_properties.py` — template-owned; contains tooling property tests.
+
+A coupling guard (`_emit_coupling_warnings`) warns when a drifted non-owned test imports
+tooling that has also drifted, so users know to run `bootstrap --sync` before adopting
+that test.
+
+## Consequences
+- **Downstream projects carry no tests for the tooling they run.** The tooling
+  (`manage.py`, `check_template_updates.py`, `cleanup.py`, …) still ships via
+  `bootstrap.py` `SYNC_FILES`, but its tests do not. We accept this: downstreams
+  consume the tooling without modifying it, and these tests depend on template-only
+  fixtures (the `package_name` skeleton) that no longer exist once a downstream is
+  configured. This is why the alternative — adding the tests to `SYNC_FILES` so
+  tooling and tests travel together — was rejected: it would push non-runnable,
+  skeleton-coupled tests into every downstream.
+- **Existing downstreams need a one-time cleanup.** Projects that adopted these
+  tests in an earlier sync are not cleaned up automatically; they should run
+  `cleanup --setup` once to shed them (see
+  [AI Sync Checklist – Phase 1](../template/ai-sync-checklist.md)).
+- **Known limitation — the stale-comparator facet remains.** The drift checker runs
+  from the downstream's local (possibly stale) tooling, so both the exclusion list
+  (`TEMPLATE_OWNED_TEST_FILES`) and the comparison logic are only as fresh as the
+  last `bootstrap --sync`; a newly template-owned test added upstream is not excluded
+  until the downstream syncs `utils.py`. A self-updating comparator was considered and
+  declined as too fragile — running `bootstrap --sync` first (now an always-run early
+  step) is the mitigation.
+
+## Related Issues
+- Issue #631: Make template tooling tests template-owned
+
+## Related Documentation
+- [Template Tooling](../template/tools-reference.md)
+- [AI Sync Checklist – Phase 1](../template/ai-sync-checklist.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -96,6 +96,7 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [9014](9014-use-click-for-application-cli.md) | Use click for application CLI | Accepted |
 | [9015](9015-install-tools-framework-archive-extraction-and-custom-urls.md) | install_tools framework: archive extraction and custom URLs | Accepted |
 | [9016](9016-unify-adr-directories.md) | Unify ADR directories under docs/decisions | Accepted |
+| [9017](9017-template-tooling-and-its-tests-are-template-owned.md) | Template tooling and its tests are template-owned | Accepted |
 
 ### Project-level ADRs (0001+)
 

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -33,9 +33,11 @@ This checklist guides an AI agent through synchronizing a downstream project wit
 
 ---
 
-## Phase 1: Install Template Management Tools (First-Time Only)
+## Phase 1: Sync Template Management Tools (Always Run First)
 
-If the project does NOT yet have `tools/pyproject_template/manage.py`, install it using the bootstrap script. Skip this phase if already present.
+Run `bootstrap --sync` at the start of **every** sync, not just the first time.
+This ensures the tooling suite in `tools/pyproject_template/` matches the version of the template
+you are about to adopt. Applying file diffs with a stale tooling version can produce incorrect results.
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3 - --sync
@@ -43,16 +45,25 @@ curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/boot
 
 This will:
 
-1. Download the management suite to `tools/pyproject_template/`:
+1. Overwrite the management suite in `tools/pyproject_template/` with the latest template version:
     - `__init__.py`, `utils.py`, `settings.py`, `check_template_updates.py`, `manage.py`, `configure.py`, `cleanup.py`
-2. Detect project settings from `pyproject.toml`
-3. Create `.config/pyproject_template/settings.toml` with detected values
-4. Verify the installation
+2. Detect project settings from `pyproject.toml` (first-time only creates `.config/pyproject_template/settings.toml`)
+3. Verify the installation
 
-After installation:
+**Version-skew caveat:** The drift checker (`check_template_updates.py`) compares your files against the
+template version it was fetched with. If your local tooling is older than the template version you are
+comparing against, the checker may miss or misreport differences. Always run `bootstrap --sync` before running
+the drift check.
 
-- [ ] Review `.config/pyproject_template/settings.toml` and correct any values
-- [ ] Decide: Track `.config/pyproject_template/` in git or add to `.gitignore`
+**Template-owned tests:** The files listed in `TEMPLATE_OWNED_TEST_FILES` (e.g. `tests/template/test_check_template_updates.py`)
+are tooling tests that run only in the template's own CI. They are silently excluded from the drift report and
+will be shed from your project by `cleanup --setup`. You do not need to adopt or maintain them.
+
+After running bootstrap:
+
+- [ ] Review `.config/pyproject_template/settings.toml` and correct any values (first-time only)
+- [ ] Decide: Track `.config/pyproject_template/` in git or add to `.gitignore` (first-time only)
+- [ ] **Existing projects:** run `cleanup --setup` once to shed any template-owned tests adopted in an earlier sync
 - [ ] Verify: `python tools/pyproject_template/manage.py --dry-run check`
 
 ---

--- a/tests/template/test_check_template_updates.py
+++ b/tests/template/test_check_template_updates.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import pytest
 
 from tools.pyproject_template.check_template_updates import (
+    _emit_coupling_warnings,
     compare_files,
     load_sync_excludes,
 )
+from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
 
 
 def _make_template(
@@ -158,3 +160,139 @@ class TestCompareFilesWithExcludes:
         diff, excluded = compare_files(project, template_root, excludes=["a.py"])
         assert [p.as_posix() for p in diff] == ["b.py"]
         assert [p.as_posix() for p in excluded] == ["a.py"]
+
+
+class TestCompareFilesExcludesTemplateOwnedTests:
+    """``compare_files`` silently skips template-owned tooling test files."""
+
+    @pytest.fixture
+    def project(self, tmp_path: Path) -> Path:
+        p = tmp_path / "project"
+        p.mkdir()
+        return p
+
+    @pytest.fixture
+    def template(self, tmp_path: Path) -> Path:
+        return tmp_path / "template"
+
+    def test_template_owned_test_not_in_different_files(
+        self, project: Path, template: Path
+    ) -> None:
+        """A template-owned test that differs must NOT appear in different_files."""
+        # Use the first entry in the constant as the representative case.
+        owned = TEMPLATE_OWNED_TEST_FILES[0]  # e.g. tests/template/test_pyproject_template_main.py
+        template_root = _make_template(
+            template,
+            {
+                owned: "upstream-content",
+                "README.md": "upstream-readme",
+            },
+        )
+        # Project has different content for the owned test and different README.
+        (project / "README.md").write_text("project-readme", encoding="utf-8")
+        diff, _excluded = compare_files(project, template_root)
+        diff_strs = [p.as_posix() for p in diff]
+        assert owned not in diff_strs, f"Template-owned test must be excluded: {owned}"
+        assert "README.md" in diff_strs, "Non-owned drifted file must still appear"
+
+    def test_all_template_owned_tests_silently_skipped(self, project: Path, template: Path) -> None:
+        """Every entry in TEMPLATE_OWNED_TEST_FILES is suppressed, regardless of content."""
+        files: dict[str, str] = dict.fromkeys(TEMPLATE_OWNED_TEST_FILES, "upstream")
+        files["tools/pyproject_template/utils.py"] = "upstream-tooling"
+        template_root = _make_template(template, files)
+        diff, _excluded = compare_files(project, template_root)
+        diff_strs = [p.as_posix() for p in diff]
+        for owned in TEMPLATE_OWNED_TEST_FILES:
+            assert owned not in diff_strs, f"Owned test must be skipped: {owned}"
+        # The non-owned tooling file still surfaces.
+        assert "tools/pyproject_template/utils.py" in diff_strs
+
+    def test_non_owned_test_still_surfaces(self, project: Path, template: Path) -> None:
+        """Tests NOT in TEMPLATE_OWNED_TEST_FILES surface normally as drift."""
+        template_root = _make_template(
+            template,
+            {"tests/template/test_templates.py": "upstream"},
+        )
+        diff, _excluded = compare_files(project, template_root)
+        assert "tests/template/test_templates.py" in [p.as_posix() for p in diff]
+
+
+class TestEmitCouplingWarnings:
+    """Tests for ``_emit_coupling_warnings``."""
+
+    def test_warns_when_drifted_test_imports_tooling_and_tooling_drifted(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warning emitted when a non-owned test imports tooling AND tooling has drifted."""
+        project = tmp_path / "project"
+        project.mkdir()
+        # Create a local non-template-owned test that imports tooling.
+        test_dir = project / "tests" / "template"
+        test_dir.mkdir(parents=True)
+        drifted_test = test_dir / "test_custom.py"
+        drifted_test.write_text(
+            "from tools.pyproject_template.utils import validate_package_name\n",
+            encoding="utf-8",
+        )
+        different_files = [
+            Path("tests/template/test_custom.py"),
+            Path("tools/pyproject_template/utils.py"),  # tooling has also drifted
+        ]
+        _emit_coupling_warnings(different_files, project)
+        captured = capsys.readouterr()
+        assert "bootstrap --sync" in captured.out
+        assert "tests/template/test_custom.py" in captured.out
+
+    def test_silent_when_no_tooling_drift(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No warning when the drifted test imports tooling but tooling itself has NOT drifted."""
+        project = tmp_path / "project"
+        project.mkdir()
+        test_dir = project / "tests" / "template"
+        test_dir.mkdir(parents=True)
+        drifted_test = test_dir / "test_custom.py"
+        drifted_test.write_text(
+            "from tools.pyproject_template.utils import validate_package_name\n",
+            encoding="utf-8",
+        )
+        # No tooling file in different_files.
+        different_files = [Path("tests/template/test_custom.py")]
+        _emit_coupling_warnings(different_files, project)
+        captured = capsys.readouterr()
+        assert "bootstrap" not in captured.out
+
+    def test_silent_when_drifted_test_does_not_import_tooling(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No warning when the drifted test does not import tooling (even if tooling drifted)."""
+        project = tmp_path / "project"
+        project.mkdir()
+        test_dir = project / "tests" / "template"
+        test_dir.mkdir(parents=True)
+        drifted_test = test_dir / "test_custom.py"
+        drifted_test.write_text(
+            "from package_name.core import greet\n",
+            encoding="utf-8",
+        )
+        different_files = [
+            Path("tests/template/test_custom.py"),
+            Path("tools/pyproject_template/utils.py"),
+        ]
+        _emit_coupling_warnings(different_files, project)
+        captured = capsys.readouterr()
+        assert "bootstrap" not in captured.out
+
+    def test_silent_when_no_drifted_tests(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No warning when different_files contains only non-test files."""
+        project = tmp_path / "project"
+        project.mkdir()
+        different_files = [
+            Path("tools/pyproject_template/utils.py"),
+            Path("README.md"),
+        ]
+        _emit_coupling_warnings(different_files, project)
+        captured = capsys.readouterr()
+        assert "bootstrap" not in captured.out

--- a/tests/template/test_cleanup.py
+++ b/tests/template/test_cleanup.py
@@ -1310,3 +1310,41 @@ class TestCheckStaleTemplateReferences:
         assert path == readme
         assert line_no == 3
         assert "tools/doit/template_clean" in content
+
+
+class TestSetupFilesIncludesTemplateOwnedTests:
+    """SETUP_FILES must include every template-owned test so downstream sheds them.
+
+    This is the structural invariant: the single source of truth
+    ``TEMPLATE_OWNED_TEST_FILES`` must be fully reflected in ``SETUP_FILES``.
+    A mismatch means a tooling test could silently remain in a downstream project.
+    """
+
+    def test_setup_files_contains_all_template_owned_test_files(self) -> None:
+        """Every path in TEMPLATE_OWNED_TEST_FILES is present in SETUP_FILES."""
+        from tools.pyproject_template.cleanup import SETUP_FILES
+        from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
+
+        missing = [p for p in TEMPLATE_OWNED_TEST_FILES if p not in SETUP_FILES]
+        assert not missing, (
+            f"SETUP_FILES is missing template-owned test paths: {missing}. "
+            "Ensure SETUP_FILES uses *TEMPLATE_OWNED_TEST_FILES in cleanup.py."
+        )
+
+    def test_setup_only_cleanup_targets_include_owned_tests(self, tmp_path: Path) -> None:
+        """``get_files_to_delete`` for SETUP_ONLY lists template-owned tests when present."""
+        from tools.pyproject_template.cleanup import CleanupMode, get_files_to_delete
+        from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
+
+        # Create one of the owned test files on disk so get_files_to_delete can find it.
+        sample_rel = TEMPLATE_OWNED_TEST_FILES[0]
+        sample_path = tmp_path / sample_rel
+        sample_path.parent.mkdir(parents=True, exist_ok=True)
+        sample_path.write_text("# placeholder\n", encoding="utf-8")
+
+        files = get_files_to_delete(CleanupMode.SETUP_ONLY, tmp_path)
+        file_posix = [f.relative_to(tmp_path).as_posix() for f in files]
+        assert sample_rel in file_posix, (
+            f"{sample_rel!r} was not targeted by SETUP_ONLY cleanup. "
+            "Check that SETUP_FILES includes *TEMPLATE_OWNED_TEST_FILES."
+        )

--- a/tests/template/test_properties.py
+++ b/tests/template/test_properties.py
@@ -1,112 +1,17 @@
-"""Property-based tests using Hypothesis.
+"""Property-based tests for the skeleton package (downstream-owned).
 
-Tests invariant properties of utility functions and core module
-using randomly generated inputs rather than hand-picked examples.
+Only skeleton assertions live here (greet, etc.).  Tooling assertions for
+``tools.pyproject_template.utils`` have been moved to the template-owned
+``tests/template/test_utils_properties.py``.
 """
 
 from __future__ import annotations
-
-import re
 
 import pytest
 from hypothesis import example, given
 from hypothesis import strategies as st
 
 from package_name.core import greet
-from tools.pyproject_template.utils import (
-    is_github_url,
-    validate_email,
-    validate_package_name,
-    validate_pypi_name,
-)
-
-# ---------------------------------------------------------------------------
-# validate_package_name
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.property
-class TestValidatePackageNameProperties:
-    """Property-based tests for validate_package_name."""
-
-    @given(name=st.text(min_size=1))
-    @example("MyPackage")
-    @example("123start")
-    @example("hello-world")
-    @example("__leading__")
-    def test_output_contains_only_valid_chars(self, name: str) -> None:
-        """Output must only contain lowercase letters, digits, and underscores."""
-        result = validate_package_name(name)
-        if result:
-            assert re.fullmatch(r"[a-z0-9_]+", result), f"Invalid chars in output: {result!r}"
-
-    @given(name=st.text(min_size=1))
-    @example("9lives")
-    def test_output_never_starts_with_digit(self, name: str) -> None:
-        """Output must never start with a digit (Python identifier rule)."""
-        result = validate_package_name(name)
-        if result:
-            assert not result[0].isdigit(), f"Output starts with digit: {result!r}"
-
-    @given(name=st.from_regex(r"[a-zA-Z][a-zA-Z0-9_]*", fullmatch=True))
-    @example("valid_name")
-    def test_valid_input_produces_nonempty_output(self, name: str) -> None:
-        """Input with at least one alpha char produces non-empty output."""
-        result = validate_package_name(name)
-        assert result, f"Expected non-empty output for input: {name!r}"
-
-    @given(name=st.text(min_size=1))
-    def test_output_has_no_leading_trailing_underscores(self, name: str) -> None:
-        """Output must not have leading or trailing underscores (after strip).
-
-        Exception: a leading underscore is added when the result starts with a digit.
-        """
-        result = validate_package_name(name)
-        if result:
-            # If it starts with _, the next char must be a digit (the prefix case)
-            if result.startswith("_"):
-                assert len(result) > 1 and result[1].isdigit(), (
-                    f"Unexpected leading underscore: {result!r}"
-                )
-            assert not result.endswith("_"), f"Trailing underscore in output: {result!r}"
-
-
-# ---------------------------------------------------------------------------
-# validate_pypi_name
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.property
-class TestValidatePypiNameProperties:
-    """Property-based tests for validate_pypi_name."""
-
-    @given(name=st.text(min_size=1))
-    @example("My--Package")
-    @example("--leading")
-    @example("trailing--")
-    def test_output_contains_only_valid_chars(self, name: str) -> None:
-        """Output must only contain lowercase letters, digits, and hyphens."""
-        result = validate_pypi_name(name)
-        if result:
-            assert re.fullmatch(r"[a-z0-9-]+", result), f"Invalid chars in output: {result!r}"
-
-    @given(name=st.text(min_size=1))
-    @example("a--b--c")
-    def test_no_consecutive_hyphens(self, name: str) -> None:
-        """Output must not contain consecutive hyphens."""
-        result = validate_pypi_name(name)
-        assert "--" not in result, f"Consecutive hyphens in output: {result!r}"
-
-    @given(name=st.text(min_size=1))
-    @example("-leading")
-    @example("trailing-")
-    def test_no_leading_or_trailing_hyphens(self, name: str) -> None:
-        """Output must not start or end with a hyphen."""
-        result = validate_pypi_name(name)
-        if result:
-            assert not result.startswith("-"), f"Leading hyphen: {result!r}"
-            assert not result.endswith("-"), f"Trailing hyphen: {result!r}"
-
 
 # ---------------------------------------------------------------------------
 # greet
@@ -144,66 +49,3 @@ class TestGreetProperties:
         """The greeting must exactly match 'Hello, {name}!'."""
         result = greet(name)
         assert result == f"Hello, {name}!", f"Unexpected format: {result!r}"
-
-
-# ---------------------------------------------------------------------------
-# validate_email
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.property
-class TestValidateEmailProperties:
-    """Property-based tests for validate_email."""
-
-    def test_empty_string_returns_false(self) -> None:
-        """Empty string must not be considered a valid email."""
-        assert validate_email("") is False
-
-    @given(text=st.text(alphabet=st.characters(blacklist_characters="@"), min_size=1))
-    def test_string_without_at_returns_false(self, text: str) -> None:
-        """A string without '@' cannot be a valid email."""
-        assert validate_email(text) is False
-
-    @given(
-        local=st.from_regex(r"[a-zA-Z0-9._%+-]+", fullmatch=True),
-        domain=st.from_regex(r"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", fullmatch=True),
-    )
-    @example(local="user", domain="example.com")
-    def test_well_formed_email_returns_true(self, local: str, domain: str) -> None:
-        """Well-formed local@domain emails must validate as true."""
-        email = f"{local}@{domain}"
-        assert validate_email(email) is True, f"Expected valid: {email!r}"
-
-
-# ---------------------------------------------------------------------------
-# is_github_url
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.property
-class TestIsGithubUrlProperties:
-    """Property-based tests for is_github_url."""
-
-    @given(
-        domain=st.from_regex(r"[a-z]{3,12}\.(com|org|net|io)", fullmatch=True).filter(
-            lambda d: "github" not in d
-        )
-    )
-    def test_non_github_domains_return_false(self, domain: str) -> None:
-        """URLs with non-github domains must return False."""
-        url = f"https://{domain}/owner/repo"
-        assert is_github_url(url) is False, f"Expected False for: {url!r}"
-
-    @given(path=st.from_regex(r"/[a-z]+/[a-z]+", fullmatch=True))
-    @example(path="/owner/repo")
-    def test_github_com_returns_true(self, path: str) -> None:
-        """URLs with github.com domain must return True."""
-        url = f"https://github.com{path}"
-        assert is_github_url(url) is True, f"Expected True for: {url!r}"
-
-    @given(text=st.text(min_size=0, max_size=50))
-    def test_never_raises(self, text: str) -> None:
-        """is_github_url must never raise an exception for any input."""
-        # Should return a bool without raising
-        result = is_github_url(text)
-        assert isinstance(result, bool)

--- a/tests/template/test_utils.py
+++ b/tests/template/test_utils.py
@@ -583,6 +583,69 @@ class TestGitHubCLI:
             assert GitHubCLI.is_authenticated() is False
 
 
+class TestTemplateOwnedTestFilesInvariant:
+    """Invariants that enforce TEMPLATE_OWNED_TEST_FILES as the single source of truth."""
+
+    def test_every_path_exists_on_disk(self) -> None:
+        """Every path listed in TEMPLATE_OWNED_TEST_FILES must exist in the repo."""
+        from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
+
+        # Repo root: two parents up from tests/template/
+        repo_root = Path(__file__).parent.parent.parent
+        for rel in TEMPLATE_OWNED_TEST_FILES:
+            full = repo_root / rel
+            assert full.is_file(), f"Listed path does not exist on disk: {rel}"
+
+    def test_checker_exclusion_set_matches_constant(self) -> None:
+        """_TEMPLATE_OWNED_TEST_SET must equal frozenset(TEMPLATE_OWNED_TEST_FILES)."""
+        from tools.pyproject_template.check_template_updates import _TEMPLATE_OWNED_TEST_SET
+        from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
+
+        assert frozenset(TEMPLATE_OWNED_TEST_FILES) == _TEMPLATE_OWNED_TEST_SET, (
+            "_TEMPLATE_OWNED_TEST_SET has diverged from TEMPLATE_OWNED_TEST_FILES. "
+            "Update check_template_updates.py to re-derive from the constant."
+        )
+
+    def test_cleanup_setup_files_includes_all_owned_tests(self) -> None:
+        """cleanup.SETUP_FILES must contain every entry in TEMPLATE_OWNED_TEST_FILES."""
+        from tools.pyproject_template.cleanup import SETUP_FILES
+        from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
+
+        missing = [p for p in TEMPLATE_OWNED_TEST_FILES if p not in SETUP_FILES]
+        assert not missing, (
+            f"SETUP_FILES is missing template-owned test paths: {missing}. "
+            "Add them to cleanup.py SETUP_FILES via *TEMPLATE_OWNED_TEST_FILES."
+        )
+
+    def test_every_tooling_importing_test_is_classified(self) -> None:
+        """Every tests/template/test_*.py that imports the tooling must be classified.
+
+        Guards the *inverse* of the checks above: a new tooling test that someone
+        forgets to add to TEMPLATE_OWNED_TEST_FILES would otherwise ship to
+        downstream projects and only trip the runtime coupling guard at sync time
+        (a warning), never failing template CI. Reuses the guard's own import
+        detection so the two definitions cannot drift apart.
+        """
+        from tools.pyproject_template.check_template_updates import (
+            _imports_pyproject_tooling,
+        )
+        from tools.pyproject_template.utils import TEMPLATE_OWNED_TEST_FILES
+
+        template_tests_dir = Path(__file__).parent
+        owned = set(TEMPLATE_OWNED_TEST_FILES)
+        unclassified = [
+            f"tests/template/{test_file.name}"
+            for test_file in sorted(template_tests_dir.glob("test_*.py"))
+            if _imports_pyproject_tooling(test_file.read_text(encoding="utf-8"))
+            and f"tests/template/{test_file.name}" not in owned
+        ]
+        assert not unclassified, (
+            "These tests import tools.pyproject_template but are not in "
+            f"TEMPLATE_OWNED_TEST_FILES: {unclassified}. Add them to the constant "
+            "in utils.py (or drop the tooling import if the test is downstream-owned)."
+        )
+
+
 class TestFilesToUpdate:
     """Tests for FILES_TO_UPDATE constant."""
 

--- a/tests/template/test_utils_properties.py
+++ b/tests/template/test_utils_properties.py
@@ -1,0 +1,171 @@
+"""Property-based tests for tools.pyproject_template.utils (template-owned).
+
+These tests are template-owned: they run in the template's own CI, are
+excluded from the drift checker, and are shed from downstreams via cleanup.
+Only tooling assertions live here.  Skeleton assertions (greet, etc.) live in
+the downstream-owned ``tests/template/test_properties.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from tools.pyproject_template.utils import (
+    is_github_url,
+    validate_email,
+    validate_package_name,
+    validate_pypi_name,
+)
+
+# ---------------------------------------------------------------------------
+# validate_package_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestValidatePackageNameProperties:
+    """Property-based tests for validate_package_name."""
+
+    @given(name=st.text(min_size=1))
+    @example("MyPackage")
+    @example("123start")
+    @example("hello-world")
+    @example("__leading__")
+    def test_output_contains_only_valid_chars(self, name: str) -> None:
+        """Output must only contain lowercase letters, digits, and underscores."""
+        result = validate_package_name(name)
+        if result:
+            assert re.fullmatch(r"[a-z0-9_]+", result), f"Invalid chars in output: {result!r}"
+
+    @given(name=st.text(min_size=1))
+    @example("9lives")
+    def test_output_never_starts_with_digit(self, name: str) -> None:
+        """Output must never start with a digit (Python identifier rule)."""
+        result = validate_package_name(name)
+        if result:
+            assert not result[0].isdigit(), f"Output starts with digit: {result!r}"
+
+    @given(name=st.from_regex(r"[a-zA-Z][a-zA-Z0-9_]*", fullmatch=True))
+    @example("valid_name")
+    def test_valid_input_produces_nonempty_output(self, name: str) -> None:
+        """Input with at least one alpha char produces non-empty output."""
+        result = validate_package_name(name)
+        assert result, f"Expected non-empty output for input: {name!r}"
+
+    @given(name=st.text(min_size=1))
+    def test_output_has_no_leading_trailing_underscores(self, name: str) -> None:
+        """Output must not have leading or trailing underscores (after strip).
+
+        Exception: a leading underscore is added when the result starts with a digit.
+        """
+        result = validate_package_name(name)
+        if result:
+            # If it starts with _, the next char must be a digit (the prefix case)
+            if result.startswith("_"):
+                assert len(result) > 1 and result[1].isdigit(), (
+                    f"Unexpected leading underscore: {result!r}"
+                )
+            assert not result.endswith("_"), f"Trailing underscore in output: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# validate_pypi_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestValidatePypiNameProperties:
+    """Property-based tests for validate_pypi_name."""
+
+    @given(name=st.text(min_size=1))
+    @example("My--Package")
+    @example("--leading")
+    @example("trailing--")
+    def test_output_contains_only_valid_chars(self, name: str) -> None:
+        """Output must only contain lowercase letters, digits, and hyphens."""
+        result = validate_pypi_name(name)
+        if result:
+            assert re.fullmatch(r"[a-z0-9-]+", result), f"Invalid chars in output: {result!r}"
+
+    @given(name=st.text(min_size=1))
+    @example("a--b--c")
+    def test_no_consecutive_hyphens(self, name: str) -> None:
+        """Output must not contain consecutive hyphens."""
+        result = validate_pypi_name(name)
+        assert "--" not in result, f"Consecutive hyphens in output: {result!r}"
+
+    @given(name=st.text(min_size=1))
+    @example("-leading")
+    @example("trailing-")
+    def test_no_leading_or_trailing_hyphens(self, name: str) -> None:
+        """Output must not start or end with a hyphen."""
+        result = validate_pypi_name(name)
+        if result:
+            assert not result.startswith("-"), f"Leading hyphen: {result!r}"
+            assert not result.endswith("-"), f"Trailing hyphen: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# validate_email
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestValidateEmailProperties:
+    """Property-based tests for validate_email."""
+
+    def test_empty_string_returns_false(self) -> None:
+        """Empty string must not be considered a valid email."""
+        assert validate_email("") is False
+
+    @given(text=st.text(alphabet=st.characters(blacklist_characters="@"), min_size=1))
+    def test_string_without_at_returns_false(self, text: str) -> None:
+        """A string without '@' cannot be a valid email."""
+        assert validate_email(text) is False
+
+    @given(
+        local=st.from_regex(r"[a-zA-Z0-9._%+-]+", fullmatch=True),
+        domain=st.from_regex(r"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", fullmatch=True),
+    )
+    @example(local="user", domain="example.com")
+    def test_well_formed_email_returns_true(self, local: str, domain: str) -> None:
+        """Well-formed local@domain emails must validate as true."""
+        email = f"{local}@{domain}"
+        assert validate_email(email) is True, f"Expected valid: {email!r}"
+
+
+# ---------------------------------------------------------------------------
+# is_github_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestIsGithubUrlProperties:
+    """Property-based tests for is_github_url."""
+
+    @given(
+        domain=st.from_regex(r"[a-z]{3,12}\.(com|org|net|io)", fullmatch=True).filter(
+            lambda d: "github" not in d
+        )
+    )
+    def test_non_github_domains_return_false(self, domain: str) -> None:
+        """URLs with non-github domains must return False."""
+        url = f"https://{domain}/owner/repo"
+        assert is_github_url(url) is False, f"Expected False for: {url!r}"
+
+    @given(path=st.from_regex(r"/[a-z]+/[a-z]+", fullmatch=True))
+    @example(path="/owner/repo")
+    def test_github_com_returns_true(self, path: str) -> None:
+        """URLs with github.com domain must return True."""
+        url = f"https://github.com{path}"
+        assert is_github_url(url) is True, f"Expected True for: {url!r}"
+
+    @given(text=st.text(min_size=0, max_size=50))
+    def test_never_raises(self, text: str) -> None:
+        """is_github_url must never raise an exception for any input."""
+        result = is_github_url(text)
+        assert isinstance(result, bool)

--- a/tools/pyproject_template/check_template_updates.py
+++ b/tools/pyproject_template/check_template_updates.py
@@ -26,6 +26,7 @@ import filecmp
 import fnmatch
 import json
 import os
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -44,12 +45,16 @@ if str(_script_dir) not in sys.path:
 
 # Import shared utilities
 from utils import (  # noqa: E402
+    TEMPLATE_OWNED_TEST_FILES,
     TEMPLATE_REPO,
     TEMPLATE_URL,
     Colors,
     Logger,
     download_and_extract_archive,
 )
+
+# Frozen set for O(1) membership tests in the hot path of compare_files.
+_TEMPLATE_OWNED_TEST_SET: frozenset[str] = frozenset(TEMPLATE_OWNED_TEST_FILES)
 
 # Default archive URL derived from template constants
 DEFAULT_ARCHIVE_URL = f"{TEMPLATE_URL}/archive/refs/heads/main.zip"
@@ -222,12 +227,77 @@ def compare_files(
 
         # File differs (or is missing). Bucket it.
         rel_str = rel_path.as_posix()
+
+        # Template-owned tooling tests are never adoptable drift: they live and
+        # run in the template's own CI only. Skip them silently so they never
+        # appear in different_files (and therefore never show up as "please
+        # adopt this test" suggestions to downstream projects).
+        if rel_str in _TEMPLATE_OWNED_TEST_SET:
+            continue
+
         if excludes and any(fnmatch.fnmatch(rel_str, pat) for pat in excludes):
             excluded_files.append(rel_path)
         else:
             different_files.append(rel_path)
 
     return sorted(different_files), sorted(excluded_files)
+
+
+def _imports_pyproject_tooling(content: str) -> bool:
+    """Return True if ``content`` has a real import of the pyproject_template tooling.
+
+    Anchored to actual ``import`` / ``from`` statements so that docstring or comment
+    mentions of ``tools.pyproject_template`` (for example the note left behind in the
+    split-out ``tests/template/test_properties.py``) do not count. This also keeps the
+    coupling guard from matching ``tools.doit`` imports, which ``bootstrap --sync`` does
+    not refresh.
+    """
+    return bool(
+        re.search(
+            r"^\s*(?:from|import)\s+tools\.pyproject_template\b",
+            content,
+            re.MULTILINE,
+        )
+    )
+
+
+def _emit_coupling_warnings(different_files: list[Path], project_root: Path) -> None:
+    """Warn when a drifted non-template-owned test imports tooling that has also drifted.
+
+    This is a backstop for future straddlers: if a ``tests/template/test_*.py``
+    file is NOT in ``TEMPLATE_OWNED_TEST_FILES`` (so it shows up as normal drift)
+    but its local copy imports from ``tools.pyproject_template``, AND the tooling
+    itself has also drifted, the downstream needs to run ``bootstrap --sync``
+    first so the tooling matches what the test expects.
+
+    Args:
+        different_files: Paths (upstream-relative) returned by ``compare_files``.
+        project_root: Downstream project root.
+    """
+    # Only engage the guard when the tooling itself has also drifted.
+    tooling_drifted = any(
+        file_path.as_posix().startswith("tools/pyproject_template/")
+        for file_path in different_files
+    )
+    if not tooling_drifted:
+        return
+
+    for file_path in different_files:
+        rel_str = file_path.as_posix()
+        if not (rel_str.startswith("tests/template/test_") and rel_str.endswith(".py")):
+            continue
+        local_file = project_root / file_path
+        if not local_file.is_file():
+            continue
+        try:
+            content = local_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _imports_pyproject_tooling(content):
+            Logger.warning(
+                f"{rel_str}: imports tools/pyproject_template/ which has also drifted — "
+                "run 'bootstrap --sync' to refresh tooling before adopting this test."
+            )
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -349,6 +419,10 @@ def run_check_updates(
                 print(f"  {file_path}")
             else:
                 print(f"  {file_path} {Colors.CYAN}(new in template){Colors.NC}")
+
+        # Coupling guard: warn when a non-template-owned drifted test imports
+        # tooling that has also drifted — the user needs to bootstrap --sync first.
+        _emit_coupling_warnings(different_files, project_root)
 
         # Show how to compare
         Logger.header("How to Review Changes")

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -34,7 +34,7 @@ _script_dir = Path(__file__).parent
 if str(_script_dir) not in sys.path:
     sys.path.insert(0, str(_script_dir))
 
-from utils import Logger  # noqa: E402
+from utils import TEMPLATE_OWNED_TEST_FILES, Logger  # noqa: E402
 
 
 class CleanupMode(Enum):
@@ -54,13 +54,16 @@ class CleanupResult(NamedTuple):
 
 
 # Files to delete when removing setup files only
-# These are only needed for initial project creation
+# These are only needed for initial project creation.
+# TEMPLATE_OWNED_TEST_FILES are included so that SETUP_ONLY sheds tooling
+# tests from downstream projects (they only run in the template's own CI).
 SETUP_FILES = [
     "bootstrap.py",
     "tools/pyproject_template/setup_repo.py",
     "tools/pyproject_template/migrate_existing_project.py",
     "docs/template/new-project.md",
     "docs/template/migration.md",
+    *TEMPLATE_OWNED_TEST_FILES,
 ]
 
 # Additional files to delete when removing all template files

--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -23,6 +23,21 @@ except ModuleNotFoundError:  # pragma: no cover
 TEMPLATE_REPO = "endavis/pyproject-template"
 TEMPLATE_URL = f"https://github.com/{TEMPLATE_REPO}"
 
+# Tooling tests that are template-owned: they live in the template's own CI,
+# are excluded from the drift checker, and are shed from downstreams by cleanup.
+# Both check_template_updates.py and cleanup.py import this list — never
+# hardcode it in either consumer.
+TEMPLATE_OWNED_TEST_FILES: list[str] = [
+    "tests/template/test_pyproject_template_main.py",
+    "tests/template/test_check_template_updates.py",
+    "tests/template/test_cleanup.py",
+    "tests/template/test_repo_settings.py",
+    "tests/template/test_setup_repo.py",
+    "tests/template/test_bootstrap.py",
+    "tests/template/test_utils.py",
+    "tests/template/test_utils_properties.py",
+]
+
 # Files to update during placeholder replacement (single source of truth)
 # Used by both configure.py and setup_repo.py
 FILES_TO_UPDATE: tuple[str, ...] = (


### PR DESCRIPTION
## Description

Draws a consistent template-sync boundary. Tooling tests (`tests/template/test_*.py` that exercise `tools/pyproject_template/`) are now **template-owned**: they run only in the template's own CI, are excluded from the drift checker, and are shed from downstream projects by `cleanup --setup`.

Previously `bootstrap --sync` refreshed only the tooling (7 modules, no tests) while the drift checker (`compare_files`) compared the entire tree — so tooling tests surfaced as adoptable drift. A downstream could adopt a tooling test whose implementation had not been refreshed in the same step, producing a non-runnable test (the shape of PR #630: a `manage.py` public-API change plus its test in one commit).

This implements **Approach A** (template-owned) from the plan rather than the issue's original Approach B (add tests to `SYNC_FILES`): downstreams consume the tooling without modifying it, and the tests depend on template-only fixtures (the `package_name` skeleton) that would break once a downstream is configured. See ADR-9017 for the trade-off and known limitations.

## Related Issue

Addresses #631

## Type of Change

- [x] Code refactoring

## Changes Made

- **Single source of truth:** `TEMPLATE_OWNED_TEST_FILES` in `utils.py`, imported by both `check_template_updates.py` and `cleanup.py` (never hardcoded).
- **Drift checker:** `compare_files()` silently skips template-owned tests; a coupling guard warns when a drifted, non-owned `tests/template/` test imports the tooling and the tooling has also drifted.
- **Cleanup:** `SETUP_FILES` sheds the template-owned tests from downstreams via `cleanup --setup`.
- **Straddler split:** `test_properties.py` keeps only skeleton (`greet`) assertions (downstream-owned); tooling property tests moved to the new `test_utils_properties.py` (template-owned).
- **Invariants:** forward (every listed path exists; checker and cleanup agree) and inverse (every tooling-importing test is classified, else CI fails). Import detection is import-anchored and shared between the CI invariant and the runtime guard so they cannot diverge.
- **Docs:** `ai-sync-checklist.md` reframed to refresh tooling first on every sync, with the version-skew caveat and a note that tooling tests are template-owned.
- **ADR-9017:** records the decision, the A-vs-B trade-off, the one-time cleanup for existing downstreams, and the stale-comparator known limitation.

## Testing

- [x] All existing tests pass (`doit check` green: test, lint, type, security, spell)
- [x] Added new tests for new functionality (checker exclusion, coupling guard, forward + inverse invariants, straddler split)
- [x] Manually verified the completeness test ignores the docstring mention left in the split `test_properties.py`

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

## Additional Notes

- `bootstrap.py` `SYNC_FILES` is intentionally unchanged (Approach A).
- Scope is `tools/pyproject_template/` only; the parallel `tools/doit/` + `test_doit_*.py` case is deferred to a follow-up.
- The `needs-adr` requirement is satisfied by ADR-9017.
- CHANGELOG.md is generated from conventional commits at release time (commitizen `update_changelog_on_bump`), not edited per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
