### PR TITLE
fix: suppress python command-not-found noise in statusline

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -35,7 +35,7 @@ dir=$(basename "$cwd" 2>/dev/null || echo "?")
 # line goes to stderr), so clear the capture on non-zero exit — `|| echo ""`
 # would append to the error body instead of replacing it.
 gh_user=$(gh api user --jq ".login" 2>/dev/null) || gh_user=""
-python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" || echo "")
+python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>/dev/null || echo "")
 
 # Extract Python .venv
 venv_name=""

--- a/tests/test_statusline_python_version.py
+++ b/tests/test_statusline_python_version.py
@@ -1,0 +1,124 @@
+"""Tests for the Python version segment shared by both statusline scripts.
+
+A statusline runs on every render, so a missing `python` binary must degrade
+silently rather than writing a shell diagnostic to stderr each time. The
+unversioned `python` is absent on Debian/Ubuntu without `python-is-python3`
+and outside an activated virtualenv, so this is a routine condition.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The statusline scripts are bash targeting Linux/macOS; the Windows GitHub
+# Actions runner's `bash` resolves to wsl.exe (which has no installed
+# distribution), so subprocess invocations cannot exercise real shell behavior.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash statusline scripts are Linux/macOS only; Windows runner has no usable bash",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_STATUSLINE = REPO_ROOT / ".claude" / "statusline-command.sh"
+AGY_STATUSLINE = REPO_ROOT / "tools" / "statusline" / "agy-statusline.sh"
+
+SCRIPTS = pytest.mark.parametrize(
+    "script",
+    [
+        pytest.param(CLAUDE_STATUSLINE, id="claude"),
+        pytest.param(AGY_STATUSLINE, id="agy"),
+    ],
+)
+
+# Each script reads its own payload shape; supplying both keys exercises either.
+_PAYLOAD = json.dumps(
+    {
+        "model": {"display_name": "TestModel"},
+        "cwd": "/",
+        "workspace": {"current_dir": "/"},
+        "transcript_path": "",
+        "context_window": {"context_window_size": 200000},
+    }
+)
+
+# Utilities the scripts invoke; `python` is deliberately excluded so the PATH
+# built from this list reproduces a host with no unversioned python.
+_REQUIRED_TOOLS = (
+    "bash",
+    "jq",
+    "git",
+    "basename",
+    "cat",
+    "sed",
+    "head",
+    "wc",
+    "tr",
+    "date",
+    "stat",
+    "awk",
+)
+
+
+def _path_without_python(tmp_path: Path) -> Path:
+    """Build a bin dir holding the scripts' dependencies but no `python`."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in _REQUIRED_TOOLS:
+        resolved = shutil.which(tool)
+        if resolved is not None:
+            (bin_dir / tool).symlink_to(resolved)
+    assert shutil.which("python", path=str(bin_dir)) is None, "python must not be reachable"
+    return bin_dir
+
+
+def _run(script: Path, bin_dir: Path, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke a statusline script with a PATH that has no `python`."""
+    return subprocess.run(
+        ["bash", str(script)],
+        input=_PAYLOAD,
+        env={"HOME": str(tmp_path), "PATH": str(bin_dir)},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+@SCRIPTS
+def test_missing_python_writes_nothing_to_stderr(script: Path, tmp_path: Path) -> None:
+    """A missing `python` must not emit a shell diagnostic on every render."""
+    result = _run(script, _path_without_python(tmp_path), tmp_path)
+
+    assert result.returncode == 0
+    assert result.stderr == "", f"unexpected stderr: {result.stderr!r}"
+    assert "command not found" not in result.stderr
+
+
+@SCRIPTS
+def test_missing_python_omits_version_segment(script: Path, tmp_path: Path) -> None:
+    """Without `python`, the version segment is dropped but the line still renders."""
+    result = _run(script, _path_without_python(tmp_path), tmp_path)
+
+    assert result.returncode == 0
+    assert "Python:" not in result.stdout
+    assert result.stdout.strip() != "", "statusline must still render its other segments"
+
+
+@SCRIPTS
+def test_python_version_rendered_when_available(script: Path, tmp_path: Path) -> None:
+    """With `python` on PATH, its dotted version is rendered."""
+    bin_dir = _path_without_python(tmp_path)
+    # Symlink the running interpreter, not whatever `python` PATH resolves to,
+    # so the asserted version always matches sys.version_info on every CI leg.
+    (bin_dir / "python").symlink_to(sys.executable)
+
+    result = _run(script, bin_dir, tmp_path)
+
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    expected = ".".join(str(part) for part in sys.version_info[:3])
+    assert f"Python: {expected}" in result.stdout


### PR DESCRIPTION
## Description

`.claude/statusline-command.sh:38` captured the active Python version without
redirecting stderr:

```bash
python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" || echo "")
```

With no unversioned `python` on `PATH`, the shell's `command not found` diagnostic was
written to the script's stderr on **every statusline render**. That is a routine
condition rather than an edge case: Debian/Ubuntu without `python-is-python3` ships only
`python3`, and `python` also disappears outside an activated virtualenv.

The sibling Antigravity statusline (`tools/statusline/agy-statusline.sh:90`) already
redirected stderr on the same call and was silent under identical conditions. This
aligns the two.

**Scope:** rendered output was never affected. Unlike #674, `python` writes diagnostics
to stderr rather than stdout, so the captured value was already correctly empty and the
`Python:` segment already degraded away. The defect was the unsuppressed stderr and the
divergence between the two scripts.

## Related Issue

Addresses #676

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- `.claude/statusline-command.sh` — add `2>/dev/null` to the `python -c` capture,
  matching `tools/statusline/agy-statusline.sh:90`
- `tests/test_statusline_python_version.py` — new test module, 6 tests parametrized
  over both statusline scripts

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Tests build a `PATH` holding the scripts' dependencies but deliberately no `python`,
then assert per script:

| Condition | Expectation |
| :--- | :--- |
| `python` absent | `stderr == ""` — the regression guard |
| `python` absent | no `Python:` segment; the rest of the line still renders |
| `python` present | the dotted version is rendered |

The "python present" case symlinks `sys.executable` rather than resolving `python` from
`PATH`, so the asserted version matches on every leg of the CI matrix.

Confirmed genuine regression coverage: stashing the fix makes
`test_missing_python_writes_nothing_to_stderr[claude]` fail with the exact diagnostic
from the issue, while `[agy]` passes throughout — the correct signal, since agy was
already right and is now pinned against regressing.

Manual verification of the issue's reproduction, post-fix:

```
.claude/statusline-command.sh      -> stderr=[]
tools/statusline/agy-statusline.sh -> stderr=[]
```

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

`doit check` passes end to end.

## Additional Notes

No documentation change: `docs/development/ai/statusline.md` already describes the
Python version segment as optional, and this PR makes the existing documented behavior
hold quietly rather than changing it.

CHANGELOG.md is left unchanged — this project generates it at release time from
conventional commits and it has not been hand-edited since the initial commit.

No ADR is needed; this is a bug fix with no architectural decision attached.

Found while auditing the surrounding lines during #674 / PR #675.
