### PR TITLE
fix: repair dangerous-command hook for refspecs, global options, and shell wrappers

### DIFF
--- a/docs/decisions/9005-ai-agent-command-restrictions.md
+++ b/docs/decisions/9005-ai-agent-command-restrictions.md
@@ -21,6 +21,7 @@ Documentation alone is insufficient - AI agents may violate rules after context 
 - Issue #166: Block uv add in AI agent hooks
 - Issue #362: Add Copilot CLI command-blocking hook integration
 - Issue #409: Complete Copilot CLI coverage in AI_SETUP, enforcement-principles, first-5-minutes
+- Issue #678: Fix dangerous-command hook for git global options, refspecs, and shell wrappers
 
 ## Related Documentation
 

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -37,10 +37,11 @@ The hook uses Python's `shlex` module to properly parse shell quoting:
 1. **Tokenize** the command with `shlex.split()`
 2. **Check** for dangerous flags as standalone tokens
 3. **Check** for dangerous token sequences (e.g., `rm -rf ~`)
-4. **Check** for force push to protected branches (main/master)
-5. **Check** for deletion of protected branches
+4. **Check** for force push to protected branches (main/master) — including refspec forms (`HEAD:main`, `+main`) and commands preceded by git global options (`-C`, `-c`, `--git-dir`, …)
+5. **Check** for deletion of protected branches — also handles git global options
 6. **Check** for merge commits on protected branches (linear history)
-7. **Block** or **Allow** — Claude/Gemini/Codex block via exit code 2; Copilot and Antigravity block via a stdout decision JSON (exit code 0)
+7. **Recurse** into shell-wrapper payloads (`bash -c "..."`, `sh -c "..."`, `eval "..."`) — up to depth 3, so all checks above apply inside wrappers
+8. **Block** or **Allow** — Claude/Gemini/Codex block via exit code 2; Copilot and Antigravity block via a stdout decision JSON (exit code 0)
 
 #### Key Feature: Chained Command Detection
 
@@ -54,6 +55,51 @@ cd /path && doit release
 # ALLOWED - all commands in the chain are safe
 cd /path && doit check
 git status; git push origin feat/branch
+```
+
+#### Key Feature: Git Global Option Handling
+
+Git global options (e.g., `-C <path>`, `-c <k>=<v>`, `--git-dir=<dir>`) appear between the `git`
+token and the subcommand. The hook walks past them to find the real subcommand, so these are all
+caught:
+
+```bash
+# BLOCKED - global options shift the subcommand position, but hook handles them
+git -C . push --force origin main
+git -c core.pager=cat push --force origin main
+git --git-dir=.git push --force origin main
+git -C . branch -D main
+```
+
+#### Key Feature: Refspec-Aware Branch Extraction
+
+Force push to a protected branch is detected regardless of refspec form:
+
+```bash
+# BLOCKED - all target the 'main' branch
+git push --force origin HEAD:main
+git push origin +main
+git push --force-with-lease=HEAD origin HEAD:main
+
+# ALLOWED - destination branch is a feature branch
+git push origin main:feature        # pushes local 'main' to remote 'feature'
+git push origin HEAD:refs/heads/dev
+```
+
+#### Key Feature: Shell-Wrapper Payload Unwrapping
+
+The hook recurses into `bash -c`, `sh -c`, `zsh -c`, `dash -c`, and `eval` payloads (up to depth
+3), so all checks apply inside wrappers:
+
+```bash
+# BLOCKED - dangerous command inside a wrapper
+bash -c "git push --force origin main"
+sh -c "git branch -D main"
+eval "gh pr merge 1 --admin"
+
+# ALLOWED - safe command inside a wrapper
+bash -c "echo main"
+bash -c "git status"
 ```
 
 #### Key Feature: Quote-Aware Parsing
@@ -79,7 +125,8 @@ EOF
 | File | Description |
 |------|-------------|
 | [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude, Gemini, Copilot, Codex, and Antigravity) |
-| [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Test suite to verify hook behavior |
+| [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Manual test suite (run with `python3 tools/hooks/ai/test_hook.py`) |
+| [`tests/test_hook_block_dangerous_commands.py`](../../../tests/test_hook_block_dangerous_commands.py) | Pytest test suite — collected by CI via `testpaths = ["tests"]` |
 
 ### Configuration
 
@@ -252,7 +299,7 @@ Testing hook: /path/to/block-dangerous-commands.py
 + BLOCK (expected BLOCK) | actual --admin flag       | gh pr merge --admin
 ================================================================================
 
-Results: 14 passed, 0 failed
+Results: 134 passed, 0 failed
 ```
 
 ### Blocked Patterns

--- a/tests/test_hook_block_dangerous_commands.py
+++ b/tests/test_hook_block_dangerous_commands.py
@@ -1,0 +1,302 @@
+"""Tests for the ``block-dangerous-commands`` PreToolUse hook.
+
+The hook script lives at ``tools/hooks/ai/block-dangerous-commands.py``. Its
+filename contains hyphens, so it isn't directly importable as a module — we
+load it via ``importlib`` and invoke ``main()`` directly with a stubbed stdin.
+
+Pattern mirrors ``tests/test_bash_ban_raw_tools.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+HOOK_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "hooks" / "ai" / "block-dangerous-commands.py"
+)
+
+
+def _load_hook() -> types.ModuleType:
+    """Load the hook script as a fresh module instance."""
+    spec = importlib.util.spec_from_file_location("block_dangerous_commands", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook() -> Iterator[types.ModuleType]:
+    """Load a fresh copy of the hook module for each test."""
+    module = _load_hook()
+    sys.modules["block_dangerous_commands"] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop("block_dangerous_commands", None)
+
+
+def _set_stdin(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    """Replace ``sys.stdin`` with a StringIO containing *payload*."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+
+
+def _bash_payload(command: str) -> str:
+    """Build a Claude/Gemini/Codex Bash tool payload."""
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+def _run(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    *,
+    branch: str = "feature/test",
+) -> int:
+    """Run the hook for *command* and return its exit code.
+
+    ``get_current_branch`` is monkeypatched to return *branch* so tests are
+    deterministic regardless of the actual checkout state (TRAP 2 from the plan).
+    """
+    monkeypatch.setattr(hook, "get_current_branch", lambda: branch)
+    _set_stdin(monkeypatch, _bash_payload(command))
+    # ``main()`` returns its exit code rather than calling ``sys.exit()``, so
+    # call it directly. ``int()`` narrows the module attribute's ``Any`` type
+    # for mypy's ``warn_return_any``.
+    return int(hook.main())
+
+
+# ---------------------------------------------------------------------------
+# Must-block cases — all currently ALLOWED before this fix
+# ---------------------------------------------------------------------------
+
+
+def test_block_push_force_refspec_head_main(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push --force origin HEAD:main`` is blocked."""
+    assert _run(hook, monkeypatch, "git push --force origin HEAD:main") == 2
+
+
+def test_block_push_plus_main(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push origin +main`` is blocked ('+' prefix is force-push marker)."""
+    assert _run(hook, monkeypatch, "git push origin +main") == 2
+
+
+def test_block_push_with_git_global_dir_option(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git -C . push --force origin main`` is blocked despite global -C option."""
+    assert _run(hook, monkeypatch, "git -C . push --force origin main") == 2
+
+
+def test_block_push_with_git_global_dash_c(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git -c core.pager=cat push --force origin main`` is blocked."""
+    assert _run(hook, monkeypatch, "git -c core.pager=cat push --force origin main") == 2
+
+
+def test_block_push_with_git_global_git_dir(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git --git-dir=.git push --force origin main`` is blocked."""
+    assert _run(hook, monkeypatch, "git --git-dir=.git push --force origin main") == 2
+
+
+def test_block_push_force_with_lease_eq_form(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push --force-with-lease=main origin HEAD:main`` is blocked.
+
+    The ``=<ref>`` form of ``--force-with-lease`` must be recognised as a
+    force flag (prefix-aware matching).
+    """
+    assert _run(hook, monkeypatch, "git push --force-with-lease=main origin HEAD:main") == 2
+
+
+def test_block_bash_c_push_force(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bash -c "git push --force origin main"`` is blocked via payload unwrap."""
+    assert _run(hook, monkeypatch, 'bash -c "git push --force origin main"') == 2
+
+
+def test_block_sh_c_push_force(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``sh -c "git push --force origin main"`` is blocked via payload unwrap."""
+    assert _run(hook, monkeypatch, 'sh -c "git push --force origin main"') == 2
+
+
+def test_block_eval_push_force(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``eval "git push --force origin main"`` is blocked via eval unwrap."""
+    assert _run(hook, monkeypatch, 'eval "git push --force origin main"') == 2
+
+
+def test_block_branch_delete_with_git_global_dir(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git -C . branch -D main`` is blocked despite global -C option."""
+    assert _run(hook, monkeypatch, "git -C . branch -D main") == 2
+
+
+def test_block_bash_c_branch_delete(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bash -c "git branch -D main"`` is blocked via payload unwrap."""
+    assert _run(hook, monkeypatch, 'bash -c "git branch -D main"') == 2
+
+
+def test_block_bash_c_gh_pr_merge_admin(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bash -c "gh pr merge 1 --admin"`` is blocked — proves unwrap reaches non-git checks."""
+    assert _run(hook, monkeypatch, 'bash -c "gh pr merge 1 --admin"') == 2
+
+
+# ---------------------------------------------------------------------------
+# Must-stay-ALLOWED guards
+# ---------------------------------------------------------------------------
+
+
+def test_allow_push_refspec_main_to_feature(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push origin main:feature`` is allowed (destination is 'feature')."""
+    assert _run(hook, monkeypatch, "git push origin main:feature") == 0
+
+
+def test_allow_push_refspec_head_to_refs_feature(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push origin HEAD:refs/heads/feature`` is allowed (destination is 'feature')."""
+    assert _run(hook, monkeypatch, "git push origin HEAD:refs/heads/feature") == 0
+
+
+def test_allow_push_feature_branch(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push origin feature`` is allowed."""
+    assert _run(hook, monkeypatch, "git push origin feature") == 0
+
+
+def test_allow_force_push_feature_branch(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push --force origin feat/my-feature`` is allowed (existing regression guard)."""
+    assert _run(hook, monkeypatch, "git push --force origin feat/my-feature") == 0
+
+
+def test_allow_bash_c_echo_main(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bash -c "echo main"`` is allowed — unwrap must not over-block."""
+    assert _run(hook, monkeypatch, 'bash -c "echo main"') == 0
+
+
+def test_allow_git_global_dir_push_feature(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git -C /other/repo push origin feature`` is allowed."""
+    assert _run(hook, monkeypatch, "git -C /other/repo push origin feature") == 0
+
+
+# ---------------------------------------------------------------------------
+# Message-correctness: deletion refspec must keep its own reason string
+# ---------------------------------------------------------------------------
+
+
+def test_delete_refspec_colon_main_reports_deletion_reason(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``git push origin :main`` must be blocked with the *deletion* reason, not push reason.
+
+    This guards the ordering hazard documented in the plan: check_push_to_protected
+    runs before check_delete_protected_branch. The colon-prefixed token must be
+    skipped by the push check so the delete check owns it and reports the correct
+    reason.
+    """
+    monkeypatch.setattr(hook, "get_current_branch", lambda: "feature/test")
+    _set_stdin(monkeypatch, _bash_payload("git push origin :main"))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Deleting protected remote branch 'main'" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Existing regression: force-with-lease without "=" still blocked
+# ---------------------------------------------------------------------------
+
+
+def test_block_push_force_with_lease_plain(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``git push --force-with-lease origin main`` (no ``=``) is still blocked."""
+    assert _run(hook, monkeypatch, "git push --force-with-lease origin main") == 2
+
+
+# ---------------------------------------------------------------------------
+# Determinism: bare push on protected branch is blocked only when on that branch
+# ---------------------------------------------------------------------------
+
+
+def test_bare_push_blocked_when_on_main(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare ``git push`` is blocked when current branch is main."""
+    assert _run(hook, monkeypatch, "git push", branch="main") == 2
+
+
+def test_bare_push_allowed_when_on_feature(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare ``git push`` with no explicit branch is allowed on a feature branch.
+
+    (Force push without explicit branch is still blocked separately — this checks
+    plain push only.)
+    """
+    # A bare "git push" with no force flag on a feature branch is allowed
+    assert _run(hook, monkeypatch, "git push", branch="feature/my-work") == 0

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -41,7 +41,7 @@ DANGEROUS_SEQUENCES = [
     (["sudo", "rm"], "Privileged deletion"),
 ]
 
-# Force push flags
+# Force push flags (matched as exact token OR as prefix before "=")
 FORCE_PUSH_FLAGS = {"--force", "-f", "--force-with-lease"}
 
 # Blocked workflow commands - use doit wrappers or require user approval
@@ -172,6 +172,114 @@ def tokenize(command: str) -> list[str]:
             return command.split()
 
 
+def _normalize_branch_ref(token: str) -> str:
+    """Return the destination branch name from a git refspec token.
+
+    Strips a leading ``+`` (force-push marker), takes the last segment after
+    ``:`` (the *destination* side of a refspec — ``src:dst`` pushes local
+    ``src`` to remote ``dst``), then takes the last segment after ``/``
+    (strip remote or ``refs/heads/`` prefix).
+
+    Examples::
+
+        "HEAD:main"           -> "main"
+        "+main"               -> "main"
+        "main:feature"        -> "feature"
+        "HEAD:refs/heads/dev" -> "dev"
+        "origin/main"         -> "main"
+        "main"                -> "main"
+    """
+    if token.startswith("+"):
+        token = token[1:]
+    # Take destination side of refspec (last segment after ":")
+    token = token.split(":")[-1]
+    # Strip remote/refs prefix (last segment after "/")
+    token = token.split("/")[-1]
+    return token
+
+
+# Git global options that consume a SEPARATE following token (value).
+# Options written as "--opt=val" already consume one token; these are the
+# ones that use "--opt val" (two-token) form and must skip an extra token.
+_GIT_GLOBAL_OPTS_WITH_VALUE = frozenset(
+    {
+        "-C",
+        "-c",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--exec-path",
+        "--super-prefix",
+        "--list-cmds",
+    }
+)
+
+# Note: git global flags that consume no value (``--paginate``, ``--bare``,
+# ``--no-pager``, ...) need no explicit list — ``_git_subcommand_index`` treats
+# any token starting with "-" that is not in _GIT_GLOBAL_OPTS_WITH_VALUE as a
+# single-token flag, which covers them and any future additions.
+
+
+def _git_subcommand_index(tokens: list[str], git_idx: int) -> int | None:
+    """Return the index of the git subcommand token, skipping global options.
+
+    ``git`` global options appear between the ``git`` token and the subcommand.
+    For example::
+
+        git -C /path push ...       => subcommand index is git_idx + 3
+        git -c k=v push ...         => subcommand index is git_idx + 3
+        git --git-dir=.git push ... => subcommand index is git_idx + 2
+        git push ...                => subcommand index is git_idx + 1
+
+    Options written in ``--opt=val`` form (one token) consume only themselves.
+    Options written in ``--opt val`` form (two tokens) consume themselves plus
+    the next token.
+
+    Returns ``None`` if the end of ``tokens`` is reached before finding a
+    subcommand (malformed or truncated input).
+    """
+    i = git_idx + 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith("-"):
+            # Check if it's a known two-token option (written without "=")
+            if tok in _GIT_GLOBAL_OPTS_WITH_VALUE:
+                i += 2  # skip option AND its value
+            else:
+                # Either a one-token flag or an "--opt=val" option
+                i += 1
+        else:
+            # First non-flag token is the subcommand
+            return i
+    return None
+
+
+def _wrapped_payloads(tokens: list[str]) -> list[str]:
+    """Return shell payloads from ``bash/sh/zsh/dash -c <payload>`` and ``eval ...``.
+
+    Yields (as a list) the payload strings that would be re-executed by the
+    shell wrapper so ``check_command`` can recurse into them.
+    """
+    shell_names = frozenset({"bash", "sh", "zsh", "dash"})
+    payloads: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i].lower()
+        if tok in shell_names:
+            # Look for a -c flag immediately after (possibly with --login etc.)
+            j = i + 1
+            while j < len(tokens) and tokens[j].startswith("-") and tokens[j] != "-c":
+                j += 1
+            if j < len(tokens) and tokens[j] == "-c" and j + 1 < len(tokens):
+                payloads.append(tokens[j + 1])
+        elif tok == "eval" and i + 1 < len(tokens):
+            # eval "..." — join all remaining tokens as a single payload
+            payloads.append(" ".join(tokens[i + 1 :]))
+            break
+        i += 1
+    return payloads
+
+
 def check_dangerous_flags(tokens: list[str]) -> tuple[bool, str]:
     """
     Check if any dangerous flag appears as a standalone token.
@@ -209,6 +317,12 @@ def check_push_to_protected(tokens: list[str]) -> tuple[bool, str]:
     Force pushes to protected branches are also blocked even from feature branches.
 
     Scans all positions to handle chained commands (e.g., git status; git push --force).
+    Handles git global options (e.g., ``git -C /path push ...``).
+    Handles refspec forms (e.g., ``HEAD:main``, ``+main``).
+
+    Tokens beginning with ``:`` are deletion refspecs — they are owned by
+    ``check_delete_protected_branch`` and skipped here to preserve correct
+    block-reason messages.
     """
     tokens_lower = [t.lower() for t in tokens]
 
@@ -221,34 +335,37 @@ def check_push_to_protected(tokens: list[str]) -> tuple[bool, str]:
         if tokens_lower[git_idx] != "git":
             continue
 
-        # Ensure "push" is the git subcommand, not part of another command like "git stash push"
-        subcommand_idx = git_idx + 1
+        # Resolve subcommand index, skipping git global options
+        subcommand_idx = _git_subcommand_index(tokens, git_idx)
+        if subcommand_idx is None:
+            continue
         if tokens_lower[subcommand_idx] != "push":
             continue
 
         # Determine the end of this git push command (next git/doit/gh/uv token or end)
         cmd_end = len(tokens)
         for j in range(subcommand_idx + 1, len(tokens_lower)):
-            # A new command starts at a token that is a known command root
-            # Also handle shell operators that got merged with tokens (e.g., "status;")
             if tokens_lower[j] in ("git", "doit", "gh", "uv"):
                 cmd_end = j
                 break
         cmd_tokens = tokens[git_idx:cmd_end]
 
-        # Check if any force flag is present in this git push command
-        has_force_flag = any(flag in cmd_tokens for flag in FORCE_PUSH_FLAGS)
+        # Check if any force flag is present (prefix-aware for --force-with-lease=<ref>)
+        has_force_flag = any(
+            t == flag or t.startswith(flag + "=") for t in cmd_tokens for flag in FORCE_PUSH_FLAGS
+        )
 
-        # Look for branch name in tokens after 'push'
-        # Skip flags (tokens starting with -)
-        push_idx = subcommand_idx
-        after_push = [t for t in tokens[push_idx + 1 : cmd_end] if not t.startswith("-")]
+        # Look for branch name in tokens after 'push'.
+        # Skip flags (tokens starting with -) and deletion refspecs (start with :).
+        after_push = [
+            t
+            for t in tokens[subcommand_idx + 1 : cmd_end]
+            if not t.startswith("-") and not t.startswith(":")
+        ]
 
-        # Check if explicitly pushing to a protected branch
+        # Check if explicitly pushing to a protected branch via refspec or branch name
         for token in after_push:
-            # Handle origin/main format
-            branch = token.split("/")[-1] if "/" in token else token
-
+            branch = _normalize_branch_ref(token)
             if branch.lower() in PROTECTED_BRANCHES:
                 action = "Force push" if has_force_flag else "Push"
                 return True, f"{action} to protected branch '{branch}'"
@@ -294,14 +411,15 @@ def check_delete_protected_branch(tokens: list[str]) -> tuple[bool, str]:
         if tokens_lower[git_idx] != "git":
             continue
 
-        if git_idx + 1 >= len(tokens_lower):
+        subcommand_idx = _git_subcommand_index(tokens, git_idx)
+        if subcommand_idx is None:
             continue
 
-        subcommand = tokens_lower[git_idx + 1]
+        subcommand = tokens_lower[subcommand_idx]
 
         # Determine the end of this git command (next command root or end)
         cmd_end = len(tokens)
-        for j in range(git_idx + 2, len(tokens_lower)):
+        for j in range(subcommand_idx + 1, len(tokens_lower)):
             if tokens_lower[j] in ("git", "doit", "gh", "uv"):
                 cmd_end = j
                 break
@@ -603,7 +721,7 @@ def check_merge_to_protected(tokens: list[str]) -> tuple[bool, str]:
     return False, ""
 
 
-def check_command(command: str) -> tuple[bool, str]:
+def check_command(command: str, _depth: int = 0) -> tuple[bool, str]:
     """
     Check if command contains dangerous patterns.
 
@@ -615,6 +733,8 @@ def check_command(command: str) -> tuple[bool, str]:
     5. Merge commits on protected branches
     6. Blocked workflow commands
     7. Governance labels
+    8. Shell-wrapper payloads (``bash -c``, ``sh -c``, ``eval``) — recursed up
+       to depth 3 so all seven checks above gain wrapper coverage.
 
     Returns:
         (is_dangerous, reason)
@@ -660,6 +780,14 @@ def check_command(command: str) -> tuple[bool, str]:
     is_dangerous, reason = check_env_persistence_in_bash(tokens)
     if is_dangerous:
         return True, reason
+
+    # Recurse into shell-wrapper payloads (bash/sh/zsh/dash -c <payload>, eval ...)
+    # Depth cap of 3 prevents infinite loops on adversarial inputs.
+    if _depth < 3:
+        for payload in _wrapped_payloads(tokens):
+            is_dangerous, reason = check_command(payload, _depth + 1)
+            if is_dangerous:
+                return True, reason
 
     return False, ""
 

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -154,6 +154,24 @@ EOF
         "BLOCK",
         "persist rtm var to .zshrc",
     ),
+    # === SHOULD BLOCK - Refspec and global-option forms (issue #678) ===
+    ("git push --force origin HEAD:main", "BLOCK", "force push HEAD:main refspec"),
+    ("git push origin +main", "BLOCK", "push +main force-push marker"),
+    ("git -C . push --force origin main", "BLOCK", "git -C global option push force"),
+    ("git -c core.pager=cat push --force origin main", "BLOCK", "git -c global option push force"),
+    ("git --git-dir=.git push --force origin main", "BLOCK", "git --git-dir push force"),
+    ("git push --force-with-lease=main origin HEAD:main", "BLOCK", "force-with-lease= prefix form"),
+    ('bash -c "git push --force origin main"', "BLOCK", "bash -c push force"),
+    ('sh -c "git push --force origin main"', "BLOCK", "sh -c push force"),
+    ('eval "git push --force origin main"', "BLOCK", "eval push force"),
+    ("git -C . branch -D main", "BLOCK", "git -C branch -D main"),
+    ('bash -c "git branch -D main"', "BLOCK", "bash -c branch -D main"),
+    ('bash -c "gh pr merge 1 --admin"', "BLOCK", "bash -c gh pr merge --admin"),
+    # === SHOULD ALLOW - Refspec destination is a feature branch (issue #678) ===
+    ("git push origin main:feature", "ALLOW", "refspec dst is feature"),
+    ("git push origin HEAD:refs/heads/feature", "ALLOW", "refspec HEAD to refs feature"),
+    ("git -C /other/repo push origin feature", "ALLOW", "git -C push feature"),
+    ('bash -c "echo main"', "ALLOW", "bash -c echo main is safe"),
     # === SHOULD ALLOW - Bash write to non-protected target ===
     (
         'echo "ALLOW_AI_READY_TO_MERGE=1" >> /tmp/notes.txt',


### PR DESCRIPTION
## Description

Fixes four root causes in the shared dangerous-command hook
(`tools/hooks/ai/block-dangerous-commands.py`) that allowed dangerous git
commands to slip through when expressed in non-trivial forms. The hook is the
enforcement gate for all five AI agents (Claude, Gemini, Codex, Copilot,
Antigravity); the same code path is used by every agent.

### Root causes fixed

1. **Refspec-aware branch extraction** (`_normalize_branch_ref`): strips a
   leading `+` force-push marker, takes the `:` destination side, then the `/`
   last segment. Previously `git push --force origin HEAD:main` and
   `git push origin +main` were allowed; now both are blocked.

2. **Git global-option walking** (`_git_subcommand_index`): walks past
   global options (`-C`, `-c`, `--git-dir`, `--work-tree`, …) instead of
   assuming the subcommand is always at `tokens[git_idx + 1]`. Applied at
   **both** `check_push_to_protected` and `check_delete_protected_branch`.
   Previously `git -C . push --force origin main` and
   `git -C . branch -D main` were allowed; now both are blocked.

3. **Shell-wrapper payload unwrapping** (`_wrapped_payloads` + recursion in
   `check_command`, depth cap 3): recurses into `bash -c`, `sh -c`, `zsh -c`,
   `dash -c`, and `eval` payloads. Placed in `check_command` so **all seven
   checks** benefit, not just git ones. Previously
   `bash -c "git push --force origin main"` and
   `eval "gh pr merge 1 --admin"` were allowed; now both are blocked.

4. **Prefix-aware force-flag matching**: catches `--force-with-lease=<ref>` by
   checking `t.startswith(flag + "=")` in addition to exact-token equality.

**Deletion refspec guard**: `:main` tokens (colon-prefix deletion refspecs) are
skipped in `check_push_to_protected` so `check_delete_protected_branch` keeps
its correct `"Deleting protected remote branch 'main'"` reason message.

### Why the diff is wider than the issue text

The issue (#678) describes the problem only in the context of
`check_push_to_protected`. During implementation it became clear that
`check_delete_protected_branch` shares **both** root causes 2 and 3 —
`git -C . branch -D main` and `bash -c "git branch -D main"` were both
allowed before this fix. Fixing only the push check would have left the delete
check bypassable by the same techniques. The widened scope was explicitly
approved.

A pytest suite (`tests/test_hook_block_dangerous_commands.py`) was added at the
same time. CI collects it via `testpaths = ["tests"]`; it does not duplicate the
standalone `test_hook.py` (which exercises the hook as a subprocess), but
instead imports the module directly for faster iteration and coverage reporting.

## Related Issue

Addresses #678

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement

## Changes Made

- `tools/hooks/ai/block-dangerous-commands.py`: added `_normalize_branch_ref`,
  `_git_subcommand_index`, `_wrapped_payloads`; updated `check_push_to_protected`
  and `check_delete_protected_branch` to use global-option walking and
  refspec-aware branch extraction; added wrapper-payload recursion to
  `check_command` (all 7 existing checks gain coverage inside `bash -c` / `eval`).
- `tools/hooks/ai/test_hook.py`: 18 new test cases covering the fixed forms
  (134 total, 0 failed).
- `tests/test_hook_block_dangerous_commands.py`: new pytest file, 22 tests
  collected by CI.
- `docs/development/ai/command-blocking.md`: updated "How It Works" to list the
  new capabilities; added key-feature sections for git global option handling,
  refspec-aware branch extraction, and shell-wrapper unwrapping; updated the
  "Files" table to include the new pytest file; updated the test-output example
  count.
- `docs/decisions/9005-ai-agent-command-restrictions.md`: added Issue #678 to
  Related Issues.

## Testing

- 12 previously-allowed dangerous forms now blocked (verified via targeted
  probes for each root cause).
- 6 false-positive guards confirmed still allowed, each covered by a test in
  `tests/test_hook_block_dangerous_commands.py`:
  - `git push origin main:feature` — destination is `feature`, not `main`
  - `git push origin HEAD:refs/heads/feature` — non-protected destination
  - `git push origin feature`
  - `git push --force origin feat/my-feature` — pre-existing case, no regression
  - `bash -c "echo main"` — unwrapping must not over-block safe payloads
  - `git -C /other/repo push origin feature` — global option, safe target
- A seventh test (`test_bare_push_allowed_when_on_feature`) pins the
  `get_current_branch` monkeypatch so results do not depend on checkout state.
- `git push origin :main` still reports `Deleting protected remote branch 'main'`
  (deletion refspec correctly routed to `check_delete_protected_branch`).
- Per-agent probes confirmed for all three input schemas: exit-2 default,
  Copilot stdout JSON, Antigravity stdout JSON.

| Suite | Result |
|---|---|
| `python3 tools/hooks/ai/test_hook.py` | 134 passed, 0 failed |
| `pytest tests/test_hook_block_dangerous_commands.py` | 22 passed |
| `doit check` (full suite) | 1101 passed |
| Hook coverage | 47.47% (previously absent from coverage report) |

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A: this repo generates `CHANGELOG.md`
      via commitizen at release time (`update_changelog_on_bump = true`); it is
      not hand-edited per PR.
- [x] My changes generate no new warnings

## Additional Notes

Two pre-existing gaps are out of scope for this PR (present on `main` before
this branch):

- `doit type_check` targets `src/ tools/doit/ bootstrap.py` — `tools/hooks/`
  and `tests/` are not type-checked. A pre-existing `no-redef` error at
  `block-dangerous-commands.py:833` has therefore gone unreported; it was
  confirmed present on `main` and is **not** introduced by this PR.
- `tools/hooks/ai/test_hook.py` is a standalone script; CI does not collect it
  (only `tests/` is in `testpaths`). The new pytest file in `tests/` is the
  CI-collected complement.
