### PR TITLE
chore: widen doit check to cover tools/ and tests/

### DIFF
--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -327,8 +327,32 @@ All checks should pass in CI:
 - Code formatting (ruff format)
 - Linting (ruff check)
 - Type checking (mypy)
+- Dead code (vulture)
 - Test suite (pytest)
 - Coverage threshold (pytest-cov)
+
+### Known gate blind spot: unused module-level constants
+
+`doit check` does **not** detect an unused module-level constant whose name begins with an
+underscore. Verified against each tool in the stack:
+
+| Tool | Behaviour |
+| :--- | :--- |
+| vulture | Skips underscore-prefixed names entirely, at any `min_confidence` |
+| ruff | `F841` covers unused *locals* only; there is no module-level rule |
+| pyright (CLI) | "is not accessed" is an editor-only hint, absent from `--outputjson` |
+| mypy | Out of scope by design |
+
+Two independent reasons vulture cannot see it: a leading `_` marks a name as deliberately
+private, and even a *public* unused module variable is reported at only 60% confidence — below
+the configured `min_confidence = 80`.
+
+Lowering that threshold is not a workable fix: at 60% this repo produces 57 findings, 55 of them
+`unused function` for `task_*` and `test_*` names that doit and pytest discover dynamically.
+
+**What this means in practice:** an editor with a Python language server will grey out an unused
+private constant, but CI will not fail on it. Treat the "unused symbol" hint as real signal even
+though `doit check` is green. See issue #700.
 
 ### Import Compatibility
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,18 +135,29 @@ no_implicit_optional = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
-# tools/pyproject_template/ uses sys.path manipulation for standalone execution
-exclude = ["tools/pyproject_template/", ".claude/", ".gemini/", ".codex/"]
+exclude = [".claude/", ".gemini/", ".codex/"]
 
 [[tool.mypy.overrides]]
 module = "doit.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-# Standalone scripts using sys.path manipulation; excluded from discovery
-# but still followed via imports from bootstrap.py
-module = "tools.pyproject_template.*"
-follow_imports = "skip"
+# tools/pyproject_template/ scripts run standalone and do `sys.path.insert`
+# before importing their siblings by bare name (`from utils import ...`).
+# mypy cannot resolve those, so suppress the import errors by naming the
+# sibling modules. Suppressing only the imports — rather than excluding the
+# directory, as this config previously did — keeps the other ~5,300 lines
+# type-checked. See issue #700.
+module = [
+    "check_template_updates",
+    "cleanup",
+    "configure",
+    "repo_settings",
+    "settings",
+    "setup_repo",
+    "utils",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "8.0"
@@ -219,13 +230,17 @@ ignore-words-list = "crate"
 
 [tool.vulture]
 min_confidence = 80
-paths = ["src", "tests"]
+paths = ["src", "tests", "tools"]
 exclude = [
     "*/tests/*",      # Test fixtures often appear unused
     "*/__pycache__/*",
 ]
 # Common false positives in Python projects
 ignore_names = [
+    # Imported under `if TYPE_CHECKING:` and referenced only from string
+    # annotations (e.g. `console: "ConsoleType"`), which vulture does not
+    # parse. Deleting these imports would break type checking.
+    "ConsoleType",
     "test_*",         # Pytest test functions
     "fixture_*",      # Pytest fixtures
     "*_fixture",      # Pytest fixtures

--- a/tests/template/test_doit_quality.py
+++ b/tests/template/test_doit_quality.py
@@ -115,12 +115,17 @@ class TestTaskCheck:
         assert "audit" in task["task_dep"]
 
     def test_task_dep_covers_full_check_set(self) -> None:
-        """``task_check`` must depend on every pre-PR quality/security task."""
+        """``task_check`` must depend on every pre-PR quality/security task.
+
+        ``deadcode`` joined the set in #700: it was defined as a task but never
+        gated, so unused imports in ``tools/`` accumulated unnoticed.
+        """
         task = task_check()
         assert set(task["task_dep"]) == {
             "format_check",
             "lint",
             "type_check",
+            "deadcode",
             "security",
             "audit",
             "spell_check",
@@ -152,3 +157,59 @@ class TestTaskTypeCheck:
         assert isinstance(action, str)
         assert "bootstrap.py" not in action
         assert "mypy" in action
+
+
+class TestQualityGateScope:
+    """The quality gate must cover the directories it claims to.
+
+    Before #700, ``type_check`` targeted only ``src/ tools/doit/`` and vulture's
+    configured paths omitted ``tools/`` entirely — so real errors in
+    ``tools/hooks/`` and ``tests/`` passed a green ``doit check``. Two escaped
+    that way in PR #699. These tests pin the scope so it cannot silently narrow
+    again.
+    """
+
+    def test_type_check_covers_tools_and_tests(self) -> None:
+        """``type_check`` must check all of ``src/``, ``tools/`` and ``tests/``."""
+        action = task_type_check()["actions"][0]
+        assert isinstance(action, str)
+        for root in ("src/", "tools/", "tests/"):
+            assert root in action, f"type_check no longer covers {root}"
+
+    def test_type_check_does_not_narrow_to_tools_subdir(self) -> None:
+        """Guard the specific regression: narrowing ``tools/`` to one subdirectory."""
+        action = task_type_check()["actions"][0]
+        assert isinstance(action, str)
+        assert "tools/doit/" not in action, (
+            "type_check narrowed back to tools/doit/; this hides tools/hooks/"
+        )
+
+    def test_check_gates_on_deadcode(self) -> None:
+        """``deadcode`` must run as part of ``doit check``, not just on demand."""
+        assert "deadcode" in task_check()["task_dep"]
+
+    def test_vulture_paths_include_tools(self) -> None:
+        """Vulture's configured paths must include ``tools/``."""
+        import tomllib
+
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject.open("rb") as handle:
+            config = tomllib.load(handle)
+        paths = config["tool"]["vulture"]["paths"]
+        assert "tools" in paths, f"vulture paths missing 'tools': {paths}"
+
+    def test_mypy_does_not_exclude_pyproject_template(self) -> None:
+        """The tooling package must not be excluded from type checking wholesale.
+
+        Its bare ``sys.path`` imports are suppressed by module-name overrides
+        instead, so the other ~5,300 lines stay checked.
+        """
+        import tomllib
+
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject.open("rb") as handle:
+            config = tomllib.load(handle)
+        excludes = config["tool"]["mypy"].get("exclude", [])
+        assert not any("pyproject_template" in entry for entry in excludes), (
+            f"tools/pyproject_template/ is excluded from mypy again: {excludes}"
+        )

--- a/tests/template/test_doit_release.py
+++ b/tests/template/test_doit_release.py
@@ -44,7 +44,11 @@ class TestRunStreamed:
 
     def test_success_returns_none(self) -> None:
         """A zero-exit command returns ``None`` and does not raise."""
-        result = run_streamed([sys.executable, "-c", "print('hi')"])
+        # run_streamed is annotated `-> None`, so mypy calls the binding below
+        # pointless. The assertion is kept deliberately: it documents the
+        # contract at runtime and would catch the signature being widened to
+        # return something. Suppressing beats deleting a real check.
+        result = run_streamed([sys.executable, "-c", "print('hi')"])  # type: ignore[func-returns-value]
         assert result is None
 
     def test_failure_with_check_true_raises(self) -> None:
@@ -56,7 +60,9 @@ class TestRunStreamed:
     def test_failure_with_check_false_does_not_raise(self) -> None:
         """Non-zero exit with ``check=False`` returns without raising."""
         # Must not raise.
-        result = run_streamed(
+        # See the note in test_success_returns_none for why this is suppressed
+        # rather than the assertion removed.
+        result = run_streamed(  # type: ignore[func-returns-value]
             [sys.executable, "-c", "import sys; sys.exit(3)"],
             check=False,
         )

--- a/tests/test_benchmark_workflow.py
+++ b/tests/test_benchmark_workflow.py
@@ -13,7 +13,10 @@ def _load_workflow() -> dict:
     """Load and parse the benchmark workflow YAML."""
     # Windows read_text() defaults to cp1252 which can't decode non-ASCII
     # characters like ✅ in workflow files — always specify utf-8.
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # Bind to an annotated local first: yaml.safe_load returns Any,
+    # and returning Any from a typed function trips warn_return_any.
+    data: dict = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return data
 
 
 class TestBenchmarkWorkflowExists:
@@ -68,7 +71,10 @@ class TestBenchmarkWorkflowSteps:
     def _get_steps(self) -> list[dict]:
         """Get the steps from the benchmark job."""
         workflow = _load_workflow()
-        return workflow["jobs"]["benchmark"]["steps"]
+        # Indexing an untyped mapping yields Any; bind to an annotated local so
+        # warn_return_any does not fire on the return.
+        steps: list[dict] = workflow["jobs"]["benchmark"]["steps"]
+        return steps
 
     def _find_step(self, name: str) -> dict | None:
         """Find a step by name."""

--- a/tests/test_ci_full_matrix_workflow.py
+++ b/tests/test_ci_full_matrix_workflow.py
@@ -31,7 +31,10 @@ def _load_workflow() -> dict[Any, Any]:
     default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
     non-ASCII content in the workflow file (lesson from issue #430).
     """
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # Bind to an annotated local first: yaml.safe_load returns Any,
+    # and returning Any from a typed function trips warn_return_any.
+    data: dict[Any, Any] = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return data
 
 
 class TestWorkflowFile:

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -37,7 +37,10 @@ def _load_workflow() -> dict[Any, Any]:
     default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
     non-ASCII content in the workflow file (lesson from issue #430).
     """
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # Bind to an annotated local first: yaml.safe_load returns Any,
+    # and returning Any from a typed function trips warn_return_any.
+    data: dict[Any, Any] = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return data
 
 
 class TestWorkflowFile:

--- a/tests/test_codeql_workflow.py
+++ b/tests/test_codeql_workflow.py
@@ -29,7 +29,10 @@ def _load_workflow() -> dict[Any, Any]:
     default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
     non-ASCII content in the workflow file (lesson from issue #430).
     """
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # Bind to an annotated local first: yaml.safe_load returns Any,
+    # and returning Any from a typed function trips warn_return_any.
+    data: dict[Any, Any] = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return data
 
 
 def _analyze_steps() -> list[dict[str, Any]]:

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -37,7 +37,10 @@ def _load_workflow() -> dict[Any, Any]:
     Return type is ``dict[Any, Any]`` (not ``dict[str, Any]``) because
     PyYAML parses the ``on`` key as the boolean ``True`` (YAML 1.1 alias).
     """
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # Bind to an annotated local first: yaml.safe_load returns Any,
+    # and returning Any from a typed function trips warn_return_any.
+    data: dict[Any, Any] = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return data
 
 
 def _enable_automerge_steps() -> list[dict[str, Any]]:

--- a/tests/test_dependabot_blocked_label_workflow.py
+++ b/tests/test_dependabot_blocked_label_workflow.py
@@ -40,7 +40,10 @@ def _load_workflow() -> dict[Any, Any]:
     default ``locale.getpreferredencoding()`` is cp1252 and chokes on any
     non-ASCII content in the workflow file (lesson from issue #430).
     """
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # Bind to an annotated local first: yaml.safe_load returns Any,
+    # and returning Any from a typed function trips warn_return_any.
+    data: dict[Any, Any] = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return data
 
 
 def _handle_blocked_label_steps() -> list[dict[str, Any]]:

--- a/tools/doit/quality.py
+++ b/tools/doit/quality.py
@@ -41,8 +41,10 @@ def task_format_check() -> dict[str, Any]:
 
 def task_type_check() -> dict[str, Any]:
     """Run mypy type checking (uses pyproject.toml configuration)."""
+    # Covers tools/ and tests/, not just tools/doit/: narrower scopes let real
+    # errors in tools/hooks/ and tests/ pass a green `doit check`. See #700.
     return {
-        "actions": ["uv run mypy src/ tools/doit/" + optional_root_files("bootstrap.py")],
+        "actions": ["uv run mypy src/ tools/ tests/" + optional_root_files("bootstrap.py")],
         "title": title_with_actions,
         "verbosity": 0,
     }
@@ -73,13 +75,14 @@ def task_maintainability() -> dict[str, Any]:
 
 
 def task_check() -> dict[str, Any]:
-    """Run all checks (format, lint, type check, security, audit, spelling, test)."""
+    """Run all checks (format, lint, type check, dead code, security, audit, spelling, test)."""
     return {
         "actions": [success_message],
         "task_dep": [
             "format_check",
             "lint",
             "type_check",
+            "deadcode",
             "security",
             "audit",
             "spell_check",

--- a/tools/hooks/ai/test_hook.py
+++ b/tools/hooks/ai/test_hook.py
@@ -269,7 +269,9 @@ BYPASS_TESTS = [
 # File-edit test cases: (tool_name, tool_input_dict, expected, description)
 # expected: 'ALLOW' or 'BLOCK'
 # ---------------------------------------------------------------------------
-EDIT_TESTS = [
+# Annotated so the tuple unpacking in main() sees the element types
+# directly; mypy widens a heterogeneous literal list to `object`.
+EDIT_TESTS: list[tuple[str, dict, str, str]] = [
     # Edit ~/.bashrc adding the env var name → BLOCK
     (
         "Edit",
@@ -377,7 +379,7 @@ EDIT_TESTS = [
 
 # Copilot-format file-edit tests: same shape but using camelCase hook input
 # (tool_name, tool_input_dict, expected, description)
-COPILOT_EDIT_TESTS = [
+COPILOT_EDIT_TESTS: list[tuple[str, dict, str, str]] = [
     (
         "Edit",
         {
@@ -424,7 +426,7 @@ AGY_COMMAND_TESTS = [
 ]
 
 # write_to_file tests: (target_file, code_content, expected, description)
-AGY_EDIT_TESTS = [
+AGY_EDIT_TESTS: list[tuple[str, str, str, str]] = [
     ("~/.bashrc", "export ALLOW_AI_READY_TO_MERGE=1", "BLOCK", "write_to_file .bashrc rtm var"),
     (".envrc", "export ALLOW_AI_READY_TO_MERGE=1\n", "BLOCK", "write_to_file .envrc rtm var"),
     (

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -773,7 +773,11 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    # Determine mode
+    # Determine mode. Annotated up front because ``prompt_cleanup()`` in the
+    # else-branch returns ``CleanupMode | None``; without this, mypy infers
+    # ``CleanupMode`` from the first branch and then reports the ``is None``
+    # guard below as unreachable.
+    mode: CleanupMode | None
     if args.setup and args.all:
         Logger.error("Cannot specify both --setup and --all")
         return 1

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -46,9 +46,9 @@ from utils import Colors, Logger, prompt, validate_package_name  # noqa: E402
 try:
     from cleanup import CleanupMode, cleanup_template_files, prompt_cleanup
 except ImportError:
-    CleanupMode = None  # type: ignore[misc,assignment]
-    cleanup_template_files = None  # type: ignore[assignment]
-    prompt_cleanup = None  # type: ignore[assignment]
+    CleanupMode = None
+    cleanup_template_files = None
+    prompt_cleanup = None
 
 
 def print_banner() -> None:


### PR DESCRIPTION
## Description

`doit check` reported success on files it never inspected. Two of its sub-tasks were scoped to
directories that excluded the AI hooks entirely:

```python
# tools/doit/quality.py — before
"uv run mypy src/ tools/doit/" + optional_root_files("bootstrap.py")
```
```toml
# pyproject.toml — before
[tool.vulture]
paths = ["src", "tests"]
```

So `tools/hooks/` (2,654 lines, including the 836-line hook that gates all five AI agents) was
neither type-checked nor dead-code-checked, and `tests/` was not type-checked. Two real defects
escaped through that gap during PR #699 and were caught only by an editor LSP.

`deadcode` was also defined as a task but absent from `task_check`'s `task_dep`, so vulture never
ran as part of the gate at all.

### The exclusion was over-broad, not wrong

`tools/pyproject_template/` (5,370 lines) was excluded from mypy at the *config* layer, so
widening the command scope alone would not have reached it — a change that looks like coverage
without being coverage.

The stated reason for the exclusion is accurate: these scripts run standalone and do
`sys.path.insert` before importing siblings by bare name (`from utils import ...`), which mypy
cannot resolve. But excluding the whole directory to silence 16 import errors also silenced 5 real
findings.

This PR replaces the directory exclude with module-name `ignore_missing_imports` overrides, which
suppress only the import artifact. mypy now checks **108 source files, up from 23**.

`mypy_path` was tried first and rejected: it makes `utils.py` reachable as both `utils` and
`tools.pyproject_template.utils`, which mypy refuses.

### Errors fixed (15)

| Pattern | Count | Fix |
| :--- | ---: | :--- |
| `no-any-return` in workflow tests | 7 | `yaml.safe_load()` returns `Any`; bind to an annotated local before returning |
| Stale `# type: ignore` in `manage.py` | 3 | Removed — they no longer suppressed anything |
| `arg-type` in `test_hook.py` | 1 | Annotated the three `*_EDIT_TESTS` lists |
| `assignment` + `unreachable` in `cleanup.py` | 2 | Annotated `mode: CleanupMode \| None` up front |
| `func-returns-value` in `test_doit_release.py` | 2 | Targeted `# type: ignore`, assertions preserved |

The last two deserve a note. `run_streamed` is annotated `-> None`, so mypy considers
`result = run_streamed(...); assert result is None` pointless. The assertions were **kept** and
suppressed rather than deleted: they document the contract and would catch the signature being
widened. Per AGENTS.md, a passing test's assertions are not something to quietly remove to satisfy
a type checker.

The `cleanup.py` fix is the same trap as #701 — a name inferred from an earlier branch making a
real `is None` guard look unreachable. Two occurrences in two PRs; tracked as #704.

### Scope guards

Five tests in `TestQualityGateScope` pin the gate so it cannot silently narrow again — including
one that fails if `type_check` reverts to `tools/doit/`, and one that fails if the
`pyproject_template` mypy exclusion returns.

## Related Issue

Addresses #700

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvement
- [x] This change requires a documentation update

## Changes Made

- `tools/doit/quality.py`: `type_check` widened to `src/ tools/ tests/`; `deadcode` added to
  `task_check`'s `task_dep`; docstring updated.
- `pyproject.toml`: removed the `tools/pyproject_template/` mypy exclude in favour of bare-module
  `ignore_missing_imports` overrides; vulture `paths` now includes `tools`; added `ConsoleType` to
  vulture `ignore_names`.
- 15 mypy errors fixed across 9 files (table above).
- `tests/template/test_doit_quality.py`: new `TestQualityGateScope` (5 tests); updated
  `test_task_dep_covers_full_check_set` for the new gate contract.
- `docs/development/coding-standards.md`: documented the residual blind spot.

### On the vulture findings

Widening vulture surfaced 3 `unused import 'ConsoleType'` findings. All three are **false
positives** — `TYPE_CHECKING` imports referenced only from string annotations
(`console: "ConsoleType"`), which vulture does not parse. Deleting them would have broken type
checking, so they are allowlisted via `ignore_names` rather than "fixed".

## Testing

| Check | Result |
|---|---|
| `doit check` (now including `deadcode`) | passes |
| `mypy src/ tools/ tests/ bootstrap.py` | Success — 108 source files (was 23) |
| `vulture` (widened paths) | clean |
| Full suite | 1112 passed |
| `python3 tools/hooks/ai/test_hook.py` | 134 passed, 0 failed |

**Regression proof.** PR #699's type error was re-introduced and `doit type_check` now catches it:

```
tests/test_hook_block_dangerous_commands.py:80: error: Argument 1 to "int" has
    incompatible type "str | int | None"; ...  [arg-type]
```

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A: this repo generates `CHANGELOG.md` via commitizen at
      release time (`update_changelog_on_bump = true`); it is not hand-edited per PR.
- [x] My changes generate no new warnings

## Additional Notes

**One original success criterion was narrowed, not met.** The issue said both PR #699 defects
would be caught. The dead `_GIT_GLOBAL_FLAGS` constant is **not** caught, and cannot be with the
current toolchain — verified against vulture at confidence 100/90/80/70/60/1, ruff, pyright CLI,
and mypy. Two independent reasons vulture cannot see it: underscore-prefixed names are skipped at
any confidence, and public unused module variables are reported at only 60%, below the configured
80. Dropping to 60% yields 57 findings, 55 of them `unused function` for dynamically-discovered
`task_*`/`test_*` names.

Issue #700 was updated with this evidence, and the gap is now documented in
`docs/development/coding-standards.md` rather than left implicit. No follow-up issue was filed:
there is no achievable fix to track.
