### PR TITLE
chore: fix broken documentation links and make the docs build strict

### DIFF
--- a/docs/decisions/9001-use-uv-for-package-management.md
+++ b/docs/decisions/9001-use-uv-for-package-management.md
@@ -19,5 +19,5 @@ uv is a modern Python package manager written in Rust by Astral (creators of ruf
 
 ## Related Documentation
 
-- [Installation Guide](../../getting-started/installation.md)
-- [Tools Reference](../tools-reference.md)
+- [Installation Guide](../getting-started/installation.md)
+- [Tools Reference](../template/tools-reference.md)

--- a/docs/decisions/9002-use-doit-for-task-automation.md
+++ b/docs/decisions/9002-use-doit-for-task-automation.md
@@ -28,7 +28,7 @@ and discoverable. It is not part of the published package's public API.
   convenience; #348 moved it to dev to align with the boundary above.)
 
 For the broader layering rationale, see
-[Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md).
+[Tooling Roles and Architectural Boundaries](../development/tooling-roles.md).
 
 ## Related Issues
 
@@ -46,5 +46,5 @@ For the broader layering rationale, see
 
 ## Related Documentation
 
-- [Tools Reference](../tools-reference.md)
-- [CLI Guide](../../usage/cli.md)
+- [Tools Reference](../template/tools-reference.md)
+- [CLI Guide](../usage/cli.md)

--- a/docs/decisions/9003-use-ruff-for-linting-and-formatting.md
+++ b/docs/decisions/9003-use-ruff-for-linting-and-formatting.md
@@ -18,4 +18,4 @@ ruff is an extremely fast Python linter and formatter written in Rust that conso
 
 ## Related Documentation
 
-- [Coding Standards](../../development/coding-standards.md)
+- [Coding Standards](../development/coding-standards.md)

--- a/docs/decisions/9004-auto-discover-doit-tasks.md
+++ b/docs/decisions/9004-auto-discover-doit-tasks.md
@@ -18,4 +18,4 @@ Manual imports were error-prone - developers would forget to add imports for new
 
 ## Related Documentation
 
-- [Tools Reference](../tools-reference.md)
+- [Tools Reference](../template/tools-reference.md)

--- a/docs/decisions/9005-ai-agent-command-restrictions.md
+++ b/docs/decisions/9005-ai-agent-command-restrictions.md
@@ -25,6 +25,6 @@ Documentation alone is insufficient - AI agents may violate rules after context 
 
 ## Related Documentation
 
-- [AI Command Blocking](../../development/ai/command-blocking.md)
-- [AI Enforcement Principles](../../development/ai/enforcement-principles.md)
-- [AI Setup Guide](../../development/AI_SETUP.md)
+- [AI Command Blocking](../development/ai/command-blocking.md)
+- [AI Enforcement Principles](../development/ai/enforcement-principles.md)
+- [AI Setup Guide](../development/AI_SETUP.md)

--- a/docs/decisions/9006-merge-gate-workflow.md
+++ b/docs/decisions/9006-merge-gate-workflow.md
@@ -24,4 +24,4 @@ PRs could be merged while CI was still running or without explicit human approva
 
 ## Related Documentation
 
-- [CI/CD Testing Guide](../../development/ci-cd-testing.md)
+- [CI/CD Testing Guide](../development/ci-cd-testing.md)

--- a/docs/decisions/9007-use-mypy-for-type-checking.md
+++ b/docs/decisions/9007-use-mypy-for-type-checking.md
@@ -18,4 +18,4 @@ mypy is the most mature Python type checker with excellent IDE integration. Stri
 
 ## Related Documentation
 
-- [Coding Standards](../../development/coding-standards.md)
+- [Coding Standards](../development/coding-standards.md)

--- a/docs/decisions/9008-pr-based-development-workflow.md
+++ b/docs/decisions/9008-pr-based-development-workflow.md
@@ -20,5 +20,5 @@ Provides clear audit trail linking issues to PRs to commits, enables code review
 
 ## Related Documentation
 
-- [CI/CD Testing Guide](../../development/ci-cd-testing.md)
-- [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md)
+- [CI/CD Testing Guide](../development/ci-cd-testing.md)
+- [CONTRIBUTING.md](../../.github/CONTRIBUTING.md)

--- a/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
+++ b/docs/decisions/9009-use-pre-commit-hooks-for-quality-gates.md
@@ -22,5 +22,5 @@ Ensures bad code never enters the repository, provides fast feedback loop (secon
 
 ## Related Documentation
 
-- [Coding Standards](../../development/coding-standards.md)
-- [Installation Guide](../../getting-started/installation.md)
+- [Coding Standards](../development/coding-standards.md)
+- [Installation Guide](../getting-started/installation.md)

--- a/docs/decisions/9010-use-conventional-commits-format.md
+++ b/docs/decisions/9010-use-conventional-commits-format.md
@@ -20,4 +20,4 @@ Provides consistent, readable git history, enables automated changelog generatio
 
 ## Related Documentation
 
-- [CONTRIBUTING.md](../../../.github/CONTRIBUTING.md)
+- [CONTRIBUTING.md](../../.github/CONTRIBUTING.md)

--- a/docs/decisions/9011-use-pytest-for-testing.md
+++ b/docs/decisions/9011-use-pytest-for-testing.md
@@ -19,5 +19,5 @@ pytest minimizes boilerplate (plain functions, no classes required), has a power
 
 ## Related Documentation
 
-- [CI/CD Testing Guide](../../development/ci-cd-testing.md)
-- [Coding Standards](../../development/coding-standards.md)
+- [CI/CD Testing Guide](../development/ci-cd-testing.md)
+- [Coding Standards](../development/coding-standards.md)

--- a/docs/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md
+++ b/docs/decisions/9012-use-mkdocs-with-material-theme-for-documentation.md
@@ -20,5 +20,5 @@ MkDocs uses Markdown (familiar to most developers), Material theme provides mode
 
 ## Related Documentation
 
-- [Documentation Index](../../index.md)
-- [Extensions Guide](../../development/extensions.md)
+- [Documentation Index](../index.md)
+- [Extensions Guide](../development/extensions.md)

--- a/docs/decisions/9013-python-version-support-policy.md
+++ b/docs/decisions/9013-python-version-support-policy.md
@@ -42,4 +42,4 @@ Testing every Python version on every PR creates excessive CI load without propo
 
 ## Related Documentation
 
-- [CI/CD Testing Guide - Python Version Support Policy](../../development/ci-cd-testing.md#python-version-support-policy)
+- [CI/CD Testing Guide - Python Version Support Policy](../development/ci-cd-testing.md#python-version-support-policy)

--- a/docs/decisions/9014-use-click-for-application-cli.md
+++ b/docs/decisions/9014-use-click-for-application-cli.md
@@ -25,11 +25,11 @@ The template previously shipped with an empty `[project.scripts]` block
 and no CLI module. Contributors adding a CLI had no obvious convention to
 follow, and `docs/development/tooling-roles.md` forward-referenced a
 guide that did not yet exist. This ADR documents the chosen framework and
-grounds the new [CLI Guide](../../usage/cli.md) in real code.
+grounds the new [CLI Guide](../usage/cli.md) in real code.
 
 The runtime/dev split documented in
 [ADR-9002](9002-use-doit-for-task-automation.md)
-and [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md)
+and [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md)
 requires the application CLI to live under `src/__PACKAGE_NAME__/` and to be
 runnable without any dev tooling (no `doit`, no `uv`). A standardized
 runtime CLI framework is needed to make that boundary concrete.
@@ -87,6 +87,6 @@ runtime CLI framework is needed to make that boundary concrete.
 
 ## Related Documentation
 
-- [CLI Guide](../../usage/cli.md)
-- [Tooling Roles and Architectural Boundaries](../../development/tooling-roles.md)
+- [CLI Guide](../usage/cli.md)
+- [Tooling Roles and Architectural Boundaries](../development/tooling-roles.md)
 - [ADR-9002: Use doit for task automation](9002-use-doit-for-task-automation.md)

--- a/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -47,4 +47,4 @@ The three capabilities are intentionally orthogonal so simple cases stay simple 
 
 ## Related Documentation
 
-- [install_tools Framework](../../development/install-tools-framework.md)
+- [install_tools Framework](../development/install-tools-framework.md)

--- a/docs/development/ai/first-5-minutes.md
+++ b/docs/development/ai/first-5-minutes.md
@@ -21,7 +21,7 @@ This page is a narrative walkthrough of the AI agent workflow this template ship
 - Claude Code installed and authenticated. See [AI Agent Setup](../AI_SETUP.md) for installation and per-agent configuration.
 - The [GitHub CLI](https://cli.github.com/) (`gh`) installed and logged in. The slash commands shell out to `gh` for issue and PR operations.
 - Optionally, a second agent CLI (Copilot, Codex or Antigravity) if you want to run the multi-agent review commands. The single-agent flow described below does not require it.
-- Alternatively, the [GitHub Copilot CLI](https://github.com/github/copilot-cli) can be used in place of Claude Code for the single-agent flow — it auto-discovers the same slash commands from `.claude/commands/`. See [AI Agent Setup § 4. GitHub Copilot CLI](../AI_SETUP.md#4-github-copilot-cli) for the wiring.
+- Alternatively, the [GitHub Copilot CLI](https://github.com/github/copilot-cli) can be used in place of Claude Code for the single-agent flow — it auto-discovers the same slash commands from `.claude/commands/`. See [AI Agent Setup § 3. GitHub Copilot CLI](../AI_SETUP.md#3-github-copilot-cli) for the wiring.
 
 The rest of this page assumes you have these working.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,27 @@ markdown_extensions:
   - toc:
       permalink: true
 
+# `docs/` deliberately links to real repository files that live outside
+# `docs_dir` — AGENTS.md, README.md, .github/CONTRIBUTING.md, hook scripts
+# under tools/, and their tests. Those links are kept relative so they resolve
+# when the repository is browsed on GitHub, which is how a template is mostly
+# read, and so downstream forks resolve to their own files rather than to this
+# upstream repo.
+#
+# mkdocs 1.6 reports those identically to genuinely broken links
+# (`links.not_found`), so silencing one silences the other. `not_found` is
+# therefore ignored here and link validation lives in
+# `tests/test_docs_links.py`, which resolves every relative link against the
+# whole repository — including the out-of-docs links mkdocs can never check.
+# Anchors are still validated here, where mkdocs has the rendered headings.
+#
+# Trade-off: the out-of-docs links do not resolve on the published site.
+validation:
+  links:
+    not_found: ignore
+    unrecognized_links: ignore
+    anchors: warn
+
 nav:
   - Home: index.md
   - Getting Started:

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -1,0 +1,99 @@
+"""Validate every relative link in `docs/` against the real repository tree.
+
+`mkdocs build --strict` only resolves links that land inside `docs_dir`. This
+repository deliberately links out of `docs/` to canonical files that live
+elsewhere — `AGENTS.md`, `README.md`, `.github/CONTRIBUTING.md`, the hook
+scripts under `tools/`, and their tests — kept relative so they resolve when
+the repository is browsed on GitHub and so downstream forks resolve to their
+own files rather than to this upstream repo.
+
+mkdocs 1.6 reports both classes identically (`links.not_found`), so silencing
+the out-of-docs links there would also silence genuinely broken ones. The
+validation therefore lives here, where a link can be checked against the whole
+repository rather than only against `docs_dir`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+
+# Markdown inline links: [text](target). Reference-style and bare autolinks are
+# not used for repo paths in this docs tree.
+_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+# Targets that are not repository paths.
+_EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#")
+
+# Placeholder paths inside templates and examples, which intentionally do not
+# resolve — they are filled in by whoever copies the template.
+_PLACEHOLDER_PARTS = ("path/to/", "<", "{{", "$")
+
+
+def _iter_markdown() -> list[Path]:
+    return sorted(DOCS_DIR.rglob("*.md"))
+
+
+def _link_targets(path: Path) -> list[str]:
+    """Return the repo-path link targets in *path*, ignoring code fences."""
+    text = path.read_text(encoding="utf-8")
+    # Drop fenced code blocks so example snippets aren't treated as links.
+    text = re.sub(r"```.*?```", "", text, flags=re.S)
+    targets = []
+    for raw in _LINK_RE.findall(text):
+        target = raw.strip().split(" ")[0]
+        if not target or target.startswith(_EXTERNAL_PREFIXES):
+            continue
+        if any(part in target for part in _PLACEHOLDER_PARTS):
+            continue
+        targets.append(target)
+    return targets
+
+
+def _resolve(source: Path, target: str) -> Path:
+    """Resolve *target* relative to the directory containing *source*."""
+    return (source.parent / target.split("#")[0]).resolve()
+
+
+@pytest.mark.parametrize("doc", _iter_markdown(), ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_relative_links_resolve(doc: Path) -> None:
+    """Every relative link in a docs page points at a file that exists.
+
+    Covers links that leave `docs/` as well as those inside it — the whole
+    point of validating here rather than in mkdocs.
+    """
+    broken = []
+    for target in _link_targets(doc):
+        resolved = _resolve(doc, target)
+        if not resolved.exists():
+            broken.append(f"{target} -> {resolved}")
+    assert not broken, f"{doc.relative_to(REPO_ROOT)} has broken links:\n  " + "\n  ".join(broken)
+
+
+def test_links_stay_inside_the_repository() -> None:
+    """No docs link escapes the repository root.
+
+    A link resolving above the repo root would work on one checkout layout and
+    break on another.
+    """
+    escapes = []
+    for doc in _iter_markdown():
+        for target in _link_targets(doc):
+            resolved = _resolve(doc, target)
+            if REPO_ROOT not in resolved.parents and resolved != REPO_ROOT:
+                escapes.append(f"{doc.relative_to(REPO_ROOT)}: {target} -> {resolved}")
+    assert not escapes, "links escape the repository root:\n  " + "\n  ".join(escapes)
+
+
+def test_the_scanner_actually_finds_links() -> None:
+    """Guard against the link regex silently matching nothing.
+
+    Without this, a regex change could make every test above pass vacuously.
+    """
+    total = sum(len(_link_targets(doc)) for doc in _iter_markdown())
+    assert total > 100, f"expected many repo links across docs/, found {total}"

--- a/tools/doit/docs.py
+++ b/tools/doit/docs.py
@@ -16,9 +16,13 @@ def task_docs_serve() -> dict[str, Any]:
 
 
 def task_docs_build() -> dict[str, Any]:
-    """Build documentation site."""
+    """Build documentation site (strict: warnings fail the build)."""
     return {
-        "actions": ["uv run mkdocs build"],
+        # --strict turns mkdocs warnings into a non-zero exit. Without it the
+        # docs job stayed green while the published site carried broken links.
+        # docs_serve is deliberately left non-strict so local authoring is not
+        # blocked mid-edit.
+        "actions": ["uv run mkdocs build --strict"],
         "title": title_with_actions,
     }
 


### PR DESCRIPTION
## Description

`tools/doit/docs.py` ran `mkdocs build` without `--strict`, and `.github/workflows/ci.yml` calls
`uv run doit docs_build` — so the docs job stayed green while the published site carried **62
warnings**. The gate verified nothing it claimed to verify:

```bash
$ uv run mkdocs build --strict 2>&1 | tail -1
Aborted with 62 warnings in strict mode!

$ uv run doit docs_build; echo $?
0
```

Splitting those 62 showed they were two different problems:

| Class | Count | Reality |
| :--- | ---: | :--- |
| Intra-docs path errors | 26 | **Genuinely broken** — ADRs using one `../` too many |
| Links out of `docs_dir` | 36 | **Correct links** mkdocs simply cannot resolve |

## Related Issue

Addresses #687
Addresses #686

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## Changes Made

- Repair **27 broken links across 15 ADRs** — all one `../` too many, plus `tools-reference.md`
  having moved to `docs/template/`. Fixed by resolving each target against the real tree rather
  than by hand, so no link was "fixed" to the wrong file.
- Fix an anchor orphaned by the `AI_SETUP.md` renumbering in #712 (Copilot moved §4 → §3). That
  regression was introduced two PRs ago and is exactly the drift this gate exists to catch.
- Enable `--strict` on `docs_build`. `docs_serve` is deliberately left non-strict so local
  authoring is not blocked mid-edit.
- Add `tests/test_docs_links.py` (60 tests) validating every relative link in `docs/`.
- Record the out-of-docs link policy in `mkdocs.yml`.

### The policy decision, and why it is not implemented in mkdocs

`docs/` deliberately links to real repository files outside `docs_dir` — `AGENTS.md`,
`README.md`, `.github/CONTRIBUTING.md`, the hook scripts under `tools/`, and their tests. Those
links are kept **relative** so they resolve when the repository is browsed on GitHub (how a
template is mostly read) and so downstream forks resolve to their own files rather than to this
upstream repo. Absolute GitHub URLs would have pointed every fork's docs back here.

The intended fix was to allow them via `mkdocs.yml`. **That is not achievable as stated:** mkdocs
1.6 reports out-of-docs links and genuinely broken links identically as `links.not_found`.
Setting it to `ignore` silenced all 62 — including the 26 real bugs — which would have failed this
issue's own criterion that CI catch a newly broken link.

So validation moved to `tests/test_docs_links.py`, which resolves each link against the **whole
repository**. That is strictly stronger than the mkdocs check: it also validates the 36
out-of-docs links, which mkdocs can never resolve. mkdocs keeps `anchors: warn`, where it has the
rendered headings and the test does not.

Trade-off, stated rather than accidental: the out-of-docs links do not resolve on the published
site.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. `doit docs_build` green under `--strict`.

**Both gates verified to bite**, not merely to be configured:

| Probe | Result |
| :--- | :--- |
| Broken file link added to `docs/index.md` | `test_relative_links_resolve[docs/index.md]` **FAILED** |
| Broken anchor introduced | `doit docs_build` **exit=1** |

Both probes reverted; no residue.

The test suite also guards itself: `test_the_scanner_actually_finds_links` asserts the link regex
matches more than 100 targets, so a regex change cannot make every other test pass vacuously.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**#688 (7 pages missing from the mkdocs nav) is not addressed here.** Those surface as `INFO`, not
`WARNING`, so they never blocked `--strict` and are genuinely separate. The strict build still
prints the list, so that issue now has a generated inventory to work from.

**`doit check` does not run `docs_build`** — the strict gate runs in CI's `docs` job, which calls
`uv run doit docs_build`. The link test does run in `doit check`, so a broken link fails locally
before it reaches CI.
