### PR TITLE
chore: point the coverage gate at tools/ and make it config-driven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Run tests with coverage
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
-        run: uv run pytest -n auto --cov=package_name --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
+        run: uv run pytest -n auto --cov --cov-report=xml:tmp/coverage.xml --cov-report=term -v --ignore=tests/benchmarks/
 
       - name: Run tests
         if: "!(matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest')"

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -257,11 +257,22 @@ a smaller set than this repository does:
 
 | Shape | Statements | Coverage | Gate at 54 |
 | :--- | ---: | ---: | :--- |
-| Template (this repo) | 5,102 | 54.71% | passes |
+| Template (this repo) | 5,102 | 55.05% | passes |
 | Downstream, after `cleanup` | 2,748 | 56.92% | passes |
 
 <!-- The downstream row is measured by excluding `tools/pyproject_template/` from the report,
      which yields the same denominator `cleanup` produces by deleting it. -->
+
+#### Keep coverage hermetic
+
+These figures are reproducible on any machine. They were not always: tests reached
+`setup_repo._check_token_permissions()` through the *real* `gh auth status`, so the branch that
+runs depended on the developer's GitHub auth state — a machine holding a fine-grained PAT
+measured 34 more covered statements than CI did, a 0.54pp swing.
+
+When a test reaches an interactive or shell-dependent function only incidentally, the gate stops
+being reproducible and a tight threshold becomes unreliable. Mock the subprocess or the input and
+cover the branches deliberately.
 
 Shedding `tools/pyproject_template/` *raises* the measured percentage, so a consumer inherits a
 gate that already passes — one threshold holds in both shapes and `cleanup` needs no

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -231,10 +231,42 @@ docs:
 
 ### Coverage Requirements
 
-- **Recommended threshold**: ≥70%
-- **Configuration**: Set in `pyproject.toml` and pytest command
+- **Enforced threshold**: `fail_under = 54` in `pyproject.toml`
+- **Measured scope**: `package_name` **and** `tools/`
 - **Artifacts**: Upload HTML coverage reports for review
 - **Integration**: Use Codecov or similar service for tracking
+
+#### What the gate measures, and why
+
+The gate covers `tools/` as well as the package. `src/package_name/` is the skeleton every
+downstream project deletes and replaces; `tools/` is the code that runs releases, creates PRs and
+blocks dangerous commands. Gating only the package produced a healthy-looking number over ~66
+statements while several thousand statements of tooling went unmeasured.
+
+The threshold is deliberately set to what the codebase actually achieves rather than to an
+aspirational number pointed at the wrong target. **Ratchet it upward** as tooling coverage
+improves; treat lowering it as a change that needs justification in the PR.
+
+The manual harness `tools/hooks/ai/test_hook.py` is omitted — it is run directly rather than
+collected by pytest.
+
+#### Template vs downstream
+
+`cleanup --setup` / `--all` deletes `tools/pyproject_template/`, so a downstream project measures
+a smaller set than this repository does:
+
+| Shape | Statements | Coverage | Gate at 54 |
+| :--- | ---: | ---: | :--- |
+| Template (this repo) | 5,102 | 54.71% | passes |
+| Downstream, after `cleanup` | 2,748 | 56.92% | passes |
+
+<!-- The downstream row is measured by excluding `tools/pyproject_template/` from the report,
+     which yields the same denominator `cleanup` produces by deleting it. -->
+
+Shedding `tools/pyproject_template/` *raises* the measured percentage, so a consumer inherits a
+gate that already passes — one threshold holds in both shapes and `cleanup` needs no
+coverage-specific rewrite. A downstream project that wants a stricter gate over its own code can
+narrow `source` back to its package and raise `fail_under`.
 
 **Example pytest configuration in `pyproject.toml`:**
 ```toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,13 +179,25 @@ warmup = true
 
 [tool.coverage.run]
 branch = true
-source = ["package_name"]
+# `tools/` is the code that runs releases, creates PRs and blocks dangerous
+# commands; gating only the package would measure the skeleton every downstream
+# project deletes. See docs/development/ci-cd-testing.md for the downstream/template
+# split.
+source = ["package_name", "tools"]
+omit = [
+    # Standalone manual harness, run directly rather than collected by pytest.
+    "tools/hooks/ai/test_hook.py",
+]
 
 [tool.coverage.report]
 skip_covered = false
 show_missing = true
 precision = 2
-fail_under = 80
+# Measured over package_name + tools/. Currently 54.71% here, and 56.92% in a
+# downstream project once `cleanup` sheds tools/pyproject_template/, so the same
+# gate holds in both shapes. Ratchet upward as tooling coverage improves; treat
+# lowering it as a change that needs justification.
+fail_under = 54
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ omit = [
 skip_covered = false
 show_missing = true
 precision = 2
-# Measured over package_name + tools/. Currently 54.71% here, and 56.92% in a
+# Measured over package_name + tools/. Currently 55.05% here, and 56.92% in a
 # downstream project once `cleanup` sheds tools/pyproject_template/, so the same
 # gate holds in both shapes. Ratchet upward as tooling coverage improves; treat
 # lowering it as a change that needs justification.

--- a/tests/template/test_coverage_gate.py
+++ b/tests/template/test_coverage_gate.py
@@ -1,0 +1,82 @@
+"""Contract tests for the enforced coverage gate.
+
+The gate previously measured only ``src/package_name/`` — a 66-statement
+skeleton that every downstream project deletes — while several thousand
+statements of `tools/` went unmeasured. These tests pin the scope so that
+narrowing it back is a deliberate, visible change rather than a silent one.
+
+See ``docs/development/ci-cd-testing.md`` for the template/downstream split.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DOIT_TESTING = REPO_ROOT / "tools" / "doit" / "testing.py"
+
+
+def _coverage_config() -> dict[str, Any]:
+    """Return the ``[tool.coverage]`` table from pyproject.toml."""
+    with PYPROJECT.open("rb") as fh:
+        data: dict[str, Any] = tomllib.load(fh)
+    config: dict[str, Any] = data["tool"]["coverage"]
+    return config
+
+
+def test_gate_measures_both_the_package_and_tools() -> None:
+    """`tools/` is in scope, not just the replaceable package skeleton."""
+    source = _coverage_config()["run"]["source"]
+    assert "package_name" in source
+    assert "tools" in source, (
+        "tools/ runs releases, PRs and the dangerous-command hook; it must be measured"
+    )
+
+
+def test_threshold_is_enforced_and_not_aspirational() -> None:
+    """`fail_under` must be a real gate, not a number aimed at the wrong target.
+
+    A high threshold over a tiny scope is trivially met and measures nothing.
+    This asserts the gate is set at all and is not pointed above what the
+    combined scope achieves; the paired scope assertion above keeps it honest.
+    """
+    report = _coverage_config()["report"]
+    assert "fail_under" in report, "the coverage gate must be enforced"
+    assert 0 < report["fail_under"] <= 100
+
+
+def test_coverage_invocations_are_config_driven() -> None:
+    """Neither `doit coverage` nor CI may hardcode the scope on the command line.
+
+    A `--cov=<name>` flag overrides `[tool.coverage.run] source`, so a stale
+    flag silently narrows the gate while pyproject.toml still looks correct.
+    Hardcoding the template's own package name is worse still: placeholder
+    replacement does not rewrite every file, so a renamed project ends up
+    measuring a module that no longer exists (#684). A bare `--cov` enables
+    coverage and defers to the configured source.
+    """
+    for path in (DOIT_TESTING, CI_WORKFLOW):
+        text = path.read_text(encoding="utf-8")
+        # `--cov-report=` / `--cov-fail-under=` use a hyphen, so this only
+        # matches scope flags.
+        scopes = re.findall(r"--cov=([\w./-]+)", text)
+        assert not scopes, (
+            f"{path.name} hardcodes coverage scope {scopes}; use a bare --cov "
+            f"so [tool.coverage.run] source drives it"
+        )
+        assert "--cov" in text, f"{path.name} must still enable coverage"
+
+
+def test_manual_harness_is_omitted() -> None:
+    """The standalone harness is run directly, not collected, so it is excluded.
+
+    Pinning it here keeps the denominator — and therefore the threshold —
+    stable rather than dependent on pytest-cov's default file filtering.
+    """
+    omit = _coverage_config()["run"].get("omit", [])
+    assert any("test_hook.py" in entry for entry in omit)

--- a/tests/template/test_setup_repo.py
+++ b/tests/template/test_setup_repo.py
@@ -635,3 +635,83 @@ class TestConfigurePlaceholdersTemplateTestsRemoval:
 
         assert (tmp_path / "tests").exists()
         assert not (tmp_path / "tests" / "template").exists()
+
+
+class TestCheckTokenPermissions:
+    """Hermetic tests for ``_check_token_permissions``.
+
+    These exist because the branch was previously reached only incidentally,
+    through a test that shells out to the *real* ``gh auth status``. That made
+    coverage depend on the developer's GitHub auth state: on a machine holding
+    a PAT the warning branch ran, on CI it did not, and the reported percentage
+    differed by 34 statements between the two. Mocking the subprocess pins the
+    behaviour so both branches are exercised everywhere.
+    """
+
+    def test_warns_when_token_is_a_fine_grained_pat(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A ``github_pat_`` token prints the required-permissions guidance."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+            patch("tools.pyproject_template.setup_repo.prompt_confirm", return_value=True),
+        ):
+            mock_run.return_value = MagicMock(stderr="Token: github_pat_xxx", stdout="")
+            setup._check_token_permissions()
+
+        out = capsys.readouterr().out
+        assert "Personal Access Token" in out
+        assert "Administration: Read and write" in out
+
+    def test_warns_when_token_is_an_oauth_token(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A ``gho_`` token takes the same branch — the check ORs both markers."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+            patch("tools.pyproject_template.setup_repo.prompt_confirm", return_value=True),
+        ):
+            mock_run.return_value = MagicMock(stderr="", stdout="Token: gho_xxx")
+            setup._check_token_permissions()
+
+        assert "Personal Access Token" in capsys.readouterr().out
+
+    def test_exits_when_permissions_are_not_confirmed(self) -> None:
+        """Declining the confirmation aborts setup rather than continuing."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+            patch("tools.pyproject_template.setup_repo.prompt_confirm", return_value=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            mock_run.return_value = MagicMock(stderr="github_pat_xxx", stdout="")
+            setup._check_token_permissions()
+
+        assert exc_info.value.code == 1
+
+    def test_accepts_an_unrecognised_token_without_prompting(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Output carrying neither marker is reported as OAuth and never prompts."""
+        from tools.pyproject_template.setup_repo import RepositorySetup
+
+        setup = RepositorySetup()
+
+        with (
+            patch("tools.pyproject_template.setup_repo.subprocess.run") as mock_run,
+            patch("tools.pyproject_template.setup_repo.prompt_confirm") as mock_confirm,
+        ):
+            mock_run.return_value = MagicMock(stderr="Logged in to github.com", stdout="")
+            setup._check_token_permissions()
+
+        mock_confirm.assert_not_called()
+        assert "OAuth" in capsys.readouterr().out

--- a/tests/template/test_utils.py
+++ b/tests/template/test_utils.py
@@ -713,3 +713,73 @@ class TestFilesToUpdate:
     def test_no_duplicates(self) -> None:
         """Test that there are no duplicate entries."""
         assert len(FILES_TO_UPDATE) == len(set(FILES_TO_UPDATE))
+
+
+class TestPromptConfirm:
+    """Tests for ``prompt_confirm``.
+
+    The ``default=True`` branch was previously covered only as a side effect of
+    a test that reached it through a real ``gh auth status`` call, so its
+    coverage varied by machine. These pin both branches directly.
+    """
+
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [("", True), ("y", True), ("yes", True), ("n", False), ("no", False)],
+    )
+    def test_default_true_branch(self, response: str, expected: bool) -> None:
+        """With ``default=True`` an empty answer confirms."""
+        from tools.pyproject_template.utils import prompt_confirm
+
+        with patch("builtins.input", return_value=response):
+            assert prompt_confirm("Proceed?", default=True) is expected
+
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [("", False), ("n", False), ("y", True), ("yes", True)],
+    )
+    def test_default_false_branch(self, response: str, expected: bool) -> None:
+        """With the default of ``False`` an empty answer declines."""
+        from tools.pyproject_template.utils import prompt_confirm
+
+        with patch("builtins.input", return_value=response):
+            assert prompt_confirm("Proceed?") is expected
+
+    def test_answer_is_case_and_whitespace_insensitive(self) -> None:
+        """Answers are normalised before comparison."""
+        from tools.pyproject_template.utils import prompt_confirm
+
+        with patch("builtins.input", return_value="  YES  "):
+            assert prompt_confirm("Proceed?") is True
+
+
+class TestPrompt:
+    """Tests for ``prompt``.
+
+    Like ``prompt_confirm``, this was reached only incidentally by tests that
+    drive interactive flows, so which of its branches ran varied by
+    environment. Pinning both branches keeps the measured coverage stable.
+    """
+
+    def test_returns_default_when_answer_is_blank(self) -> None:
+        """With a default, an empty answer yields the default."""
+        from tools.pyproject_template.utils import prompt
+
+        with patch("builtins.input", return_value="   "):
+            assert prompt("Name?", default="fallback") == "fallback"
+
+    def test_returns_the_answer_over_the_default(self) -> None:
+        """A non-empty answer wins over the default."""
+        from tools.pyproject_template.utils import prompt
+
+        with patch("builtins.input", return_value="  typed  "):
+            assert prompt("Name?", default="fallback") == "typed"
+
+    def test_reprompts_until_a_required_value_is_given(self) -> None:
+        """With no default the prompt loops until the answer is non-empty."""
+        from tools.pyproject_template.utils import prompt
+
+        with patch("builtins.input", side_effect=["", "   ", "finally"]) as mock_input:
+            assert prompt("Name?") == "finally"
+
+        assert mock_input.call_count == 3

--- a/tests/template/test_utils.py
+++ b/tests/template/test_utils.py
@@ -703,6 +703,9 @@ class TestFilesToUpdate:
         config_files = [
             ".envrc",
             ".pre-commit-config.yaml",
+            # Carries a `package_name` example string; without rewriting it the
+            # help text names a module the project no longer has (#684).
+            ".vscode/launch.json",
         ]
         for f in config_files:
             assert f in FILES_TO_UPDATE, f"Missing config file: {f}"

--- a/tools/doit/testing.py
+++ b/tools/doit/testing.py
@@ -19,7 +19,7 @@ def task_coverage() -> dict[str, Any]:
     return {
         "actions": [
             "uv run pytest "
-            "--cov=package_name --cov-report=term-missing "
+            "--cov --cov-report=term-missing "
             "--cov-report=html:tmp/htmlcov --cov-report=xml:tmp/coverage.xml -v"
         ],
         "title": title_with_actions,

--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -61,6 +61,7 @@ FILES_TO_UPDATE: tuple[str, ...] = (
     ".claude/lsp-setup.md",
     ".envrc",
     ".pre-commit-config.yaml",
+    ".vscode/launch.json",
 )
 
 


### PR DESCRIPTION
## Description

The enforced coverage gate measured the part of the repo that gets deleted, and ignored the
part that does the work.

| Scope | Statements | Coverage | Gated before? |
| :--- | ---: | ---: | :--- |
| `src/package_name/` | 66 | 97.30% | yes, at `fail_under = 80` |
| `tools/` | ~4,600 | ~55% | no |

`src/package_name/` is a `greet()` function, a Click wrapper and a logging helper — the
skeleton every downstream project replaces. `tools/` runs releases, creates PRs and blocks
dangerous commands.

This points the gate at both, sets the threshold to what the codebase actually achieves, and
makes that number reproducible.

## Related Issue

Addresses #689
Addresses #684

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- `[tool.coverage.run] source = ["package_name", "tools"]`; `fail_under` 80 → **54**.
- Omit `tools/hooks/ai/test_hook.py` — a standalone harness run directly rather than collected.
- **`doit coverage` and CI now pass a bare `--cov`**, letting config drive the scope instead of
  hardcoded flags. This is also the fix for #684.
- Add `.vscode/launch.json` to `FILES_TO_UPDATE` — the remaining instance of the #684 gap.
- **Hermetic tests** for `_check_token_permissions`, `prompt` and `prompt_confirm`, so the
  measured number no longer depends on the developer's GitHub auth state (see below).
- Document the gate, the template/downstream split, and the hermeticity requirement in
  `docs/development/ci-cd-testing.md`.
- Add `tests/template/test_coverage_gate.py` (4 contract tests).

### Why this also closes #684

#684 reports that `tools/doit/testing.py` hardcodes `--cov=package_name` while not being in
`FILES_TO_UPDATE`, so a renamed project measures a module that no longer exists. A `--cov=`
flag overrides `[tool.coverage.run] source`, so the two silently disagree.

Adding `--cov=tools` alongside it — the obvious way to satisfy #689 — would have added a
*second* hardcoded value to a line already filed as broken, and the new contract test would
have cemented it. A bare `--cov` satisfies both issues with one change.

### The number was not reproducible, and that had to be fixed first

The first push was green, but CI reported **54.17%** where this machine reported **54.71%** —
0.17pp of margin against the gate, not the 0.71pp the threshold was chosen for.

Cause: `tests/template/test_bootstrap.py` reaches `setup_repo._check_token_permissions()`
without mocking `subprocess.run`, so the suite shells out to the **real** `gh auth status`.
That function branches on whether the output contains `github_pat_` or `gho_`. A machine
holding a fine-grained PAT covered the warning branch (`setup_repo.py:162-179`) and with it
`prompt_confirm(default=True)` (`utils.py:123-125`); CI covered neither. Exactly the
34-statement delta, in exactly those two files, with nothing else differing.

A gate is only as trustworthy as the reproducibility of the number it enforces, so those
branches are now covered deliberately rather than incidentally. Verified with a shim that
answers `gh auth status` the way CI does:

| Run | Statements | Miss | Total |
| :--- | ---: | ---: | ---: |
| Real `gh` (holds a PAT) | 5,102 | 2,161 | **55.05%** |
| Shimmed `gh` (CI's state) | 5,102 | 2,161 | **55.05%** |

Byte-identical. Coverage rose to 55.05% because the new tests reach branches nothing covered
before, so `fail_under = 54` now carries the ~1pp margin it was chosen for.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. `doit coverage`: **55.05%**, "Required test coverage of 54.0% reached."
1,146 tests (+17).

The gate was verified to actually enforce, not merely to be configured:

```
coverage report --fail-under=60  -> exit 2   (would fail)
coverage report --fail-under=54  -> exit 0   (currently green)
```

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**This changes what is measured, not how much is covered** — beyond the 17 tests added to make
the number reproducible. `github.py` (50.94%) and `release.py` (40.26%) are untouched. The gate
makes that debt visible and prevents it worsening; it does not pay it down. Tracked in **#708**.

**The real `gh` call in the bootstrap tests remains.** It no longer affects coverage, but it is
still a real subprocess in the unit suite that asserts nothing about which branch ran. Tracked
in **#710**.

**The downstream figure is a faithful proxy, not a `cleanup` run.** 56.92% is measured by
excluding `tools/pyproject_template/` from the report, which yields the same denominator
`cleanup` produces by deleting it. `cleanup` was not run — it is destructive to this repo.

**On the threshold.** 54 is a ratchet, not a floor. Expect it to need raising; lowering it
should require justification in the PR that does so.
