### PR TITLE
docs: add the missing pages to the mkdocs nav and guard against recurrence

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,20 @@ markdown_extensions:
 # Anchors are still validated here, where mkdocs has the rendered headings.
 #
 # Trade-off: the out-of-docs links do not resolve on the published site.
+# `decisions/adr-template.md` is a scaffold, not a decision record: it carries
+# placeholder text and intentionally unresolvable links (`../path/to/doc.md`).
+# Listing it in the nav would present a fill-in-the-blanks form to readers as
+# though it were content, and `doit adr` is how an ADR is actually created. It
+# is excluded deliberately rather than left to drift out of the nav unnoticed.
+not_in_nav: |
+  decisions/adr-template.md
+
 validation:
+  nav:
+    # Any other page missing from the nav is an oversight; surface it. With
+    # `mkdocs build --strict` this fails the docs job rather than scrolling
+    # past as INFO, which is how seven pages became unreachable (#688).
+    omitted_files: warn
   links:
     not_found: ignore
     unrecognized_links: ignore
@@ -101,14 +114,19 @@ nav:
       - Tooling Roles: development/tooling-roles.md
       - Extensions: development/extensions.md
       - Release & Automation: development/release-and-automation.md
+      - Dependabot Auto-Merge: development/dependabot-automerge.md
       - AI:
           - First 5 Minutes: development/ai/first-5-minutes.md
           - Setup: development/AI_SETUP.md
           - Slash Commands: development/ai/slash-commands.md
+          - Cross-Agent Delegation: development/ai/cross-agent-delegation.md
           - Architectural Conventions: development/ai/architectural-conventions.md
           - Enforcement Principles: development/ai/enforcement-principles.md
           - Command Blocking: development/ai/command-blocking.md
+          - Auto-Checkpoint Hook: development/ai/auto-checkpoint-hook.md
+          - Ruff-Fix Hook: development/ai/ruff-fix-hook.md
           - LSP Tool and Diagnostics: development/ai/lsp-tool.md
+          - Statusline: development/ai/statusline.md
           - Token-Efficiency Add-Ons: development/ai/token-efficiency-add-ons.md
   - Deployment:
       - Development: deployment/development.md
@@ -139,6 +157,7 @@ nav:
       - ADR-9014 click CLI: decisions/9014-use-click-for-application-cli.md
       - ADR-9015 install_tools: decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
       - ADR-9016 Unify ADRs: decisions/9016-unify-adr-directories.md
+      - ADR-9017 Template ownership: decisions/9017-template-tooling-and-its-tests-are-template-owned.md
   - Reference:
       - API Reference: reference/api.md
   - Examples:


### PR DESCRIPTION
## Description

Seven pages existed under `docs/` but were absent from the `nav:` block, so they were built into
the site and unreachable from it. Five document live, non-obvious features a reader had no way to
discover:

| Page | What it documents |
| :--- | :--- |
| `development/ai/cross-agent-delegation.md` | The delegation matrix |
| `development/ai/auto-checkpoint-hook.md` | PreCompact checkpoint + session-resume hooks |
| `development/ai/ruff-fix-hook.md` | The PostToolUse ruff-fix hook |
| `development/ai/statusline.md` | The statusline scripts |
| `development/dependabot-automerge.md` | The Dependabot auto-merge workflow |
| `decisions/9017-...-template-owned.md` | ADR-9017 |
| `decisions/adr-template.md` | ADR scaffold — deliberately excluded, see below |

`AGENTS.md` links several of them directly, so they were current — just unreachable.

## Related Issue

Addresses #688

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

`mkdocs.yml` only.

- **Placed the five feature pages by topic**, not appended: the two hook pages sit with Command
  Blocking (also a hook doc), delegation sits with Slash Commands, statusline with the LSP tool,
  and dependabot with Release & Automation.
- **Listed ADR-9017** alongside the other ADRs. `docs/decisions/README.md` already indexed it and
  the nav lists every other ADR individually, so its absence was an oversight from when it landed.
- **Excluded `decisions/adr-template.md` deliberately** via `not_in_nav`, with the reasoning in a
  comment. It is a scaffold carrying placeholder text and intentionally unresolvable
  `../path/to/doc.md` links; listing it would present a fill-in-the-blanks form to readers as
  though it were content, and `doit adr` is how an ADR actually gets created. Explicit exclusion
  rather than silent drift.
- **Set `validation.nav.omitted_files: warn`.** Combined with `--strict` from #687, the next
  omission fails the docs job instead of scrolling past as `INFO` — which is exactly how seven
  pages accumulated.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. `doit docs_build` exits 0 under `--strict`.

**Verified the guard bites**, rather than trusting the setting:

| Check | Result |
| :--- | :--- |
| Pages still missing from nav | **none** |
| New page added outside the nav | `doit docs_build` **exit=1** |
| Probe page removed, rebuild | **exit=0** |

No new test file: the enforcement is the mkdocs build itself, which CI already runs via
`uv run doit docs_build`. Criterion 4 of the issue asked for exactly that.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**The guard matters more than the seven entries.** Adding pages to a nav is a one-time fix; without
`omitted_files: warn` it recurs the next time anyone adds a page. This is the third gate in the
docs cluster — #687 made the build strict, #686 widened link validation to root markdown, and this
one closes nav coverage.

This completes the docs cluster: **#686, #687, #688**.
