### PR TITLE
fix: pin the Antigravity hook path and fail closed when the hook cannot start

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ../tools/hooks/ai/block-dangerous-commands.py"
+            "command": "sh \"$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.sh\""
           }
         ]
       }

--- a/.github/hooks/copilot-hooks.json
+++ b/.github/hooks/copilot-hooks.json
@@ -4,7 +4,7 @@
     "preToolUse": [
       {
         "type": "command",
-        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "bash": "sh ../../tools/hooks/ai/block-dangerous-commands.sh",
         "cwd": ".github/hooks",
         "timeoutSec": 10
       }

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -125,6 +125,7 @@ EOF
 | File | Description |
 |------|-------------|
 | [`block-dangerous-commands.py`](../../../tools/hooks/ai/block-dangerous-commands.py) | The hook script (shared by Claude, Gemini, Copilot, Codex, and Antigravity) |
+| [`block-dangerous-commands.sh`](../../../tools/hooks/ai/block-dangerous-commands.sh) | Fail-closed launcher used by the stdout-contract CLIs (Copilot, Antigravity) |
 | [`test_hook.py`](../../../tools/hooks/ai/test_hook.py) | Manual test suite (run with `python3 tools/hooks/ai/test_hook.py`) |
 | [`tests/test_hook_block_dangerous_commands.py`](../../../tests/test_hook_block_dangerous_commands.py) | Pytest test suite — collected by CI via `testpaths = ["tests"]` |
 
@@ -202,7 +203,7 @@ Gemini's file-write tools are `write_file` (full-file overwrite, `content` param
     "preToolUse": [
       {
         "type": "command",
-        "bash": "python3 ../../tools/hooks/ai/block-dangerous-commands.py",
+        "bash": "sh ../../tools/hooks/ai/block-dangerous-commands.sh",
         "cwd": ".github/hooks",
         "timeoutSec": 10
       }
@@ -255,7 +256,7 @@ Codex uses the shared hook as the primary defense layer. Project docs should not
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ../tools/hooks/ai/block-dangerous-commands.py"
+            "command": "sh \"$(git rev-parse --show-toplevel)/tools/hooks/ai/block-dangerous-commands.sh\""
           }
         ]
       }
@@ -274,11 +275,70 @@ Unlike Claude/Gemini/Codex (which block via exit code 2), `agy` blocks only when
 and defers to `agy`'s normal permission flow. A `deny` decision hard-blocks even under
 `--dangerously-skip-permissions`.
 
-The handler's working directory is the directory containing `hooks.json` (`.agents/`), and `agy`
-exposes no project-dir env var, so the command path is relative (`../tools/...`). `agy` only loads
-workspace customizations for an **active/trusted** workspace, so headless `agy -p` invocations must
-pass `--add-dir <repo-root>` for the hook to apply; interactive sessions prompt to trust the
-workspace on first open.
+`agy` exposes no project-dir env var, but it **does** shell-interpret the hook command, so the
+path is pinned with `$(git rev-parse --show-toplevel)` rather than left relative.
+
+The handler's working directory is the directory containing `hooks.json`. Verified empirically by
+logging `os.getcwd()` from the hook during a real `agy` run:
+
+```
+_cwd   = <repo-root>/.agents
+_argv0 = ../tools/hooks/ai/block-dangerous-commands.py
+```
+
+A relative `../tools/...` therefore did resolve — but only because of that CWD, which is `agy`
+behaviour rather than a documented contract. Since the hook is `agy`'s only gate (delegated
+invocations pass `--dangerously-skip-permissions`) and its deny contract is stdout-based, a CWD
+change in a future `agy` release would have disabled it silently and permissively. The absolute
+form removes that dependency.
+
+`agy` only loads workspace customizations for an **active/trusted** workspace, so headless
+`agy -p` invocations must pass `--add-dir <repo-root>` for the hook to apply; interactive sessions
+prompt to trust the workspace on first open.
+
+To confirm the hook is firing, set `HOOK_BLOCKCOMMAND_DEBUG=1` — without it the hook writes no
+debug log and an "is it wired?" probe reads as a false negative:
+
+```bash
+HOOK_BLOCKCOMMAND_DEBUG=1 agy -p 'run: git status' --add-dir "$(git rev-parse --show-toplevel)"
+cat tools/hooks/ai/hook-debug.jsonl   # a new line means the hook ran
+```
+
+### Failure Behaviour
+
+The hook uses two deny contracts, and they diverge on *failure*:
+
+| Agents | Deny contract | If the hook produces nothing |
+| :--- | :--- | :--- |
+| Claude, Gemini, Codex | exit code 2 + stderr | Blocked — a failed `python3` also exits non-zero |
+| Copilot, Antigravity | stdout JSON, exit 0 | **Allowed** — "no payload" means "no objection" |
+
+So for the stdout-contract CLIs, anything that stops the hook from printing its payload silently
+removes protection. Two layers close that:
+
+**In-script** (`block-dangerous-commands.py`) — `run()` wraps `main()` so an unexpected exception
+denies instead of propagating, and unparsable stdin denies instead of returning `1` (which no CLI
+treats as a block). Both paths call `_fail_closed()`, which emits *every* contract at once — a
+single JSON object carrying both `decision` and `permissionDecision`, plus exit 2 and stderr —
+because at that point the calling CLI is unknown.
+
+**At the wiring** (`block-dangerous-commands.sh`) — a script that never starts cannot emit its own
+deny, so the stdout-contract CLIs invoke this launcher instead of the `.py` directly. It denies
+when `python3` or the hook script is unavailable.
+
+The launcher checks those preconditions rather than the hook's exit status, deliberately: the hook
+exits 2 on its own fail-closed path, which is indistinguishable from "`python3` could not find the
+file". Branching on exit status would append a second deny payload after the hook's own, putting
+two JSON objects on stdout.
+
+Verified against the real CLIs — `agy`, `copilot`, and Claude Code all block on the combined
+payload, and both stdout-contract CLIs tolerate the extra key and the non-zero exit. Gemini and
+Codex share Claude's exit-2 contract.
+
+**Known gap:** a syntax error in the hook script, or a hook timeout, still yields no payload and no
+launcher precondition failure. Covering that would require the hook to emit something on every
+invocation, including allows, which is a protocol change both stdout-contract CLIs would need to
+tolerate.
 
 ### Testing
 

--- a/tests/template/test_ai_agent_assets.py
+++ b/tests/template/test_ai_agent_assets.py
@@ -188,8 +188,15 @@ def test_antigravity_hooks_json_wires_shared_hook() -> None:
         for entry in group.get("PreToolUse", [])
         for handler in entry.get("hooks", [])
     ]
-    assert any("block-dangerous-commands.py" in c for c in commands), (
-        "Antigravity .agents/hooks.json must wire block-dangerous-commands.py on PreToolUse"
+    assert any("block-dangerous-commands" in c for c in commands), (
+        "Antigravity .agents/hooks.json must wire the shared dangerous-command hook on PreToolUse"
+    )
+    # The hook is agy's only gate (delegated invocations pass
+    # --dangerously-skip-permissions), so its path must not depend on the CWD
+    # agy happens to run handlers from. A bare "../tools/..." satisfied the
+    # assertion above while resolving outside the repo from any other CWD.
+    assert any("$(git rev-parse --show-toplevel)" in c for c in commands), (
+        "Antigravity hook path must resolve independently of the handler CWD"
     )
 
     matchers = [
@@ -200,6 +207,54 @@ def test_antigravity_hooks_json_wires_shared_hook() -> None:
     assert any("run_command" in m for m in matchers), (
         "Antigravity hook matcher must target the run_command tool"
     )
+
+
+def test_copilot_hooks_json_pins_its_hook_path() -> None:
+    """Copilot's wiring must keep an explicit cwd so its relative path resolves."""
+    hooks_path = REPO_ROOT / ".github" / "hooks" / "copilot-hooks.json"
+    assert hooks_path.exists(), f"Missing Copilot hooks config: {hooks_path}"
+
+    config = json.loads(hooks_path.read_text(encoding="utf-8"))
+    entries = config.get("hooks", {}).get("preToolUse", [])
+    assert entries, "Copilot config must define a preToolUse hook"
+
+    for entry in entries:
+        assert "block-dangerous-commands" in entry.get("bash", ""), (
+            "Copilot preToolUse hook must wire the shared dangerous-command hook"
+        )
+        # The path is relative, so the cwd pin is what makes it resolve.
+        assert entry.get("cwd"), (
+            "Copilot hook uses a relative path and must pin cwd, or it resolves "
+            "against an unstated working directory"
+        )
+
+
+def test_stdout_contract_wirings_route_through_the_launcher() -> None:
+    """Antigravity and Copilot must invoke the launcher, not the .py directly.
+
+    Both block only on a stdout deny payload, so a hook that cannot start reads
+    as "allow". The launcher denies in that case; calling the .py directly does
+    not, because a script that never runs cannot emit its own deny.
+    """
+    agy = json.loads((REPO_ROOT / ".agents" / "hooks.json").read_text(encoding="utf-8"))
+    agy_commands = [
+        handler.get("command", "")
+        for group in agy.values()
+        for entry in group.get("PreToolUse", [])
+        for handler in entry.get("hooks", [])
+    ]
+    copilot = json.loads(
+        (REPO_ROOT / ".github" / "hooks" / "copilot-hooks.json").read_text(encoding="utf-8")
+    )
+    copilot_commands = [e.get("bash", "") for e in copilot.get("hooks", {}).get("preToolUse", [])]
+
+    for label, commands in (("Antigravity", agy_commands), ("Copilot", copilot_commands)):
+        assert any("block-dangerous-commands.sh" in c for c in commands), (
+            f"{label} must route through the fail-closed launcher"
+        )
+
+    launcher = REPO_ROOT / "tools" / "hooks" / "ai" / "block-dangerous-commands.sh"
+    assert launcher.exists(), f"Missing launcher: {launcher}"
 
 
 def test_gemini_disabled_list_contains_antigravity_skills() -> None:

--- a/tests/test_hook_block_dangerous_commands.py
+++ b/tests/test_hook_block_dangerous_commands.py
@@ -518,3 +518,85 @@ def test_script_denies_malformed_input_as_a_subprocess() -> None:
         check=False,
     )
     _assert_denies_every_contract(proc.returncode, proc.stdout, proc.stderr)
+
+
+# --- Launcher fail-closed behaviour (issue #680) ---------------------------
+#
+# `block-dangerous-commands.sh` exists because the in-script guards from #679
+# cannot cover a script that never starts. It checks preconditions rather than
+# the hook's exit status: the hook exits 2 on its own fail-closed path, which
+# is indistinguishable from "python3 could not find the file", so branching on
+# exit status would append a second deny payload to the hook's own.
+
+LAUNCHER_PATH = HOOK_PATH.with_suffix(".sh")
+
+requires_posix_sh = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="launcher is POSIX sh; the hook wirings that use it are POSIX-only",
+)
+
+
+def _run_launcher(
+    payload: str, *, cwd: Path | None = None, script: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run the launcher with *payload* on stdin."""
+    return subprocess.run(
+        ["sh", str(script or LAUNCHER_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+    )
+
+
+@requires_posix_sh
+def test_launcher_passes_through_a_normal_deny() -> None:
+    """A dangerous command still denies with the CLI's native contract."""
+    proc = _run_launcher(_agy_payload(DANGEROUS))
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["decision"] == "deny"
+
+
+@requires_posix_sh
+def test_launcher_passes_through_an_allow() -> None:
+    """A safe command still produces no deny payload."""
+    proc = _run_launcher(_agy_payload("git status"))
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+@requires_posix_sh
+def test_launcher_emits_exactly_one_payload_on_fail_closed() -> None:
+    """Regression: the launcher must not append a payload to the hook's own.
+
+    Both "hook fail-closed" and "hook missing" exit 2. A launcher that keyed
+    off the exit status would emit two JSON objects on stdout here.
+    """
+    proc = _run_launcher("not json")
+    assert proc.returncode == 2
+    lines = [ln for ln in proc.stdout.strip().splitlines() if ln.strip()]
+    assert len(lines) == 1, f"expected one JSON object, got {len(lines)}"
+    json.loads(lines[0])
+
+
+@requires_posix_sh
+def test_launcher_denies_when_the_hook_script_is_missing(tmp_path: Path) -> None:
+    """The case the launcher exists for: the .py is absent, so nothing can run."""
+    stray = tmp_path / LAUNCHER_PATH.name
+    stray.write_text(LAUNCHER_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    proc = _run_launcher(_agy_payload("git status"), script=stray)
+
+    payload = json.loads(proc.stdout)
+    assert proc.returncode == 2
+    assert payload["decision"] == "deny"
+    assert payload["permissionDecision"] == "deny"
+    assert "BLOCKED" in proc.stderr
+
+
+@requires_posix_sh
+def test_launcher_resolves_the_hook_independently_of_cwd(tmp_path: Path) -> None:
+    """The launcher locates the hook via its own path, not the caller's CWD."""
+    proc = _run_launcher(_agy_payload(DANGEROUS), cwd=tmp_path)
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["decision"] == "deny"

--- a/tools/hooks/ai/block-dangerous-commands.sh
+++ b/tools/hooks/ai/block-dangerous-commands.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Fail-closed launcher for block-dangerous-commands.py.
+#
+# The stdout-contract CLIs (Antigravity, Copilot) block only when the hook
+# prints a deny payload; "no output" means allow. So a hook that cannot even
+# start silently disables protection for them -- and Antigravity's delegated
+# invocations pass --dangerously-skip-permissions, making the hook its only
+# gate. This launcher denies when the interpreter or the hook script is
+# unavailable, instead of letting the operation through.
+#
+# It checks preconditions rather than the hook's exit status on purpose: the
+# hook itself exits 2 on its own fail-closed path, which is indistinguishable
+# from "python3 could not find the file". Branching on exit status would emit
+# a second deny payload after the hook's own, producing two JSON objects on
+# stdout.
+#
+# POSIX sh only -- macOS CI runs bash 3.2 and this must not depend on bash 4+.
+
+set -u
+
+HOOK_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HOOK="$HOOK_DIR/block-dangerous-commands.py"
+
+if command -v python3 >/dev/null 2>&1 && [ -r "$HOOK" ]; then
+    exec python3 "$HOOK"
+fi
+
+REASON="the dangerous-command hook could not start (missing python3 or $HOOK)"
+MANUAL="Blocked: $REASON. If intentional, ask the user to run it manually."
+
+# Emit every deny contract at once: the caller is unknown at this point.
+printf '{"decision":"deny","reason":"%s","permissionDecision":"deny","permissionDecisionReason":"%s"}\n' \
+    "$MANUAL" "$MANUAL"
+printf 'BLOCKED: %s\n' "$MANUAL" >&2
+exit 2


### PR DESCRIPTION
## Description

`.agents/hooks.json` was the only one of the five agent wirings using a bare relative
path (`python3 ../tools/...`) with no `cwd` pin.

**The probe result was not what the issue assumed.** `agy` runs hook handlers with the
working directory set to the directory containing `hooks.json`, so `../tools/...` *did*
resolve, and the hook has been firing. Verified by logging `os.getcwd()` from inside the
hook during a real `agy` run:

```
_cwd   = <repo-root>/.agents
_argv0 = ../tools/hooks/ai/block-dangerous-commands.py
```

So this is a latent robustness fix, not an active hole — worth stating plainly, since the
issue was filed on the assumption it might already be broken.

It is still worth fixing: that CWD is `agy` behaviour rather than a documented contract,
the hook is `agy`'s only gate (delegated invocations pass
`--dangerously-skip-permissions`), and its deny contract is stdout-based — so a CWD change
in a future `agy` release would have disabled it silently and permissively.

## Related Issue

Addresses #680

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Pin the Antigravity hook path with `$(git rev-parse --show-toplevel)`, matching Codex.
  A probe confirmed `agy` shell-interprets the hook command, so the substitution expands.
- Add `tools/hooks/ai/block-dangerous-commands.sh`, a fail-closed launcher that denies when
  `python3` or the hook script is unavailable, and route both stdout-contract CLIs
  (Antigravity, Copilot) through it. This closes the missing-script case deferred from #679:
  the in-script guards there cannot cover a script that never starts.
- Retarget the Antigravity wiring test at the launcher and add the assertion the old one
  lacked — that the path resolves independently of CWD.
- Document the verified CWD, the failure-behaviour model, and the
  `HOOK_BLOCKCOMMAND_DEBUG=1` requirement in `docs/development/ai/command-blocking.md`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. Manual hook suite: 134/134.

New tests cover launcher passthrough (deny and allow unchanged), resolution independent of
the caller's CWD, denial when the `.py` is absent, and — as a regression guard — that the
fail-closed path emits **exactly one** JSON object. Plus wiring contract tests asserting
both stdout-contract CLIs route through the launcher and that Copilot keeps its `cwd` pin.

Live-verified after the wiring change: both `agy` and `copilot` fire through the launcher
(`fmt=agy` and `fmt=copilot` recorded in the hook debug log).

### Why not the obvious `|| echo '{"decision":"deny"}'`

Because it double-emits. With #679 merged, "hook script missing" and "hook fail-closed"
both exit 2, so the fallback appends a second JSON object after the hook's own:

```
$ printf 'not json' | sh -c 'python3 .../block-dangerous-commands.py || echo "{...deny...}"'
{"decision": "deny", "reason": "Blocked: hook could not parse its input ...", ...}
{"decision":"deny","reason":"hook unavailable"}
```

Both objects deny, so it is fail-safe, but malformed stdout is a real parser risk. The
launcher branches on preconditions (`command -v python3`, `[ -r "$HOOK" ]`) instead, which
distinguishes the two cases cleanly.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**Known gap, documented rather than hidden.** A syntax error in the hook script, or a hook
timeout, still yields no payload and trips no launcher precondition. Covering that would
require the hook to emit output on *every* invocation including allows — a protocol change
both stdout-contract CLIs would need to tolerate. Recorded under "Failure Behaviour" in
`docs/development/ai/command-blocking.md`.

**Not exercised live:** Gemini and Codex. Both share Claude's exit-2 contract and neither
wiring changed in this PR.

**Launcher tests skip on Windows** (`sh` is POSIX); the wirings that use it are POSIX-only,
matching the existing `python3` assumption across all five configs.

With #679, this completes the fail-closed story: #679 covers errors *inside* a running
hook, #680 covers a hook that cannot start.
