### PR TITLE
chore: author the first per-stack rule file and load it

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -157,3 +157,21 @@ See [`.claude/rules/README.md`](../../.claude/rules/README.md),
   violated, the rule-shaped skill is not ready to be written yet.
 - **Workflow logic** — do not mix rule-shaped skills (self-check checklists) with workflow skills
   (multi-step instructions like `codex-plan`). Keep them in separate subdirectories.
+
+## Shipped rule: `typing-branch-narrowing`
+
+This template ships one rule file, mirrored across all four agent rule surfaces because every
+agent in the delegation matrix edits this codebase. The checklist body is identical everywhere;
+only the frontmatter and the loading mechanism differ.
+
+| Surface | Path |
+| :--- | :--- |
+| Claude | `.claude/rules/typing-branch-narrowing.md` |
+| Gemini | `.gemini/rules/typing-branch-narrowing.md` |
+| Copilot | `.github/instructions/typing-branch-narrowing.instructions.md` |
+| Codex / Antigravity | `.agents/skills/typing-branch-narrowing/SKILL.md` |
+
+**When you change one, change all four.** A rule that disagrees with itself across agents is worse
+than no rule, because whichever agent is driving decides which version applies.
+`tests/template/test_rule_files.py` enforces that the four bodies stay identical. See
+[`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/.agents/skills/typing-branch-narrowing/SKILL.md
+++ b/.agents/skills/typing-branch-narrowing/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: typing-branch-narrowing
+description: Use when adding, widening, or removing a Python type annotation to resolve a mypy [no-redef], [assignment], or [unreachable] error on a name bound in more than one if/elif/else branch.
+---
+
+Skill: typing
+
+Self-check before adding or changing a type annotation to silence a mypy error:
+
+1. Is the name bound in more than one branch? If not, this rule does not apply.
+2. Do all branches `return` before the branches converge? If yes, each branch owns
+   its own binding — do NOT hoist an annotation to function scope. Remove the
+   redundant one instead (`_parse_input`, #701).
+3. If the branches fall through to shared code, annotate once before the chain
+   using the WIDEST type any branch assigns — including `| None` (`cleanup.py`,
+   #700).
+4. After the change, re-run mypy and confirm no new `[unreachable]` appeared.
+5. If mypy now calls an `isinstance` / `is None` guard unreachable, the annotation
+   is too narrow. Fix the annotation. Do NOT delete the guard — both observed
+   failures had a guard that fires on real input.
+6. Confirm the file is actually type-checked. Both failures reached review because
+   `doit check` did not cover the file at the time (#700).
+
+Observed failures: endavis/pyproject-template#701, endavis/pyproject-template#700

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,5 @@
 @../AGENTS.md
-<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
-<!-- @./rules/*.md -->
+@./rules/*.md
 
 # BASIC CLAUDE INSTRUCTIONS
 

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -50,23 +50,44 @@ Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, spli
 
 ## How to load
 
-Uncomment the `@./rules/*.md` line in `.claude/CLAUDE.md`:
-
-```
-@../AGENTS.md
-<!-- Uncomment when you add rule files. See .claude/rules/README.md for the pattern. -->
-<!-- @./rules/*.md -->
-```
-
-becomes:
+`.claude/CLAUDE.md` glob-imports every rule file in this directory:
 
 ```
 @../AGENTS.md
 @./rules/*.md
 ```
 
-Note: the line stays commented out in this template repository. Downstream consumers uncomment it
-after authoring their first rule file.
+**This loader is enabled in the template.** It was previously commented out, on the reasoning that
+a template ships no rule files and downstream consumers would opt in after authoring their first.
+That reasoning expired when the template authored its own: `typing-branch-narrowing.md` documents
+a trap that produced defects in two consecutive PRs **in this repository's code**. A rule file that
+ships but never loads is a mechanism built and not used, so the loader is on and downstream
+projects inherit it.
+
+If you fork this template and delete the shipped rule file, remove the import too — Claude Code
+tolerates a glob matching nothing, but leaving it invites a future file to load unnoticed.
+
+## Mirroring across agent surfaces
+
+Every agent in the delegation matrix edits this codebase, so a rule that only Claude loads is a
+half-installed control. `typing-branch-narrowing` is mirrored to all four surfaces, each with its
+own format and loading mechanism:
+
+| Surface | Path | Loading |
+| :--- | :--- | :--- |
+| Claude | `.claude/rules/*.md` | glob import in `.claude/CLAUDE.md` |
+| Gemini | `.gemini/rules/*.md` | **explicit per-file** `@`-import in `GEMINI.md` — globs are not supported |
+| Copilot | `.github/instructions/*.instructions.md` | auto-discovered; requires `applyTo:` frontmatter |
+| Codex / Antigravity | `.agents/skills/<name>/SKILL.md` | `description:` frontmatter is the skill gate |
+
+The checklist body is identical in all four; only the frontmatter and loading differ. **When you
+change one, change all four** — a rule that disagrees with itself across agents is worse than no
+rule, because whichever agent is driving determines which version applies.
+`tests/template/test_rule_files.py` enforces that the four bodies stay byte-identical.
+
+Note that Copilot reads `.agents/skills/` in addition to `.github/instructions/`, so it sees the
+rule on two surfaces at once. That is harmless while the bodies match — which is exactly what the
+sync test guarantees — but it is another reason not to let them drift.
 
 ## Discipline: build from observed failures, not generic best-practices
 

--- a/.claude/rules/typing-branch-narrowing.md
+++ b/.claude/rules/typing-branch-narrowing.md
@@ -1,0 +1,19 @@
+Skill: typing
+
+Self-check before adding or changing a type annotation to silence a mypy error:
+
+1. Is the name bound in more than one branch? If not, this rule does not apply.
+2. Do all branches `return` before the branches converge? If yes, each branch owns
+   its own binding — do NOT hoist an annotation to function scope. Remove the
+   redundant one instead (`_parse_input`, #701).
+3. If the branches fall through to shared code, annotate once before the chain
+   using the WIDEST type any branch assigns — including `| None` (`cleanup.py`,
+   #700).
+4. After the change, re-run mypy and confirm no new `[unreachable]` appeared.
+5. If mypy now calls an `isinstance` / `is None` guard unreachable, the annotation
+   is too narrow. Fix the annotation. Do NOT delete the guard — both observed
+   failures had a guard that fires on real input.
+6. Confirm the file is actually type-checked. Both failures reached review because
+   `doit check` did not cover the file at the time (#700).
+
+Observed failures: endavis/pyproject-template#701, endavis/pyproject-template#700

--- a/.gemini/rules/README.md
+++ b/.gemini/rules/README.md
@@ -91,3 +91,21 @@ file is not ready to be written yet.
   behavior.
 - **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
   was violated, the rule file is not ready to be written.
+
+## Shipped rule: `typing-branch-narrowing`
+
+This template ships one rule file, mirrored across all four agent rule surfaces because every
+agent in the delegation matrix edits this codebase. The checklist body is identical everywhere;
+only the frontmatter and the loading mechanism differ.
+
+| Surface | Path |
+| :--- | :--- |
+| Claude | `.claude/rules/typing-branch-narrowing.md` |
+| Gemini | `.gemini/rules/typing-branch-narrowing.md` |
+| Copilot | `.github/instructions/typing-branch-narrowing.instructions.md` |
+| Codex / Antigravity | `.agents/skills/typing-branch-narrowing/SKILL.md` |
+
+**When you change one, change all four.** A rule that disagrees with itself across agents is worse
+than no rule, because whichever agent is driving decides which version applies.
+`tests/template/test_rule_files.py` enforces that the four bodies stay identical. See
+[`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/.gemini/rules/typing-branch-narrowing.md
+++ b/.gemini/rules/typing-branch-narrowing.md
@@ -1,0 +1,19 @@
+Skill: typing
+
+Self-check before adding or changing a type annotation to silence a mypy error:
+
+1. Is the name bound in more than one branch? If not, this rule does not apply.
+2. Do all branches `return` before the branches converge? If yes, each branch owns
+   its own binding — do NOT hoist an annotation to function scope. Remove the
+   redundant one instead (`_parse_input`, #701).
+3. If the branches fall through to shared code, annotate once before the chain
+   using the WIDEST type any branch assigns — including `| None` (`cleanup.py`,
+   #700).
+4. After the change, re-run mypy and confirm no new `[unreachable]` appeared.
+5. If mypy now calls an `isinstance` / `is None` guard unreachable, the annotation
+   is too narrow. Fix the annotation. Do NOT delete the guard — both observed
+   failures had a guard that fires on real input.
+6. Confirm the file is actually type-checked. Both failures reached review because
+   `doit check` did not cover the file at the time (#700).
+
+Observed failures: endavis/pyproject-template#701, endavis/pyproject-template#700

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -133,3 +133,21 @@ See [`.claude/rules/README.md`](../../.claude/rules/README.md) and
   behavior.
 - **Anything not tied to an observed failure** — if you cannot cite a PR or issue where the rule
   was violated, the instruction file is not ready to be written.
+
+## Shipped rule: `typing-branch-narrowing`
+
+This template ships one rule file, mirrored across all four agent rule surfaces because every
+agent in the delegation matrix edits this codebase. The checklist body is identical everywhere;
+only the frontmatter and the loading mechanism differ.
+
+| Surface | Path |
+| :--- | :--- |
+| Claude | `.claude/rules/typing-branch-narrowing.md` |
+| Gemini | `.gemini/rules/typing-branch-narrowing.md` |
+| Copilot | `.github/instructions/typing-branch-narrowing.instructions.md` |
+| Codex / Antigravity | `.agents/skills/typing-branch-narrowing/SKILL.md` |
+
+**When you change one, change all four.** A rule that disagrees with itself across agents is worse
+than no rule, because whichever agent is driving decides which version applies.
+`tests/template/test_rule_files.py` enforces that the four bodies stay identical. See
+[`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/.github/instructions/typing-branch-narrowing.instructions.md
+++ b/.github/instructions/typing-branch-narrowing.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: '**/*.py'
+---
+
+Skill: typing
+
+Self-check before adding or changing a type annotation to silence a mypy error:
+
+1. Is the name bound in more than one branch? If not, this rule does not apply.
+2. Do all branches `return` before the branches converge? If yes, each branch owns
+   its own binding — do NOT hoist an annotation to function scope. Remove the
+   redundant one instead (`_parse_input`, #701).
+3. If the branches fall through to shared code, annotate once before the chain
+   using the WIDEST type any branch assigns — including `| None` (`cleanup.py`,
+   #700).
+4. After the change, re-run mypy and confirm no new `[unreachable]` appeared.
+5. If mypy now calls an `isinstance` / `is None` guard unreachable, the annotation
+   is too narrow. Fix the annotation. Do NOT delete the guard — both observed
+   failures had a guard that fires on real input.
+6. Confirm the file is actually type-checked. Both failures reached review because
+   `doit check` did not cover the file at the time (#700).
+
+Observed failures: endavis/pyproject-template#701, endavis/pyproject-template#700

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,5 @@
 @./AGENTS.md
+@./.gemini/rules/typing-branch-narrowing.md
 
 # Gemini CLI Instructions
 

--- a/tests/template/test_rule_files.py
+++ b/tests/template/test_rule_files.py
@@ -1,0 +1,120 @@
+"""Contract tests for per-stack rule files.
+
+Rule files are mirrored across all four agent rule surfaces because every agent
+in the delegation matrix edits this codebase. The checklist body must stay
+identical everywhere: a rule that disagrees with itself across agents is worse
+than no rule, because whichever agent is driving decides which version applies.
+
+These tests also enforce the authoring discipline from
+``.claude/rules/README.md`` — the 30-line cap and the mandatory
+``Observed failures:`` footer, which is what separates a rule derived from real
+defects from a generic best-practices checklist.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RULE_NAME = "typing-branch-narrowing"
+
+# Every surface that must carry the rule, and how each one is loaded.
+RULE_PATHS = {
+    "claude": REPO_ROOT / ".claude" / "rules" / f"{RULE_NAME}.md",
+    "gemini": REPO_ROOT / ".gemini" / "rules" / f"{RULE_NAME}.md",
+    "copilot": REPO_ROOT / ".github" / "instructions" / f"{RULE_NAME}.instructions.md",
+    "agents": REPO_ROOT / ".agents" / "skills" / RULE_NAME / "SKILL.md",
+}
+
+MAX_LINES = 30
+
+
+def _body(path: Path) -> str:
+    """Return the rule body, stripped of any YAML frontmatter.
+
+    Copilot requires ``applyTo:`` frontmatter and Codex/Antigravity require
+    ``name:``/``description:``; only the checklist below it must match.
+    """
+    text = path.read_text(encoding="utf-8")
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            text = parts[2]
+    return text.strip()
+
+
+@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
+def test_rule_exists_on_every_surface(surface: str) -> None:
+    """The rule is present for all four agent families."""
+    assert RULE_PATHS[surface].exists(), f"missing {surface} copy: {RULE_PATHS[surface]}"
+
+
+def test_rule_bodies_are_identical_across_surfaces() -> None:
+    """The checklist must not drift between agents."""
+    bodies = {name: _body(path) for name, path in RULE_PATHS.items()}
+    reference = bodies["claude"]
+    mismatched = [name for name, body in bodies.items() if body != reference]
+    assert not mismatched, f"rule body differs on {mismatched}; update all four surfaces together"
+
+
+@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
+def test_rule_declares_observed_failures(surface: str) -> None:
+    """A rule with no observed-failure link is a guess, not a discipline."""
+    body = _body(RULE_PATHS[surface])
+    match = re.search(r"^Observed failures:\s*(.+)$", body, re.MULTILINE)
+    assert match, f"{surface} copy is missing the 'Observed failures:' footer"
+    assert re.search(r"#\d+", match.group(1)), (
+        f"{surface} footer must cite at least one real issue or PR"
+    )
+
+
+@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
+def test_rule_names_a_skill_gate(surface: str) -> None:
+    """``Skill:`` is the first body line — it names the capability gate."""
+    assert _body(RULE_PATHS[surface]).splitlines()[0].startswith("Skill: ")
+
+
+@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
+def test_rule_stays_within_the_line_budget(surface: str) -> None:
+    """Past 30 lines a rule stops surviving a long context window; split it."""
+    count = len(RULE_PATHS[surface].read_text(encoding="utf-8").splitlines())
+    assert count <= MAX_LINES, f"{surface} copy is {count} lines (max {MAX_LINES})"
+
+
+def test_copilot_copy_declares_a_path_scope() -> None:
+    """Copilot's loader requires ``applyTo:`` frontmatter to gate the file."""
+    text = RULE_PATHS["copilot"].read_text(encoding="utf-8")
+    assert text.startswith("---"), "Copilot instructions need YAML frontmatter"
+    assert re.search(r"^applyTo:\s*\S+", text, re.MULTILINE)
+
+
+def test_agents_copy_declares_a_skill_gate_description() -> None:
+    """``description:`` is the skill-gate trigger for Codex and Antigravity."""
+    text = RULE_PATHS["agents"].read_text(encoding="utf-8")
+    assert re.search(r"^name:\s*\S+", text, re.MULTILINE)
+    assert re.search(r"^description:\s*\S+", text, re.MULTILINE)
+
+
+def test_claude_loads_rule_files() -> None:
+    """The glob import must be live, not commented out.
+
+    A rule file that ships but never loads is a mechanism built and not used.
+    """
+    text = (REPO_ROOT / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+    assert re.search(r"^@\./rules/\*\.md\s*$", text, re.MULTILINE), (
+        "CLAUDE.md must import ./rules/*.md (uncommented)"
+    )
+
+
+def test_gemini_imports_each_rule_file_explicitly() -> None:
+    """Gemini CLI does not support glob imports — each file needs its own line.
+
+    A glob here makes Gemini log an ImportProcessor ENOENT error on every run.
+    """
+    text = (REPO_ROOT / "GEMINI.md").read_text(encoding="utf-8")
+    assert f"@./.gemini/rules/{RULE_NAME}.md" in text
+    assert "@./.gemini/rules/*.md" not in text, "Gemini cannot glob-import rule files"


### PR DESCRIPTION
## Description

The branch-narrowing typing trap produced a defect in two consecutive PRs, which meets the bar
`.claude/rules/README.md` sets for authoring a rule file. All four per-stack rule directories
were README-only until now, so this is the first exercise of a mechanism the template built and
never loaded.

**The pattern.** A name is bound in more than one branch, so mypy infers its type from the first
branch. A later branch assigns something wider, and a *real runtime guard* on the wider case is
then reported as a redefinition or as unreachable. Annotating the name silences the error while
making a genuine defensive check look like dead code.

## Related Issue

Addresses #704

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

- Author the rule and mirror it to **all four** agent surfaces (19 lines each, identical bodies):
  `.claude/rules/`, `.gemini/rules/`, `.github/instructions/*.instructions.md` (`applyTo:`
  frontmatter), `.agents/skills/typing-branch-narrowing/SKILL.md` (`name:`/`description:`).
- Wire each loader the way that CLI actually works — Claude glob-imports; **Gemini gets an
  explicit per-file import**, because its README documents that a glob makes Gemini CLI log
  `ImportProcessor ENOENT` on every run.
- Enable `@./rules/*.md` in `.claude/CLAUDE.md` and revise the README guidance that kept it
  commented out.
- Record both decisions (mirror scope, loader) in all four READMEs.
- Add `tests/template/test_rule_files.py` (21 tests).

### The drafted checklist was wrong half the time

#704's draft advised *"prefer annotating at the point of first binding with the WIDEST type."*
That is correct for `cleanup.py` — but it is the **opposite** of the right fix for `_parse_input`,
where the resolution was to *remove* an annotation entirely.

| Occurrence | Shape | Fix |
| :--- | :--- | :--- |
| `_parse_input` (#701) | every branch `return`s before converging | **remove** the annotation — each branch owns its binding |
| `cleanup.py` (#700) | branches fall through to shared code | **add** one before the chain, at the widest type (`\| None`) |

The discriminator is whether the branches return early or fall through, so the rule leads with
that rather than with a direction that only applies to one of the two documented failures. A
checklist that gives the wrong answer half the time is precisely the drift
`.claude/rules/README.md` warns about.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green.

The tests pin the four copies byte-identical, the mandatory `Observed failures:` footer citing a
real issue, the `Skill:` gate, the 30-line budget, per-surface frontmatter, and both loader
wirings — including that Gemini's import is *not* a glob.

Verified to bite, not merely to pass: injecting a line into the Gemini copy fails with
`rule body differs on ['gemini']; update all four surfaces together`.

### Each agent was asked whether it actually loads the rule

| Surface | Result |
| :--- | :--- |
| Claude | Fresh session: *"item 5: the annotation is too narrow, fix the annotation and do not delete the guard"* |
| Antigravity | `description:` gate fired; recited the checklist accurately |
| Copilot | Named `typing-branch-narrowing.instructions.md` and its subject |
| Gemini | **Not verified — see below** |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**Gemini CLI could not be verified, because it cannot authenticate on this machine at all:**

```
Error authenticating: IneligibleTierError: This client is no longer supported for
Gemini Code Assist for individuals. To continue using Gemini, please migrate to the
Antigravity suite of products.
```

This is unrelated to this change — no Gemini invocation succeeds here regardless — but it means
the whole `/gemini:*` delegation surface is currently non-functional on the free tier. The import
syntax follows `.gemini/rules/README.md` exactly and is covered by a test, but it has not been
observed loading. Flagged rather than glossed; worth its own issue if the delegation matrix is
expected to work.

**Copilot sees the rule on two surfaces.** It reads `.agents/skills/` in addition to
`.github/instructions/`, so it discovers both copies. Harmless while the bodies match — which is
what the sync test guarantees — and documented in `.claude/rules/README.md`.

**On enabling the loader.** `.claude/rules/README.md` previously said the import "stays commented
out in this template repository." That reasoning assumed the template ships no rule files; it now
ships one, documenting a trap in its own code. A rule file that ships but never loads is a
mechanism built and not used, so the loader is on and downstream projects inherit it. The README
now explains this rather than silently contradicting its former self.
