### PR TITLE
docs: fix broken links in README and CONTRIBUTING, widen the link test

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -951,7 +951,7 @@ git push origin main
 
 If you have questions:
 
-1. Check the [README.md](README.md) and [AGENTS.md](AGENTS.md)
+1. Check the [README.md](../README.md) and [AGENTS.md](../AGENTS.md)
 2. Search existing [Issues](https://github.com/username/package_name/issues)
 3. Open a new issue with the "question" label
 4. Join our discussions (if available)

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ doit docs_serve  # Opens at http://127.0.0.1:8000
 ```
 
 Key documentation files:
-- [Installation Guide](docs/installation.md) - Setup instructions
-- [Usage Guide](docs/usage.md) - Development workflows and commands
-- [API Reference](docs/api.md) - Complete API documentation
-- [Extensions Guide](docs/extensions.md) - Optional tools and extensions
+- [Installation Guide](docs/getting-started/installation.md) - Setup instructions
+- [Usage Guide](docs/usage/basics.md) - Development workflows and commands
+- [API Reference](docs/reference/api.md) - Complete API documentation
+- [Extensions Guide](docs/development/extensions.md) - Optional tools and extensions
 
 ## Quick Setup (Automated)
 
@@ -271,7 +271,7 @@ doit cleanup       # Clean build artifacts and caches
 doit update_deps   # Update dependencies and run tests
 ```
 
-See the [Usage Guide](docs/usage.md) for comprehensive documentation of all development workflows.
+See the [Usage Guide](docs/usage/basics.md) for comprehensive documentation of all development workflows.
 
 ## Running Tests
 

--- a/tests/test_markdown_links.py
+++ b/tests/test_markdown_links.py
@@ -1,4 +1,4 @@
-"""Validate every relative link in `docs/` against the real repository tree.
+"""Validate every relative link in the repository's markdown against the tree.
 
 `mkdocs build --strict` only resolves links that land inside `docs_dir`. This
 repository deliberately links out of `docs/` to canonical files that live
@@ -23,6 +23,13 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_DIR = REPO_ROOT / "docs"
 
+# Markdown that ships with the template and is read by humans or agents.
+# Root-level files matter as much as `docs/`: README.md and
+# .github/CONTRIBUTING.md are the first thing a new contributor opens, and
+# their links were broken for as long as nothing checked them (#686).
+_ROOT_MARKDOWN = ("README.md", "AGENTS.md", "CHANGELOG.md")
+_GITHUB_MARKDOWN_DIR = REPO_ROOT / ".github"
+
 # Markdown inline links: [text](target). Reference-style and bare autolinks are
 # not used for repo paths in this docs tree.
 _LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
@@ -36,7 +43,11 @@ _PLACEHOLDER_PARTS = ("path/to/", "<", "{{", "$")
 
 
 def _iter_markdown() -> list[Path]:
-    return sorted(DOCS_DIR.rglob("*.md"))
+    """Every checked markdown file: docs/, the repo root, and .github/."""
+    paths = list(DOCS_DIR.rglob("*.md"))
+    paths += [REPO_ROOT / name for name in _ROOT_MARKDOWN if (REPO_ROOT / name).is_file()]
+    paths += list(_GITHUB_MARKDOWN_DIR.glob("*.md"))
+    return sorted(set(paths))
 
 
 def _link_targets(path: Path) -> list[str]:


### PR DESCRIPTION
## Description

PR #715 addressed causes 1 and 2 of #686 — the ADR `../` errors and the moved `tools-reference.md`
— and added `tests/test_docs_links.py` to stop the class recurring.

**That test scanned `docs/` only.** So cause 3 was never checked and never fixed: `README.md`, the
first file a new contributor opens, still had four dead links, and `.github/CONTRIBUTING.md` had
two — with a green build. That is precisely the failure mode the test was added to prevent, one
directory over.

## Related Issue

Addresses #686

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## Changes Made

- Widen the link scan to the repository root (`README.md`, `AGENTS.md`, `CHANGELOG.md`) and
  `.github/*.md`, and rename the module `test_docs_links.py` → `test_markdown_links.py` to match
  its actual scope. 60 → 67 tests.
- Fix the six links it then reports — exactly the set #686 listed:

| File | Was | Now |
| :--- | :--- | :--- |
| `README.md` | `docs/installation.md` | `docs/getting-started/installation.md` |
| `README.md` | `docs/usage.md` (×2) | `docs/usage/basics.md` |
| `README.md` | `docs/api.md` | `docs/reference/api.md` |
| `README.md` | `docs/extensions.md` | `docs/development/extensions.md` |
| `.github/CONTRIBUTING.md` | `AGENTS.md` | `../AGENTS.md` |
| `.github/CONTRIBUTING.md` | `README.md` | `../README.md` |

The `CONTRIBUTING.md` change is anchored to the whole line rather than the link text. That file
also contains **correct** `../AGENTS.md` links elsewhere, so a blind substitution of `AGENTS.md`
would have broken the ones that already worked.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. `doit docs_build` still exits 0 under `--strict`. 67 link tests pass.

**Verified the new surfaces actually bite**, rather than trusting the widened glob:

| Probe | Result |
| :--- | :--- |
| Broken link appended to `README.md` | `test_relative_links_resolve[README.md]` **FAILED** |
| Broken link appended to `.github/CONTRIBUTING.md` | `test_relative_links_resolve[.github/CONTRIBUTING.md]` **FAILED** |

Both probes reverted; `git diff --stat` confirmed only the intended changes remained.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**The rename matters more than the fixes.** The six links were a two-minute change; the reason
they survived is that nothing checked them. The scan now covers every markdown file the template
ships that a human or agent actually reads.

`CHANGELOG.md` is included in the scanned set even though it is generated — if commitizen ever
emits a bad relative link, that should surface rather than pass silently.

With this, all three causes in #686 are addressed.
