### PR TITLE
fix: remove the inert Dependabot option from configure

### DIFF
--- a/tests/template/test_configure_paths.py
+++ b/tests/template/test_configure_paths.py
@@ -1,0 +1,82 @@
+"""Every filesystem path `configure.py` names must exist in the template.
+
+`configure.py` runs once, against a freshly cloned template, to turn it into a
+real project. When it gates behaviour on a path that does not exist, the gate
+short-circuits: the branch never runs, nothing is printed, and no error is
+raised.
+
+That is how the Dependabot option became a silent no-op (#685) — it was gated
+on `.github/dependabot.yml.example`, a file that had never existed. Users were
+asked whether to enable Dependabot, shown their answer in the configuration
+summary, and the answer was then discarded.
+
+The failure is invisible by construction, so it needs a structural check rather
+than a behavioural one.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Scripts that operate on the template tree by naming paths directly.
+SCANNED = (
+    REPO_ROOT / "tools" / "pyproject_template" / "configure.py",
+    REPO_ROOT / "tools" / "pyproject_template" / "cleanup.py",
+)
+
+# Paths a script legitimately names before creating them, or that exist only at
+# runtime. Add here — with a reason — rather than deleting the assertion.
+# Empty today: every path both scripts name already ships with the template.
+ALLOWED_MISSING: frozenset[str] = frozenset()
+
+
+def _path_literals(script: Path) -> list[tuple[int, str]]:
+    """Return `(lineno, value)` for every `Path("literal")` in *script*.
+
+    Parsed rather than grepped so that string concatenation, f-strings and
+    variables are ignored — only unambiguous literals are asserted on.
+    """
+    tree = ast.parse(script.read_text(encoding="utf-8"))
+    found = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "Path"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            found.append((node.lineno, node.args[0].value))
+    return found
+
+
+@pytest.mark.parametrize("script", SCANNED, ids=lambda p: p.name)
+def test_path_literals_exist_in_the_template(script: Path) -> None:
+    """A named path that is absent makes its branch unreachable and silent."""
+    missing = [
+        f"{script.name}:{lineno} -> {value}"
+        for lineno, value in _path_literals(script)
+        if value not in ALLOWED_MISSING and not (REPO_ROOT / value).exists()
+    ]
+    assert not missing, (
+        "paths named by the script do not exist in the template:\n  "
+        + "\n  ".join(missing)
+        + "\n\nA gate on a missing path silently does nothing. Fix the path, or "
+        "add it to ALLOWED_MISSING with a reason."
+    )
+
+
+def test_the_scanner_actually_finds_literals() -> None:
+    """Guard against the AST walk silently matching nothing.
+
+    Without this, a refactor of the scan could make the assertion above pass
+    vacuously — the same way the paths it protects failed silently.
+    """
+    total = sum(len(_path_literals(script)) for script in SCANNED)
+    assert total >= 10, f"expected the configure/cleanup scripts to name paths, found {total}"

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -276,7 +276,6 @@ def run_configure(
             defaults["github_user"],
             "GitHub user (from Repository URL or git remote)",
         )
-        enable_dependabot = False
     else:
         project_name = prompt(
             "Project name (human-readable)",
@@ -310,14 +309,6 @@ def run_configure(
 
         github_user = prompt("GitHub username", defaults["github_user"] or "username")
 
-    # Optional features
-    if auto:
-        enable_dependabot = False
-    else:
-        print()
-        Logger.step("Optional Features")
-        enable_dependabot = prompt_confirm("Enable Dependabot for automatic dependency updates?")
-
     # Confirm configuration
     Logger.header("Configuration Summary")
     print(f"Project Name:     {project_name}")
@@ -326,7 +317,10 @@ def run_configure(
     print(f"Description:      {description}")
     print(f"Author:           {author_name} <{author_email}>")
     print(f"GitHub:           {github_user}")
-    print(f"Dependabot:       {'Enabled' if enable_dependabot else 'Disabled'}")
+    # Stated, not asked. Dependabot is part of the template's automation
+    # surface -- .github/dependabot.yml plus two workflows, a docs page and
+    # their tests -- and ships with every project.
+    print("Dependabot:       Enabled (ships with the template)")
     print("━" * 60)
 
     if not yes and not prompt_confirm("\nProceed with configuration?"):
@@ -450,13 +444,6 @@ def run_configure(
     if template_tests_dir.exists():
         print("  ✓ Removing template-only tests (tests/template/)")
         shutil.rmtree(template_tests_dir)
-
-    # Enable Dependabot if requested
-    dependabot_example = Path(".github/dependabot.yml.example")
-    dependabot_config = Path(".github/dependabot.yml")
-    if enable_dependabot and dependabot_example.exists():
-        print("  ✓ Enabling Dependabot")
-        shutil.copy(dependabot_example, dependabot_config)
 
     # Seed v0.0.0 baseline tag so `doit release --prerelease=alpha` works on the
     # first release (see issue #447). Idempotent and skipped gracefully when


### PR DESCRIPTION
## Description

`configure.py` asked the user whether to enable Dependabot, echoed the answer back in the
Configuration Summary, and then discarded it.

```python
dependabot_example = Path(".github/dependabot.yml.example")
if enable_dependabot and dependabot_example.exists():   # never true
    print("  ✓ Enabling Dependabot")
    shutil.copy(dependabot_example, dependabot_config)
```

`.github/dependabot.yml.example` has never existed in this repository. The `and` short-circuited,
so the branch never ran, printed nothing, and raised nothing.

**It was worse than inert — it misreported in both directions.** `.github/dependabot.yml` ships
unconditionally, so a user who *declined* saw `Dependabot: Disabled` and got Dependabot anyway. In
`auto` mode the flag was hardcoded `False`, so every non-interactive run printed `Disabled` while
shipping it.

## Related Issue

Addresses #685

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## Changes Made

- Remove the prompt, the `auto`-mode assignment, and the dead branch.
- Replace the summary line with a statement of the actual behaviour:
  `Dependabot:       Enabled (ships with the template)`.
- Add `tests/template/test_configure_paths.py` — AST-parses `configure.py` and `cleanup.py` for
  `Path("literal")` calls and asserts each exists in the template tree.

### Why remove the flag rather than restore the `.example`

The issue framed this as either/or. The evidence settles it: **Dependabot is not optional in this
template.** Six tracked assets support it —

| Asset | |
| :--- | :--- |
| `.github/dependabot.yml` | the config itself |
| `.github/workflows/dependabot-automerge.yml` | auto-merge automation |
| `.github/workflows/dependabot-blocked-label.yml` | blocked-label handling |
| `docs/development/dependabot-automerge.md` | documented workflow |
| `tests/test_dependabot_automerge_workflow.py` | |
| `tests/test_dependabot_blocked_label_workflow.py` | |

— and `repo_settings.py:236` enables Dependabot security updates through the GitHub API during
setup. `AGENTS.md` also carries a Dependabot PR-handling section.

Honouring the prompt would mean conditionally deleting two workflows and their tests, and leaving
`repo_settings.py` enabling security updates for a feature the user had just declined.
Disproportionate for something the template plainly treats as standard.

No documentation promised the prompt, so nothing else needed updating.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. No test referenced `enable_dependabot`, so nothing was silenced to make this
pass.

**Verified the guard catches the exact bug.** Reintroducing the literal:

```
E   configure.py:396 -> .github/dependabot.yml.example
FAILED tests/template/test_configure_paths.py::test_path_literals_exist_in_the_template[configure.py]
```

The scan is AST-based rather than grep-based, so concatenation, f-strings and variables are
ignored and only unambiguous literals are asserted on. It carries an `ALLOWED_MISSING` allowlist
(empty today) so a path a script legitimately creates has a sanctioned home rather than prompting
someone to delete the assertion.

It also has `test_the_scanner_actually_finds_literals`, asserting the walk sees at least 10
literals — otherwise a refactor of the scan could make the check pass by matching nothing, which
is the same silent-failure shape as the bug itself.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**Placed in a new test module, not `test_templates.py`** as the issue suggested — that module
tests the ADR and issue *template parser*, which is unrelated to the configure script.

**`cleanup.py` is scanned too**, though it currently names no path literals. Including it now
means the guard applies the moment it grows one, rather than waiting for the same bug to appear
there.
