### PR TITLE
fix: prevent gh api error body from leaking into statusline

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -31,7 +31,10 @@ input=$(cat)
 model=$(echo "$input" | jq -r '.model.display_name // .model.id // "?"')
 cwd=$(echo "$input" | jq -r '.cwd // empty')
 dir=$(basename "$cwd" 2>/dev/null || echo "?")
-gh_user=$(gh api user --jq ".login" 2>/dev/null || echo "")
+# `gh api` writes the HTTP error body to stdout on failure (only the summary
+# line goes to stderr), so clear the capture on non-zero exit — `|| echo ""`
+# would append to the error body instead of replacing it.
+gh_user=$(gh api user --jq ".login" 2>/dev/null) || gh_user=""
 python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" || echo "")
 
 # Extract Python .venv

--- a/docs/development/ai/statusline.md
+++ b/docs/development/ai/statusline.md
@@ -28,7 +28,7 @@ Claude Opus 4.5 | ▓▓░░░░░░░░ ~10% of 200k tokens
 
 - **Current directory** and Python virtual environment name
 - **Python version** currently active
-- **GitHub username** (from `gh` CLI)
+- **GitHub username** (from `gh` CLI; omitted when `gh` is missing or unauthenticated)
 - **Git branch** with uncommitted file count
 - **Sync status** showing ahead/behind commits and last fetch time
 - **Model name** with context usage bar (visual + percentage)
@@ -255,7 +255,8 @@ will not reach it. To disable: `unset AGY_STATUSLINE_EXTRAS` and restart `agy`.
 - `bash` — shell runtime
 - `jq` — JSON processor (already required by the base Claude statusline)
 - `git` — for branch and status (computed locally; `agy` reports only `vcs.type`)
-- `gh` — GitHub CLI (optional, for the `@username` segment)
+- `gh` — GitHub CLI (optional, for the `@username` segment; the segment is
+  dropped if `gh` is absent or its token is invalid)
 - `python` — optional, for the active Python version
 - `awk` — for the opt-in quota percentages (part of coreutils/busybox; already present)
 

--- a/tests/test_statusline_gh_user.py
+++ b/tests/test_statusline_gh_user.py
@@ -1,0 +1,130 @@
+"""Tests for the GitHub user segment shared by both statusline scripts.
+
+`gh api` writes the HTTP error body to stdout on failure, so a naive
+`$(gh api ... || echo "")` capture renders the error JSON into the statusline.
+These tests pin the degradation behavior for both scripts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The statusline scripts are bash targeting Linux/macOS; the Windows GitHub
+# Actions runner's `bash` resolves to wsl.exe (which has no installed
+# distribution), so subprocess invocations cannot exercise real shell behavior.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash statusline scripts are Linux/macOS only; Windows runner has no usable bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_STATUSLINE = REPO_ROOT / ".claude" / "statusline-command.sh"
+AGY_STATUSLINE = REPO_ROOT / "tools" / "statusline" / "agy-statusline.sh"
+
+SCRIPTS = pytest.mark.parametrize(
+    "script",
+    [
+        pytest.param(CLAUDE_STATUSLINE, id="claude"),
+        pytest.param(AGY_STATUSLINE, id="agy"),
+    ],
+)
+
+# Each script reads its own payload shape; supplying both keys exercises either.
+_PAYLOAD = json.dumps(
+    {
+        "model": {"display_name": "TestModel"},
+        "cwd": "/",
+        "workspace": {"current_dir": "/"},
+        "transcript_path": "",
+        "context_window": {"context_window_size": 200000},
+    }
+)
+
+# The literal body GitHub returns for an expired or invalid token.
+_BAD_CREDENTIALS_BODY = """{
+  "message": "Bad credentials",
+  "documentation_url": "https://docs.github.com/rest",
+  "status": "401"
+}"""
+
+
+def _stub_gh(tmp_path: Path, *, stdout: str, stderr: str = "", exit_code: int = 0) -> Path:
+    """Create a `gh` stub on a fresh bin dir and return that dir."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        f"cat <<'STDOUT_EOF'\n{stdout}\nSTDOUT_EOF\n"
+        f"cat >&2 <<'STDERR_EOF'\n{stderr}\nSTDERR_EOF\n"
+        f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+    return bin_dir
+
+
+def _run(script: Path, bin_dir: Path, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke a statusline script with the stub bin dir ahead of the real PATH."""
+    env = {
+        "HOME": str(tmp_path),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "CLAUDE_PROJECT_DIR": str(REPO_ROOT),
+    }
+    return subprocess.run(
+        ["bash", str(script)],
+        input=_PAYLOAD,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@SCRIPTS
+def test_gh_failure_body_not_rendered(script: Path, tmp_path: Path) -> None:
+    """A 401 body on gh's stdout must not leak into the statusline."""
+    bin_dir = _stub_gh(
+        tmp_path,
+        stdout=_BAD_CREDENTIALS_BODY,
+        stderr="gh: Bad credentials (HTTP 401)\n",
+        exit_code=1,
+    )
+
+    result = _run(script, bin_dir, tmp_path)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "Bad credentials" not in result.stdout
+    assert "documentation_url" not in result.stdout
+    assert '"status": "401"' not in result.stdout
+    # The whole user segment degrades away rather than rendering a bare marker.
+    assert "@" not in result.stdout
+
+
+@SCRIPTS
+def test_gh_missing_renders_no_user_segment(script: Path, tmp_path: Path) -> None:
+    """A `gh` that is absent (exit 127, no stdout) yields no user segment."""
+    bin_dir = _stub_gh(tmp_path, stdout="", stderr="gh: command not found\n", exit_code=127)
+
+    result = _run(script, bin_dir, tmp_path)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "@" not in result.stdout
+
+
+@SCRIPTS
+def test_gh_success_renders_login(script: Path, tmp_path: Path) -> None:
+    """A successful `gh api user` still renders the login, prefixed with `@`."""
+    bin_dir = _stub_gh(tmp_path, stdout="octocat", exit_code=0)
+
+    result = _run(script, bin_dir, tmp_path)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "@octocat" in result.stdout

--- a/tools/statusline/agy-statusline.sh
+++ b/tools/statusline/agy-statusline.sh
@@ -90,7 +90,10 @@ fi
 python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>/dev/null || echo "")
 
 # --- GitHub username (optional) ---
-gh_user=$(gh api user --jq ".login" 2>/dev/null || echo "")
+# `gh api` writes the HTTP error body to stdout on failure (only the summary
+# line goes to stderr), so clear the capture on non-zero exit — `|| echo ""`
+# would append to the error body instead of replacing it.
+gh_user=$(gh api user --jq ".login" 2>/dev/null) || gh_user=""
 
 # --- Git branch, uncommitted count, and sync status (computed locally) ---
 branch=""


### PR DESCRIPTION
## Description

Both statusline scripts captured the GitHub username with a pattern that let `gh api`'s
HTTP **error body** render into the statusline:

```bash
gh_user=$(gh api user --jq ".login" 2>/dev/null || echo "")
```

`gh api` writes the response body to **stdout** even on failure — only the
`gh: Bad credentials (HTTP 401)` summary goes to stderr. So `2>/dev/null` suppressed
nothing useful, the JSON error body was captured into `gh_user`, and `|| echo ""`
appended an empty string after it instead of replacing it. Any `gh` failure — expired
token, network outage, rate limit — rendered a multi-line JSON blob into the statusline:

```
📁 pyproject-template | 🐍 package-name | Python: 3.12.12
@{
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
} | 🔀 feat/644-agy-statusline (4 files uncommitted, no upstream)
```

The fix clears the capture on non-zero exit, so the `@username` segment is omitted and
the statusline degrades exactly as it does when `gh` isn't installed.

## Related Issue

Addresses #674

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.claude/statusline-command.sh` — replace `|| echo ""` with assignment-level
  `|| gh_user=""`, which fires on `gh`'s exit status and overwrites the captured body
- `tools/statusline/agy-statusline.sh` — same fix; the Antigravity statusline was
  copied from the Claude one and inherited the identical bug
- `tests/test_statusline_gh_user.py` — new test module, 6 tests parametrized over both
  scripts
- `docs/development/ai/statusline.md` — note that the `@username` segment is dropped
  when `gh` is missing or unauthenticated

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

New tests place a `gh` stub ahead of the real `PATH` and assert, for each script:

| Stub behavior | Expectation |
| :--- | :--- |
| 401 body on stdout, exit 1 | no `Bad credentials` / `documentation_url` / `"status": "401"` in output; no `@` segment |
| exit 127, no stdout (`gh` absent) | no `@` segment |
| prints `octocat`, exit 0 | `@octocat` still renders |

Confirmed these are genuine regression tests: stashing the script fix makes
`test_gh_failure_body_not_rendered` fail for **both** the `[claude]` and `[agy]`
parameters, and pass again once restored.

Manual verification of the original report:

```bash
$ out=$(gh api user --jq ".login" 2>/dev/null || echo ""); echo "captured=[$out]"   # old
captured=[{
  "message": "Bad credentials",
  ...
}]
$ out=$(gh api user --jq ".login" 2>/dev/null) || out=""; echo "captured=[$out]"    # new
captured=[]
```

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

`doit check` passes end to end.

## Additional Notes

CHANGELOG.md is left unchanged: this project generates it at release time from
conventional commits, and it has not been hand-edited since the initial commit.

No ADR is needed — this is a bug fix with no architectural decision attached.
