### PR TITLE
fix: fail closed when the dangerous-command hook cannot evaluate a command

### DIFF
--- a/tests/test_hook_block_dangerous_commands.py
+++ b/tests/test_hook_block_dangerous_commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -407,3 +408,113 @@ def test_non_dict_tool_input_is_tolerated(
     payload = json.dumps({"tool_name": "Bash", "tool_input": "oops"})
     code, _ = _run_raw(hook, monkeypatch, capsys, payload)
     assert code == 0
+
+
+# --- Fail-closed behaviour (issue #679) ------------------------------------
+#
+# The hook uses two deny contracts: exit code 2 (Claude/Gemini/Codex) and
+# stdout JSON (Antigravity/Copilot). They diverge on *failure*: a script that
+# produces no output is "allow" for the stdout-contract CLIs. When the hook
+# cannot evaluate a command it must deny for every CLI, which means emitting
+# all three contracts at once because the caller is unknown at that point.
+
+
+def _assert_denies_every_contract(code: int, out: str, err: str) -> None:
+    """Assert the payload denies for all five supported CLIs."""
+    assert code == 2, "Claude/Gemini/Codex block on exit code 2"
+    payload = json.loads(out)
+    assert payload["decision"] == "deny", "Antigravity reads `decision`"
+    assert payload["permissionDecision"] == "deny", "Copilot reads `permissionDecision`"
+    assert payload["reason"]
+    assert payload["permissionDecisionReason"]
+    assert "BLOCKED" in err, "Claude/Gemini/Codex surface the stderr message"
+
+
+def test_malformed_stdin_denies_instead_of_allowing(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Unparsable stdin denies for every CLI rather than returning 1.
+
+    Regression for #679: ``return 1`` is not a block for any of the five CLIs,
+    so malformed input previously let the operation through everywhere.
+    """
+    _set_stdin(monkeypatch, "not json")
+    code = int(hook.run())
+    captured = capsys.readouterr()
+    _assert_denies_every_contract(code, captured.out, captured.err)
+
+
+def test_internal_error_denies_instead_of_allowing(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unexpected exception inside ``main`` denies for every CLI."""
+
+    def _boom() -> tuple[str, str, dict[str, object]]:
+        raise RuntimeError("simulated internal failure")
+
+    monkeypatch.setattr(hook, "_parse_input", lambda *_: _boom())
+    _set_stdin(monkeypatch, _bash_payload("git status"))
+    code = int(hook.run())
+    captured = capsys.readouterr()
+    _assert_denies_every_contract(code, captured.out, captured.err)
+    assert "RuntimeError" in captured.out
+
+
+def test_non_dict_toplevel_payload_denies(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Valid JSON that isn't an object denies rather than raising a traceback."""
+    _set_stdin(monkeypatch, '"a bare string"')
+    code = int(hook.run())
+    captured = capsys.readouterr()
+    _assert_denies_every_contract(code, captured.out, captured.err)
+
+
+def test_run_passes_through_normal_outcomes(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``run`` is transparent when ``main`` completes normally."""
+    monkeypatch.setattr(hook, "get_current_branch", lambda: "feature/test")
+    _set_stdin(monkeypatch, _bash_payload("git status"))
+    assert int(hook.run()) == 0
+    assert capsys.readouterr().out.strip() == ""
+
+
+def test_fail_closed_payload_is_a_single_json_object(
+    hook: types.ModuleType,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Both stdout keys ride in one object; two objects would break parsers."""
+    assert hook._fail_closed("probe") == 2
+    out = capsys.readouterr().out
+    assert len(out.strip().splitlines()) == 1
+    assert set(json.loads(out)) == {
+        "decision",
+        "reason",
+        "permissionDecision",
+        "permissionDecisionReason",
+    }
+
+
+def test_script_denies_malformed_input_as_a_subprocess() -> None:
+    """End-to-end through the real ``__main__`` path, not just ``main()``.
+
+    The in-process tests bypass the script's entry point; this one exercises
+    the exit code a CLI actually observes.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    _assert_denies_every_contract(proc.returncode, proc.stdout, proc.stderr)

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -868,7 +868,7 @@ LOG_FILE = Path(__file__).parent / "hook-debug.jsonl"
 
 
 def _log(entry: dict) -> None:
-    """Append a JSON log entry. Only active when HOOK_DEBUG=1 is set."""
+    """Append a JSON log entry. Only active when HOOK_BLOCKCOMMAND_DEBUG=1 is set."""
     if not os.environ.get("HOOK_BLOCKCOMMAND_DEBUG"):
         return
     try:
@@ -924,13 +924,45 @@ def _block_response(fmt: str, reason: str, command: str) -> int:
     return 2  # Exit 2 = Block and show stderr to Claude/Gemini/Codex
 
 
+def _fail_closed(reason: str) -> int:
+    """Deny using every supported CLI's contract at once.
+
+    Used when the hook cannot tell which CLI called it (unparsable stdin) or
+    when it hits an unexpected internal error. A hook that cannot evaluate a
+    command must not let it through, and at that point the calling CLI is
+    unknown -- so emit all three contracts together:
+
+    - stdout JSON carrying both ``decision`` (Antigravity) and
+      ``permissionDecision`` (Copilot) keys
+    - exit code 2 + stderr (Claude/Gemini/Codex)
+
+    Verified against the real CLIs: ``agy`` and ``copilot`` both honour the
+    combined payload and both tolerate the extra key and the non-zero exit.
+    """
+    manual = f"Blocked: {reason}. If intentional, ask the user to run it manually."
+
+    print(
+        json.dumps(
+            {
+                "decision": "deny",
+                "reason": manual,
+                "permissionDecision": "deny",
+                "permissionDecisionReason": manual,
+            }
+        )
+    )
+    print(f"BLOCKED: {manual}", file=sys.stderr)
+    return 2
+
+
 def main() -> int:
     """Main entry point."""
     try:
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError as e:
-        print(f"Invalid JSON input: {e}", file=sys.stderr)
-        return 1
+        # Deny rather than return 1: no agent treats 1 as a block, so returning
+        # it here would let the operation through on unparsable input.
+        return _fail_closed(f"hook could not parse its input ({e})")
 
     tool_name, command, tool_input = _parse_input(input_data)
     fmt = _hook_format(input_data)
@@ -964,5 +996,18 @@ def main() -> int:
     return 0
 
 
+def run() -> int:
+    """Invoke :func:`main`, denying rather than propagating any internal error.
+
+    Without this guard an unexpected exception produces no deny payload at all,
+    which the stdout-contract CLIs (Antigravity, Copilot) read as "allow".
+    """
+    try:
+        return main()
+    # Broad by design: a hook that cannot evaluate a command must deny.
+    except Exception as exc:
+        return _fail_closed(f"hook raised {type(exc).__name__}: {exc}")
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(run())


### PR DESCRIPTION
## Description

The dangerous-command hook used two deny contracts that diverged on *failure*.
Claude/Gemini/Codex block on exit code 2; Antigravity/Copilot block only on stdout
JSON. A script that produced no output therefore read as **allow** for the
stdout-contract CLIs, so any internal error silently removed protection. Malformed
stdin returned `1`, which no CLI treats as a block, so all five failed open.

This makes the hook fail **closed**: when it cannot evaluate a command it denies,
uniformly, for every supported CLI.

## Related Issue

Addresses #679

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `_fail_closed()`, emitting every deny contract at once — a single stdout JSON
  object carrying both `decision` (Antigravity) and `permissionDecision` (Copilot),
  plus exit 2 + stderr (Claude/Gemini/Codex). All contracts are emitted because the
  calling CLI is unknown at the point of failure.
- Route unparsable stdin through `_fail_closed()` instead of `return 1`.
- Add `run()`, which catches any internal exception and denies. Extracted out of the
  `__main__` block so the guard is reachable from tests.
- Correct `_log`'s docstring, which named `HOOK_DEBUG` while the code reads
  `HOOK_BLOCKCOMMAND_DEBUG`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. Hook suites: 34 pytest tests (was 28) and 134 manual cases.

New coverage asserts *all five* contracts deny for unparsable stdin, a forced
internal error, and a non-dict payload; that both stdout keys ride in a **single**
JSON object (two objects would break parsers); and one subprocess test exercises the
real `__main__` path, which the in-process tests bypass.

Verified live against the real CLIs rather than assumed:

| CLI | Result |
| :--- | :--- |
| `agy` | `Denied` — accepts the merged payload *and* the non-zero exit |
| `copilot` | `Denied by preToolUse hook` |
| Claude Code | Blocked; stderr surfaced, extra stdout JSON ignored harmlessly |

Gemini and Codex share Claude's exit-2 contract so they follow by construction, but
were not exercised live.

The non-dict payload case was not hypothetical — it previously raised
`AttributeError` and produced no deny payload at all.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

Documentation unchecked: no documented behaviour changes — the deny contracts and
their per-CLI mapping are already described in
`docs/development/ai/command-blocking.md`, and this PR only changes what happens on
failure paths that the doc does not enumerate.

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**Scope split with #680, stated explicitly.** #679 also suggests "a wrapper or
preflight for the stdout-contract agents so a missing/unreadable script still
denies." That cannot be fixed inside the script — a script that never runs cannot
emit its own deny — so it belongs to the hook *wiring*, which #680 owns. A probe run
while investigating confirmed `agy` shell-interprets its hook command, so a
`|| echo '{"decision":"deny",...}'` fallback will close that path there.

**#679 and #680 together close the gap; neither does alone.**
