### PR TITLE
chore: stop the test suite writing gh state into the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,13 @@ dmypy.json
 .direnv/
 .envrc.local
 
+# Per-user local state. `.claude/settings.local.json` was previously covered
+# only by the maintainer's global ignore file, so a fresh clone by anyone else
+# showed it as untracked. `.local/` is where `gh` writes its state dir when
+# HOME is unset (see tests/test_statusline_agy.py).
+.claude/settings.local.json
+.local/
+
 # Environment variables
 .env
 .env.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,10 +56,13 @@ repos:
         stages: [pre-commit]
 
       # Type checking (uses project's mypy version)
-      # Only checks src/ to match doit type_check behavior
+      # Scope matches `doit type_check`. It was src/ only, which stopped
+      # matching when #700 widened the doit task to tools/ and tests/ --
+      # leaving the hook able to pass on code CI would then reject. Warm-cache
+      # cost of the wider scope is ~60ms.
       - id: mypy
         name: mypy
-        entry: uv run mypy src/
+        entry: uv run mypy src/ tools/ tests/ bootstrap.py
         language: system
         types: [python]
         pass_filenames: false

--- a/tests/test_statusline_agy.py
+++ b/tests/test_statusline_agy.py
@@ -31,9 +31,27 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 AGY = REPO_ROOT / "tools" / "statusline" / "agy-statusline.sh"
 
 
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point HOME at a throwaway directory for every test in this module.
+
+    The script calls `gh api user`. `gh` resolves its state directory as
+    ``$XDG_STATE_HOME``, falling back to ``$HOME/.local/state`` — and with HOME
+    unset that fallback is *relative*, so `gh` wrote ``.local/state/gh/device-id``
+    into the current working directory, which under pytest is the repository
+    root. Every run of this module dirtied the working tree (#698).
+
+    The sibling statusline modules already pin HOME to a tmp dir; this one did
+    not.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
 def _run(payload: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     """Invoke the statusline script with the given JSON payload on stdin."""
-    env = {"PATH": os.environ["PATH"]}
+    # HOME is forwarded deliberately — see `_isolated_home`. A child without it
+    # writes into the repository.
+    env = {"PATH": os.environ["PATH"], "HOME": os.environ["HOME"]}
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -191,3 +209,28 @@ def test_sandbox_absent_when_disabled() -> None:
     result = _run(payload, {"AGY_STATUSLINE_EXTRAS": "1"})
     assert result.returncode == 0
     assert "🔒" not in result.stdout
+
+
+def test_invocation_does_not_write_into_the_repository() -> None:
+    """No invocation may leave `gh`'s state directory in the repository.
+
+    `.local/` at the repository root only ever appears from this bug: real
+    `gh` usage writes to `~/.local/state`, and only a child launched without
+    HOME falls back to a relative path (#698).
+
+    Asserted absolutely rather than as a before/after diff. A diff passes
+    vacuously when an earlier test in the module already created the
+    directory — which is exactly what happened while developing this guard, so
+    the first assertion below covers sibling tests and the second covers this
+    one.
+    """
+    local_state = REPO_ROOT / ".local"
+
+    assert not local_state.exists(), (
+        "another test already wrote .local/ into the repository root; "
+        "HOME isolation has regressed (see _isolated_home)"
+    )
+
+    _run(json.dumps({"model": {"display_name": "Gemini 3 Pro"}}))
+
+    assert not local_state.exists(), "this invocation created .local/ in the repository root"


### PR DESCRIPTION
## Description

`.local/` was the only entry in `git status` on a clean checkout — which, as #698 puts it, trains
everyone to ignore a dirty status line, exactly when a real stray file gets missed.

**It was not a stale artifact.** Investigating the cause found an active bug: the test suite
recreated it on every run.

## Related Issue

Addresses #698

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## The root cause

`tests/test_statusline_agy.py::_run` built its child environment as:

```python
env = {"PATH": os.environ["PATH"]}   # no HOME
subprocess.run(["bash", str(AGY)], env=env, ...)   # and no cwd=
```

`tools/statusline/agy-statusline.sh:96` calls `gh api user`. `gh` resolves its state directory as
`$XDG_STATE_HOME`, falling back to `$HOME/.local/state` — and with HOME unset that fallback is
**relative**, so it wrote `.local/state/gh/device-id` into the inherited cwd: the repository root.

Reproduced in isolation:

```bash
$ cd "$(mktemp -d)" && env -u HOME gh auth status
$ find . -type f
./.local/state/gh/device-id
```

And end-to-end — deleting `.local/`, then running only that module, brought it back.

The two sibling modules already do this correctly: `test_statusline_claude_usage.py:49` and
`test_statusline_python_version.py:85` both pin `HOME` to a `tmp_path`. This one, the newest of
the three, simply missed the convention.

## Changes Made

- **Pin HOME** in `test_statusline_agy.py` via an autouse fixture, matching its siblings. This is
  the actual fix — the write stops at source.
- **Add a guard** asserting `.local/` never appears at the repository root.
- **Gitignore `.local/`** as belt-and-braces, since `gh` can be invoked outside the suite.
- **Gitignore `.claude/settings.local.json`** — the second half of #698's first item. It was
  covered only by a maintainer's *global* `~/.config/git/ignore`, so a fresh clone by anyone else
  showed it untracked. Wrong for a template.
- **Widen the pre-commit mypy hook** to `src/ tools/ tests/ bootstrap.py` — #698's second item.
  The comment claimed the scope matched `doit type_check`; #700 widened that task and left the
  hook behind, so a commit could pass the hook and then be rejected by CI. Measured warm-cache
  cost: 0.12s → 0.18s.

### The first version of the guard was vacuous

It compared repository contents before and after the invocation. It **passed with the bug
reintroduced**, because an earlier test in the module creates `.local/` first — so the directory
was already in `before` and the diff came out empty.

Rewritten as an absolute assertion, which also catches sibling tests polluting. That failure mode
is recorded in the docstring so the next person doesn't reach for a diff.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. `git status` is clean after a full run — for the first time.

**Verified the guard bites**, after it initially did not:

| State | Result |
| :--- | :--- |
| HOME dropped from the child env | `test_invocation_does_not_write_into_the_repository` **FAILED** |
| Fix in place | 14 passed, `.local/` absent |
| Full `doit check` | green, working tree clean |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**The gitignore alone would have been the wrong fix.** It would have hidden a test dirtying the
working tree on every run, and that pollution would have shipped to every downstream project that
runs the suite. The ignore is kept, but as a backstop rather than the remedy.

**The device ID is not a credential** — a 36-character UUID `gh` uses to identify the device. Real
auth lives in `~/.config/gh/hosts.yml` and was never involved.
