### PR TITLE
feat: add optional Antigravity CLI (agy) statusline

### DIFF
--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -7,12 +7,13 @@ audience:
 tags:
   - ai
   - claude
+  - antigravity
   - configuration
 ---
 
 # Claude Code Statusline
 
-The template includes a custom statusline for Claude Code sessions that provides useful context at a glance.
+The template includes custom statuslines for AI CLI sessions that provide useful context at a glance.
 
 ## Example Output
 
@@ -164,3 +165,116 @@ Adjust `MAX_AGE` at the top of the script. To force a refresh: `rm ~/.cache/clau
 ### Colors not displaying
 
 Some terminals may not support 256-color mode. Try setting `COLOR="gray"` for basic output.
+
+## Antigravity CLI (agy) Statusline
+
+The `agy` statusline is opt-in: unlike the Claude statusline, which is committed and auto-wired
+via `.claude/settings.json`, `agy`'s statusline is configured in the user's **global**
+`~/.gemini/antigravity-cli/settings.json` — outside the repo-committed `.agents/` workspace
+config — so it cannot be auto-provisioned per-clone. This mirrors how
+`tools/statusline/claude-usage.sh` is opt-in.
+
+### Example Output
+
+```
+📁 pyproject-template | 🐍 package-name | Python: 3.12.12
+@endavis | 🔀 main (0 files uncommitted, synced 5m ago) | ● working
+Gemini 3 Pro | ██░░░░░░░░ 12% of 1048k tokens
+```
+
+### Enable (Opt-In)
+
+Add the following to `~/.gemini/antigravity-cli/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "command": "bash /absolute/path/to/pyproject-template/tools/statusline/agy-statusline.sh",
+    "enabled": true
+  }
+}
+```
+
+> **`statusLine` (camelCase):** The key must be camelCase — `statusLine`, not `statusline`.
+> Lowercase `statusline` is silently ignored by `agy`.
+
+> **Absolute path required:** The global settings file has no `$CLAUDE_PROJECT_DIR` equivalent.
+> Replace the placeholder with the full absolute path to this repository on your machine.
+
+### What It Shows
+
+Like the Claude statusline, the **directory, virtual environment, Python version, git branch +
+status, and GitHub username are computed locally** — `agy`'s payload reports only `vcs.type`, not
+the branch, so the script derives them itself (via `git`, `python`, `$VIRTUAL_ENV`, and `gh`),
+anchored on the workspace directory. `agy`-native fields come from the JSON payload on stdin:
+
+| Field | Used for |
+|-------|----------|
+| `.workspace.current_dir` (or `.cwd`) | Anchor for local git / venv / Python / `gh` detection |
+| `.model.display_name` | Model label |
+| `.agent_state` | Colored state dot + label |
+| `.context_window.context_window_size` | Token-window size shown after the bar |
+| `.context_window.current_usage.*` | Token occupancy for the context bar (falls back to `.context_window.used_percentage`) |
+| `.sandbox.enabled` | Sandbox indicator (quota segment, opt-in) |
+| `.quota["gemini-5h"]`, `.quota["gemini-weekly"]` | Quota segment (opt-in) |
+
+### Color Theme
+
+The script shares the same `COLOR` theme knob as `.claude/statusline-command.sh`.
+Edit `tools/statusline/agy-statusline.sh` and change `COLOR="blue"` at the top.
+Available themes: `gray`, `orange`, `blue`, `teal`, `green`, `lavender`, `rose`, `gold`,
+`slate`, `cyan`.
+
+### Opt-In: Quota Display
+
+By default the `agy` statusline shows the three lines above. Set `AGY_STATUSLINE_EXTRAS=1` to
+append `agy`'s quota usage to the model/context line: 5-hour and weekly usage (from the Gemini
+`quota` block, rendered as *used* percent = `1 − remaining_fraction`) plus a sandbox indicator
+(🔒, shown only when the sandbox is enabled). This mirrors how `CLAUDE_USAGE_STATUSLINE` gates
+the Claude Max usage segment — the base render is unchanged; the env var only appends a segment.
+
+```bash
+# In ~/.bashrc, ~/.zshrc, or .envrc.local — the shell that launches `agy`
+export AGY_STATUSLINE_EXTRAS=1
+```
+
+Example with the segment enabled:
+
+```
+📁 pyproject-template | 🐍 package-name | Python: 3.12.12
+@endavis | 🔀 main (0 files uncommitted, synced 5m ago) | ● working
+Gemini 3 Pro | ██░░░░░░░░ 12% of 1048k tokens | 5h:0% · wk:1% · 🔒
+```
+
+The var must be exported in the shell `agy` is launched from: `agy` runs the statusline script
+as a subprocess and passes its environment through, so a var set only for the current command
+will not reach it. To disable: `unset AGY_STATUSLINE_EXTRAS` and restart `agy`.
+
+### Requirements
+
+- `bash` — shell runtime
+- `jq` — JSON processor (already required by the base Claude statusline)
+- `git` — for branch and status (computed locally; `agy` reports only `vcs.type`)
+- `gh` — GitHub CLI (optional, for the `@username` segment)
+- `python` — optional, for the active Python version
+- `awk` — for the opt-in quota percentages (part of coreutils/busybox; already present)
+
+### Troubleshooting
+
+**Statusline not appearing:** verify the config key is `statusLine` (camelCase) and
+`enabled` is `true`.
+
+**Branch / directory blank:** the script anchors on `.workspace.current_dir`/`.cwd`, falling back
+to the process working directory. If `agy` launches it from outside the repo, git detection can't
+find the branch.
+
+**Test manually:**
+
+```bash
+echo '{"agent_state":"working","model":{"display_name":"Gemini 3 Pro"},"context_window":{"context_window_size":1048576,"current_usage":{"input_tokens":26000}},"workspace":{"current_dir":"'"$PWD"'"}}' \
+  | bash tools/statusline/agy-statusline.sh
+```
+
+**References:**
+[official example script](https://github.com/google-antigravity/antigravity-cli/blob/main/examples/statusline/statusline.sh) ·
+[agy statusline docs](https://antigravity.google/docs/cli-statusline)

--- a/tests/test_statusline_agy.py
+++ b/tests/test_statusline_agy.py
@@ -1,0 +1,193 @@
+"""Tests for tools/statusline/agy-statusline.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(text: str) -> str:
+    """Remove ANSI color codes so exact substrings aren't split by color spans."""
+    return _ANSI.sub("", text)
+
+
+# The helper is a bash script targeting Linux/macOS; the Windows GitHub Actions
+# runner's `bash` resolves to wsl.exe (which has no installed distribution),
+# so subprocess invocations cannot exercise the real shell behavior.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash helper is Linux/macOS only; Windows runner has no usable bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AGY = REPO_ROOT / "tools" / "statusline" / "agy-statusline.sh"
+
+
+def _run(payload: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Invoke the statusline script with the given JSON payload on stdin."""
+    env = {"PATH": os.environ["PATH"]}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(AGY)],
+        input=payload,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def _make_git_repo(path: Path, branch: str = "trunk") -> None:
+    """Create a minimal git repo on `branch` with a single commit."""
+    path.mkdir(parents=True, exist_ok=True)
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(path), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init", "-q")
+    git("checkout", "-q", "-b", branch)
+    (path / "README.md").write_text("x", encoding="utf-8")
+    git("add", "-A")
+    git("-c", "user.email=t@example.com", "-c", "user.name=Test", "commit", "-q", "-m", "init")
+
+
+_QUOTA_PAYLOAD = json.dumps(
+    {
+        "model": {"display_name": "Gemini 3 Pro"},
+        "sandbox": {"enabled": True},
+        "quota": {
+            "gemini-5h": {"remaining_fraction": 1.0},
+            "gemini-weekly": {"remaining_fraction": 0.9},
+        },
+    }
+)
+
+
+def test_script_exists_and_executable() -> None:
+    """Script must exist at the expected path and be executable."""
+    assert AGY.exists(), f"Script not found: {AGY}"
+    assert os.access(AGY, os.X_OK), f"Script not executable: {AGY}"
+
+
+def test_script_syntax_valid() -> None:
+    """bash -n must report no syntax errors."""
+    result = subprocess.run(
+        ["bash", "-n", str(AGY)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, f"Syntax error:\n{result.stderr}"
+
+
+def test_directory_and_branch_from_local_git(tmp_path: Path) -> None:
+    """Directory (package name) and branch are computed from the workspace git repo."""
+    repo = tmp_path / "myproj"
+    _make_git_repo(repo, "trunk")
+    payload = json.dumps({"workspace": {"current_dir": str(repo)}, "model": {"display_name": "M"}})
+    result = _run(payload, {"HOME": str(tmp_path)})
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "myproj" in result.stdout  # directory / package name
+    assert "trunk" in result.stdout  # branch computed locally via git
+
+
+def test_git_status_reports_uncommitted(tmp_path: Path) -> None:
+    """An uncommitted file is reflected in the git status segment."""
+    repo = tmp_path / "proj"
+    _make_git_repo(repo, "main")
+    (repo / "dirty.txt").write_text("x", encoding="utf-8")  # untracked → uncommitted
+    payload = json.dumps({"workspace": {"current_dir": str(repo)}})
+    result = _run(payload, {"HOME": str(tmp_path)})
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "uncommitted" in result.stdout
+
+
+def test_model_from_payload() -> None:
+    """model.display_name is rendered."""
+    result = _run(json.dumps({"model": {"display_name": "Gemini 3 Pro"}}))
+    assert result.returncode == 0
+    assert "Gemini 3 Pro" in result.stdout
+
+
+def test_agent_state_label_appears() -> None:
+    """agent_state is rendered as a label."""
+    result = _run(json.dumps({"agent_state": "working"}))
+    assert result.returncode == 0
+    assert "working" in result.stdout
+
+
+def test_context_bar_and_token_count() -> None:
+    """Context bar renders from token occupancy and shows the window size."""
+    payload = json.dumps(
+        {
+            "context_window": {
+                "context_window_size": 1000000,
+                "current_usage": {"input_tokens": 250000},
+            }
+        }
+    )
+    result = _run(payload)
+    assert result.returncode == 0
+    assert any(ch in result.stdout for ch in ("░", "▄", "█"))
+    assert "25%" in result.stdout
+    assert "of 1000k tokens" in result.stdout
+
+
+def test_empty_json_exits_zero_with_defaults() -> None:
+    """Empty JSON object falls back to defaults: rc 0, idle state, no crash."""
+    result = _run("{}")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "idle" in result.stdout
+    assert result.stdout.strip() != ""
+
+
+def test_malformed_stdin_exits_zero_with_defaults() -> None:
+    """Non-JSON stdin falls back to all defaults and exits 0 without crashing."""
+    result = _run("not json")
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert result.stdout.strip() != ""
+
+
+def test_quota_absent_by_default() -> None:
+    """Without AGY_STATUSLINE_EXTRAS, the quota segment is not rendered."""
+    result = _run(_QUOTA_PAYLOAD)
+    assert result.returncode == 0
+    assert "5h:" not in result.stdout
+
+
+def test_quota_present_when_enabled() -> None:
+    """AGY_STATUSLINE_EXTRAS=1 appends 5h and weekly quota (used = 1 - remaining)."""
+    result = _run(_QUOTA_PAYLOAD, {"AGY_STATUSLINE_EXTRAS": "1"})
+    assert result.returncode == 0
+    out = _strip(result.stdout)
+    assert "5h:0%" in out  # remaining_fraction 1.0 → 0% used
+    assert "wk:10%" in out  # remaining_fraction 0.9 → 10% used
+
+
+def test_sandbox_indicator_when_enabled() -> None:
+    """Sandbox lock indicator appears when sandbox.enabled and extras are on."""
+    result = _run(_QUOTA_PAYLOAD, {"AGY_STATUSLINE_EXTRAS": "1"})
+    assert result.returncode == 0
+    assert "🔒" in result.stdout
+
+
+def test_sandbox_absent_when_disabled() -> None:
+    """No sandbox indicator when the sandbox is disabled, even with extras on."""
+    payload = json.dumps({"model": {"display_name": "M"}, "sandbox": {"enabled": False}})
+    result = _run(payload, {"AGY_STATUSLINE_EXTRAS": "1"})
+    assert result.returncode == 0
+    assert "🔒" not in result.stdout

--- a/tools/statusline/agy-statusline.sh
+++ b/tools/statusline/agy-statusline.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+
+# Antigravity CLI (agy) statusline script.
+#
+# Renders Claude-parity project context — directory, venv, Python version, git
+# branch + status, and GitHub user — computed LOCALLY (agy's JSON payload does
+# not carry these; it only reports `vcs.type`). agy-native fields (model,
+# context window, agent state, quota, sandbox) come from the stdin JSON.
+# See docs/development/ai/statusline.md.
+#
+# Color theme: gray, orange, blue, teal, green, lavender, rose, gold, slate, cyan
+COLOR="blue"
+
+# Color codes (identical palette to .claude/statusline-command.sh for visual parity)
+C_RESET='\033[0m'
+C_GRAY='\033[38;5;245m'  # explicit gray for default text
+C_BAR_EMPTY='\033[38;5;238m'
+C_DIM="$C_BAR_EMPTY"  # dim separators
+C_PCT='\033[38;5;71m'  # green: percentage values in quota segment
+C_TIME='\033[38;5;136m'  # gold: reserved for time values
+C_ROSE='\033[38;5;132m'  # rose: error agent-state (fixed, not theme-dependent)
+case "$COLOR" in
+    orange)   C_ACCENT='\033[38;5;173m' ;;
+    blue)     C_ACCENT='\033[38;5;74m' ;;
+    teal)     C_ACCENT='\033[38;5;66m' ;;
+    green)    C_ACCENT='\033[38;5;71m' ;;
+    lavender) C_ACCENT='\033[38;5;139m' ;;
+    rose)     C_ACCENT='\033[38;5;132m' ;;
+    gold)     C_ACCENT='\033[38;5;136m' ;;
+    slate)    C_ACCENT='\033[38;5;60m' ;;
+    cyan)     C_ACCENT='\033[38;5;37m' ;;
+    *)        C_ACCENT="$C_GRAY" ;;
+esac
+
+input=$(cat)
+
+# Extract agy-native fields in one jq pass; fall back to defaults on missing/invalid JSON.
+# The last three fields feed the opt-in quota segment (AGY_STATUSLINE_EXTRAS).
+_fields=()
+mapfile -t _fields < <(
+    printf '%s' "$input" | jq -r '
+        (.workspace.current_dir // .cwd // ""),
+        (.model.display_name // .model.id // "?"),
+        (.agent_state // "idle"),
+        ((.context_window.context_window_size // 0) | tostring),
+        (((.context_window.current_usage.input_tokens // 0)
+          + (.context_window.current_usage.cache_read_input_tokens // 0)
+          + (.context_window.current_usage.cache_creation_input_tokens // 0)) | tostring),
+        ((.context_window.used_percentage // 0) | tostring),
+        ((.sandbox.enabled // false) | tostring),
+        ((.quota["gemini-5h"].remaining_fraction // -1) | tostring),
+        ((.quota["gemini-weekly"].remaining_fraction // -1) | tostring)
+    ' 2>/dev/null
+)
+
+cwd="${_fields[0]:-}"
+model="${_fields[1]:-?}"
+agent_state="${_fields[2]:-idle}"
+ctx_size="${_fields[3]:-0}"
+ctx_used_tokens="${_fields[4]:-0}"
+used_pct_raw="${_fields[5]:-0}"
+sandbox_enabled="${_fields[6]:-false}"
+q5h_frac="${_fields[7]:--1}"
+qwk_frac="${_fields[8]:--1}"
+
+# Anchor the working directory: agy's payload cwd, else the script's own PWD
+# (agy runs the statusline command from the workspace root).
+[[ -z "$cwd" || ! -d "$cwd" ]] && cwd="$PWD"
+
+# --- Directory (package name) ---
+dir=$(basename "$cwd" 2>/dev/null || echo "?")
+
+# --- Python virtual environment ---
+venv_name=""
+if [[ -n "$VIRTUAL_ENV_PROMPT" ]]; then
+    venv_name="$VIRTUAL_ENV_PROMPT"
+elif [[ -n "$VIRTUAL_ENV" ]]; then
+    venv_name="$(basename "$VIRTUAL_ENV")"
+fi
+
+# --- Active Python version ---
+python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>/dev/null || echo "")
+
+# --- GitHub username (optional) ---
+gh_user=$(gh api user --jq ".login" 2>/dev/null || echo "")
+
+# --- Git branch, uncommitted count, and sync status (computed locally) ---
+branch=""
+git_status=""
+if [[ -n "$cwd" && -d "$cwd" ]]; then
+    branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+    if [[ -n "$branch" ]]; then
+        file_count=$(git -C "$cwd" --no-optional-locks status --porcelain -uall 2>/dev/null | wc -l | tr -d ' ')
+
+        sync_status=""
+        upstream=$(git -C "$cwd" rev-parse --abbrev-ref @{upstream} 2>/dev/null)
+        if [[ -n "$upstream" ]]; then
+            fetch_head="$cwd/.git/FETCH_HEAD"
+            fetch_ago=""
+            if [[ -f "$fetch_head" ]]; then
+                fetch_time=$(stat -f %m "$fetch_head" 2>/dev/null || stat -c %Y "$fetch_head" 2>/dev/null)
+                if [[ -n "$fetch_time" ]]; then
+                    now=$(date +%s)
+                    diff=$((now - fetch_time))
+                    if [[ $diff -lt 60 ]]; then
+                        fetch_ago="<1m ago"
+                    elif [[ $diff -lt 3600 ]]; then
+                        fetch_ago="$((diff / 60))m ago"
+                    elif [[ $diff -lt 86400 ]]; then
+                        fetch_ago="$((diff / 3600))h ago"
+                    else
+                        fetch_ago="$((diff / 86400))d ago"
+                    fi
+                fi
+            fi
+
+            counts=$(git -C "$cwd" rev-list --left-right --count HEAD...@{upstream} 2>/dev/null)
+            ahead=$(echo "$counts" | cut -f1)
+            behind=$(echo "$counts" | cut -f2)
+            if [[ "$ahead" -eq 0 && "$behind" -eq 0 ]]; then
+                if [[ -n "$fetch_ago" ]]; then
+                    sync_status="synced ${fetch_ago}"
+                else
+                    sync_status="synced"
+                fi
+            elif [[ "$ahead" -gt 0 && "$behind" -eq 0 ]]; then
+                sync_status="${ahead} ahead"
+            elif [[ "$ahead" -eq 0 && "$behind" -gt 0 ]]; then
+                sync_status="${behind} behind"
+            else
+                sync_status="${ahead} ahead, ${behind} behind"
+            fi
+        else
+            sync_status="no upstream"
+        fi
+
+        if [[ "$file_count" -eq 0 ]]; then
+            git_status="(0 files uncommitted, ${sync_status})"
+        elif [[ "$file_count" -eq 1 ]]; then
+            single_file=$(git -C "$cwd" --no-optional-locks status --porcelain -uall 2>/dev/null | head -1 | sed 's/^...//')
+            git_status="(${single_file} uncommitted, ${sync_status})"
+        else
+            git_status="(${file_count} files uncommitted, ${sync_status})"
+        fi
+    fi
+fi
+
+# --- Agent state (agy-specific): colored dot + label ---
+case "$agent_state" in
+    working|running|thinking|busy|active) state_color="$C_ACCENT" ;;
+    error|failed)                         state_color="$C_ROSE" ;;
+    *)                                    state_color="$C_GRAY" ;;
+esac
+
+# --- Context bar: prefer real token occupancy, else agy's used_percentage ---
+if [[ "$ctx_size" -gt 0 && "$ctx_used_tokens" -gt 0 ]]; then
+    pct=$((ctx_used_tokens * 100 / ctx_size))
+elif [[ "$used_pct_raw" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    pct="${used_pct_raw%%.*}"
+else
+    pct=0
+fi
+[[ $pct -gt 100 ]] && pct=100
+[[ $pct -lt 0 ]] && pct=0
+
+bar=""
+for ((i=0; i<10; i++)); do
+    bar_start=$((i * 10))
+    progress=$((pct - bar_start))
+    if [[ $progress -ge 8 ]]; then
+        bar+="${C_ACCENT}█${C_RESET}"
+    elif [[ $progress -ge 3 ]]; then
+        bar+="${C_ACCENT}▄${C_RESET}"
+    else
+        bar+="${C_BAR_EMPTY}░${C_RESET}"
+    fi
+done
+ctx="${bar} ${C_GRAY}${pct}%"
+[[ "$ctx_size" -gt 0 ]] && ctx+=" of $((ctx_size / 1000))k tokens"
+
+# --- Build output (three lines, mirroring the Claude statusline) ---
+# Line 1: 📁 dir | 🐍 venv | Python: version
+line1="📁 ${dir}"
+[[ -n "$venv_name" ]] && line1+=" | 🐍 ${venv_name}"
+[[ -n "$python_version" ]] && line1+=" | Python: ${python_version}"
+
+# Line 2: @user | 🔀 branch (git status) | ● state
+line2=""
+[[ -n "$gh_user" ]] && line2+="@${gh_user}"
+if [[ -n "$branch" ]]; then
+    [[ -n "$line2" ]] && line2+=" | "
+    line2+="🔀 ${branch} ${git_status}"
+fi
+[[ -n "$line2" ]] && line2+=" | "
+line2+="${state_color}●${C_RESET} ${state_color}${agent_state}${C_RESET}"
+
+# Line 3: model | context bar [| quota extras]
+line3="${C_ACCENT}${model}${C_GRAY} | ${ctx}${C_RESET}"
+
+# Opt-in quota segment (agy-native), gated by AGY_STATUSLINE_EXTRAS.
+# Mirrors CLAUDE_USAGE_STATUSLINE: base render unchanged; this only appends.
+# See docs/development/ai/statusline.md#opt-in-quota-display
+if [[ -n "$AGY_STATUSLINE_EXTRAS" ]]; then
+    seg=""
+    if [[ "$q5h_frac" != "-1" ]]; then
+        used5=$(awk -v f="$q5h_frac" 'BEGIN { printf "%.0f", (1 - f) * 100 }')
+        seg+="${C_ACCENT}5h:${C_PCT}${used5}%${C_RESET}"
+    fi
+    if [[ "$qwk_frac" != "-1" ]]; then
+        usedw=$(awk -v f="$qwk_frac" 'BEGIN { printf "%.0f", (1 - f) * 100 }')
+        [[ -n "$seg" ]] && seg+="${C_GRAY} · "
+        seg+="${C_ACCENT}wk:${C_PCT}${usedw}%${C_RESET}"
+    fi
+    if [[ "$sandbox_enabled" == "true" ]]; then
+        [[ -n "$seg" ]] && seg+="${C_GRAY} · "
+        seg+="🔒"
+    fi
+    [[ -n "$seg" ]] && line3+="${C_GRAY} | ${seg}${C_RESET}"
+fi
+
+printf '%b\n' "$line1"
+printf '%b\n' "$line2"
+printf '%b\n' "$line3"

--- a/tools/statusline/agy-statusline.sh
+++ b/tools/statusline/agy-statusline.sh
@@ -36,8 +36,16 @@ input=$(cat)
 
 # Extract agy-native fields in one jq pass; fall back to defaults on missing/invalid JSON.
 # The last three fields feed the opt-in quota segment (AGY_STATUSLINE_EXTRAS).
+#
+# Populate the array with a `while read` loop rather than `mapfile`: `mapfile`
+# is a bash 4+ builtin, and macOS ships bash 3.2 by default. Process
+# substitution keeps the loop in this shell so the array persists. jq emits one
+# newline-terminated line per field (empty fields become empty lines), so the
+# array always has the same nine elements read positionally below.
 _fields=()
-mapfile -t _fields < <(
+while IFS= read -r _line; do
+    _fields+=("$_line")
+done < <(
     printf '%s' "$input" | jq -r '
         (.workspace.current_dir // .cwd // ""),
         (.model.display_name // .model.id // "?"),


### PR DESCRIPTION
## Description

Adds an opt-in statusline for the Antigravity CLI (`agy`), mirroring the existing Claude Code statusline. `agy` supports the same "JSON-on-stdin → line-on-stdout" contract, so `agy` users in this repo now get the same at-a-glance context Claude users get: directory, virtual environment, Python version, git branch + status, GitHub user, model, and context-window usage.

Because `agy`'s statusline is configured in the user's **global** `~/.gemini/antigravity-cli/settings.json` (outside the repo-committed `.agents/` workspace config), it cannot be auto-provisioned per-clone — so it ships as a committed script plus documented opt-in wiring, mirroring how `tools/statusline/claude-usage.sh` is opt-in.

Like the Claude statusline, git branch/status, directory, venv, Python version, and `@username` are **computed locally** — `agy`'s payload reports only `vcs.type`, not the branch. The real `agy` v1.1.4 stdin payload was confirmed via a probe: it supplies `model`, `agent_state`, `context_window` (with token counts), `sandbox`, and a `quota` block, which the script uses directly.

## Related Issue

Addresses #644

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **`tools/statusline/agy-statusline.sh`** (new): single `jq` pass over `agy`'s stdin JSON (model / context window / agent state / quota / sandbox); computes directory, venv, Python version, git branch + status, and GitHub user locally. Reuses the Claude statusline's 256-color palette and 10-block context bar for visual parity. Renders three themed lines and degrades gracefully (exits 0) on missing `jq` / invalid JSON.
- **Opt-in `AGY_STATUSLINE_EXTRAS=1`**: appends `agy`'s real quota (5-hour + weekly, shown as *used* % = `1 − remaining_fraction`) and a sandbox indicator — the analogue of Claude's `CLAUDE_USAGE_STATUSLINE` usage segment.
- **`docs/development/ai/statusline.md`**: new "Antigravity CLI (agy) Statusline" section — opt-in wiring (`statusLine` camelCase in the global settings, absolute path), fields consumed (noting local compute), quota opt-in, requirements, troubleshooting. Frontmatter `antigravity` tag added; intro generalized to cover both statuslines.
- **`tests/test_statusline_agy.py`** (new): 13 tests — local git-repo fixtures for branch/status, model/context/agent-state rendering, quota + sandbox extras, and graceful fallbacks (empty/malformed input).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Full suite: **1067 passed** in a CI-like environment (`doit test`). Manually exercised against `agy` v1.1.4's real payload and eyeballed the rendered output.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] CHANGELOG.md — N/A; auto-generated from conventional commits at release
- [x] My changes generate no new warnings

## Additional Notes

- **No ADR**: parity tooling following the #640 Antigravity onboarding; no `needs-adr` label and no related ADR in `docs/decisions/`.
- The final design computes git/project context locally rather than trusting `agy`'s payload — confirmed necessary after probing `agy` v1.1.4's actual stdin (`vcs` carries only `type`, not `branch`). This diverges from the initial plan comment on #644, which assumed `agy` supplied `vcs.branch` and per-render counts.
