### PR TITLE
fix: remove redundant tool_input annotation in _parse_input

### DIFF
--- a/tests/test_hook_block_dangerous_commands.py
+++ b/tests/test_hook_block_dangerous_commands.py
@@ -300,3 +300,110 @@ def test_bare_push_allowed_when_on_feature(
     """
     # A bare "git push" with no force flag on a feature branch is allowed
     assert _run(hook, monkeypatch, "git push", branch="feature/my-work") == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-agent input-schema parsing (``_parse_input``)
+#
+# The hook serves five CLIs across three input schemas. Everything above uses
+# the Claude/Gemini/Codex schema. These cover the other two, which deny via
+# stdout JSON with exit 0 rather than via exit code 2 — so an exit-code-only
+# assertion would pass even if their parsing broke entirely.
+# ---------------------------------------------------------------------------
+
+DANGEROUS = "git push --force origin HEAD:main"
+
+
+def _copilot_payload(command: str) -> str:
+    """Build a Copilot CLI payload (camelCase keys; ``toolArgs`` is a JSON string)."""
+    return json.dumps({"toolName": "bash", "toolArgs": json.dumps({"command": command})})
+
+
+def _agy_payload(command: str) -> str:
+    """Build an Antigravity CLI payload (nested ``toolCall``, PascalCase args)."""
+    return json.dumps({"toolCall": {"name": "run_command", "args": {"CommandLine": command}}})
+
+
+def _run_raw(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    payload: str,
+    *,
+    branch: str = "feature/test",
+) -> tuple[int, str]:
+    """Run the hook on a raw payload; return ``(exit_code, stdout)``."""
+    monkeypatch.setattr(hook, "get_current_branch", lambda: branch)
+    _set_stdin(monkeypatch, payload)
+    code = int(hook.main())
+    return code, capsys.readouterr().out
+
+
+def test_copilot_schema_denies_via_stdout(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Copilot payloads deny with ``permissionDecision`` on stdout and exit 0."""
+    code, out = _run_raw(hook, monkeypatch, capsys, _copilot_payload(DANGEROUS))
+    assert code == 0
+    assert json.loads(out)["permissionDecision"] == "deny"
+
+
+def test_antigravity_schema_denies_via_stdout(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Antigravity payloads deny with ``decision`` on stdout and exit 0."""
+    code, out = _run_raw(hook, monkeypatch, capsys, _agy_payload(DANGEROUS))
+    assert code == 0
+    assert json.loads(out)["decision"] == "deny"
+
+
+def test_copilot_schema_allows_safe_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A safe command through the Copilot schema emits no deny payload."""
+    code, out = _run_raw(hook, monkeypatch, capsys, _copilot_payload("git status"))
+    assert code == 0
+    assert out.strip() == ""
+
+
+def test_antigravity_schema_allows_safe_command(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A safe command through the Antigravity schema emits no deny payload."""
+    code, out = _run_raw(hook, monkeypatch, capsys, _agy_payload("git status"))
+    assert code == 0
+    assert out.strip() == ""
+
+
+def test_copilot_schema_survives_malformed_tool_args(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-JSON ``toolArgs`` string is tolerated rather than raising."""
+    payload = json.dumps({"toolName": "bash", "toolArgs": "{not valid json"})
+    code, _ = _run_raw(hook, monkeypatch, capsys, payload)
+    assert code == 0
+
+
+def test_non_dict_tool_input_is_tolerated(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-dict ``tool_input`` falls back to an empty dict instead of raising.
+
+    Guards the ``isinstance`` check in ``_parse_input``: without it, ``.get()``
+    would raise ``AttributeError`` on a string payload.
+    """
+    payload = json.dumps({"tool_name": "Bash", "tool_input": "oops"})
+    code, _ = _run_raw(hook, monkeypatch, capsys, payload)
+    assert code == 0

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -830,7 +830,11 @@ def _parse_input(input_data: dict) -> tuple[str, str, dict]:
         tool_name = input_data.get("toolName", "")
         tool_args_raw = input_data.get("toolArgs", "{}")
         try:
-            tool_input: dict = (
+            # No ``: dict`` annotation here — the Antigravity branch above already
+            # binds ``tool_input``, so annotating in this branch reads as a
+            # redefinition to mypy. Annotating at function scope instead would
+            # narrow the Claude/Gemini branch's ``isinstance`` guard to dead code.
+            tool_input = (
                 json.loads(tool_args_raw) if isinstance(tool_args_raw, str) else tool_args_raw
             )
         except json.JSONDecodeError:


### PR DESCRIPTION
## Description

Clears the pre-existing `no-redef` mypy error in `_parse_input()` in
`tools/hooks/ai/block-dangerous-commands.py`, and adds CI-collected test
coverage for the two input schemas that had none.

### The error

`_parse_input()` handles three input schemas. The Antigravity branch binds
`tool_input` first, unannotated; the Copilot branch then *annotates* it. mypy
treats an annotated assignment as a definition, so the second read as a
redefinition of a name already bound:

```
tools/hooks/ai/block-dangerous-commands.py:833: error: Name "tool_input"
    already defined on line 820  [no-redef]
```

Pre-existing — confirmed on `main` before #678/#699 — and invisible to
`doit check`, which does not type-check `tools/` (see #700).

### Why the fix is a deletion, not a declaration

The obvious fix is hoisting `tool_input: dict` to function scope. That clears
`no-redef` but produces a **new** error:

```
tools/hooks/ai/block-dangerous-commands.py:849: error: Statement is
    unreachable  [unreachable]
```

Declaring the name as `dict` narrows the Claude/Gemini branch so mypy proves
this guard dead:

```python
tool_input = input_data.get("tool_input", {})
if not isinstance(tool_input, dict):
    tool_input = {}
```

The guard is load-bearing at runtime: `{"tool_name": "Bash", "tool_input":
"oops"}` binds a `str`, and the following `.get()` would raise
`AttributeError`. Hoisting would trade one mypy error for another while making
a real defensive check look like cruft.

So this PR removes the inline annotation instead, and leaves a comment
recording why neither the annotation nor a function-scope declaration belongs
there — the next reader would otherwise "tidy" it straight back.

### Tests

`tests/test_hook_block_dangerous_commands.py` had **zero** coverage of the
Copilot (`toolName`/`toolArgs`) and Antigravity (`toolCall`/`CommandLine`)
schemas — both were exercised only by `tools/hooks/ai/test_hook.py`, which CI
never runs (#702).

Those two schemas deny via **stdout JSON with exit 0**, not exit code 2, so an
exit-code assertion passes even if their parsing breaks entirely. The new tests
assert on parsed stdout.

The `isinstance` guard test was mutation-checked rather than assumed: deleting
the guard makes `test_non_dict_tool_input_is_tolerated` fail, confirming it
tests something real.

## Related Issue

Addresses #701

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement

## Changes Made

- `tools/hooks/ai/block-dangerous-commands.py`: removed the redundant `: dict`
  annotation in the Copilot branch of `_parse_input`; added a comment
  explaining why neither that annotation nor a function-scope declaration is
  correct. No behavior change.
- `tests/test_hook_block_dangerous_commands.py`: 6 new tests (22 -> 28)
  covering Copilot and Antigravity parsing — deny-path, allow-path, malformed
  `toolArgs`, and the non-dict `tool_input` guard.

## Testing

| Check | Result |
|---|---|
| `mypy tools/hooks/ai/block-dangerous-commands.py` | Success, no issues (was 1 error) |
| `pytest tests/test_hook_block_dangerous_commands.py` | 28 passed |
| `python3 tools/hooks/ai/test_hook.py` | 134 passed, 0 failed (behavior unchanged) |
| `doit check` | passes |

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A: no user-facing
      behavior changed; this is an internal typing fix.
- [ ] I have updated the CHANGELOG.md — N/A: this repo generates `CHANGELOG.md`
      via commitizen at release time (`update_changelog_on_bump = true`); it is
      not hand-edited per PR.
- [x] My changes generate no new warnings

## Additional Notes

`doit check` passes both before and after this change, because
`doit type_check` targets `src/ tools/doit/ bootstrap.py` and never inspects
`tools/hooks/`. The real gate for this fix is `mypy` run directly on the file.

This PR is sequenced deliberately before #700 (which widens the type-check
scope) so that change lands on a clean file rather than mixing a scope change
with an unrelated typing fix.
