### PR TITLE
chore: update stale Claude model pins and make staleness surface

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "env": {
     "ENABLE_PROMPT_CACHING_1H": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-4-6"
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-5"
   },
   "statusLine": {
     "type": "command",

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -122,7 +122,7 @@ For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` 
 | :--- | :--- | :--- | :--- |
 | `ENABLE_PROMPT_CACHING_1H` | `1` | Extends prompt cache TTL from 5 minutes to 1 hour. Cuts cost on repeated reads of the same context within a session. | None — pure efficiency flag. |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | `50` | Auto-compaction triggers at 50% of the context window instead of the default (~92%). Sessions compact earlier, leaving more headroom for the post-compact continuation. | More frequent compaction churn; mitigated by the [PreCompact handoff hook](ai/auto-checkpoint-hook.md) which preserves context across compaction events. |
-| `CLAUDE_CODE_SUBAGENT_MODEL` | `claude-sonnet-4-6` | Subagents (e.g. those spawned by `/claude:implement`) default to Sonnet 4.6 instead of inheriting the parent's Opus model. | Subagent output quality drops below Opus on hard reasoning tasks. Mitigate per-agent (see below). |
+| `CLAUDE_CODE_SUBAGENT_MODEL` | `claude-sonnet-5` | Subagents (e.g. those spawned by `/claude:implement`) default to Sonnet 5 instead of inheriting the parent's Opus model. | Subagent output quality drops below Opus on hard reasoning tasks. Mitigate per-agent (see below). |
 
 **Per-agent model overrides:**
 
@@ -131,11 +131,11 @@ For complete setup instructions and troubleshooting, see `.claude/lsp-setup.md` 
 ```yaml
 ---
 name: high-stakes-reviewer
-model: claude-opus-4-7   # overrides the env-var default for this agent only
+model: claude-opus-5   # overrides the env-var default for this agent only
 ---
 ```
 
-Agents without a `model:` line inherit the env-var default. This template's `.claude/agents/implement-worker.md` deliberately does not override — implement-worker runs on Sonnet 4.6 as an explicit cost/quality trade-off. Future high-stakes subagents (e.g. design review, security review) can opt into Opus on a per-file basis.
+Agents without a `model:` line inherit the env-var default. This template's `.claude/agents/implement-worker.md` deliberately does not override — implement-worker runs on Sonnet 5 as an explicit cost/quality trade-off. Future high-stakes subagents (e.g. design review, security review) can opt into Opus on a per-file basis.
 
 **Per-developer overrides:**
 

--- a/docs/development/ai/auto-checkpoint-hook.md
+++ b/docs/development/ai/auto-checkpoint-hook.md
@@ -24,7 +24,7 @@ Before Claude Code compacts the conversation context, the hook:
 
 1. Reads the `transcript_path` from the hook payload.
 2. Takes up to 200 KB from the tail of the JSONL transcript.
-3. Spawns `claude -p --bare --model claude-sonnet-4-6` with a strict-JSON prompt asking for:
+3. Spawns `claude -p --bare --model claude-sonnet-5` with a strict-JSON prompt asking for:
    `{title, status, in_flight_work, constraints, files_touched, next_steps, resume_prompt}`.
 4. Parses the JSON response and renders it into a markdown checkpoint file matching the
    `/checkpoint` section structure (Title, Status, In-flight work, Constraints, Files touched,

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -211,6 +211,13 @@ AI coding assistants (Claude Code, Copilot, Codex, Antigravity) use hooks to blo
 
 - [ ] Compare `.claude/settings.json` for Claude Code hook configuration
 - [ ] Compare `.codex/config.toml` for Codex CLI approval policies
+- [ ] **Review pinned model IDs.** `.claude/settings.json` pins
+      `CLAUDE_CODE_SUBAGENT_MODEL`, and `tools/hooks/ai/precompact-checkpoint.py`
+      passes a model to `claude -p`. Nothing in the update-check machinery looks at
+      model IDs, so a pin from two generations ago survives indefinitely and silently
+      (#696). `tests/template/test_model_pins.py` fails when a pinned ID leaves the
+      current family — run `doit test` after syncing and update
+      `CURRENT_MODEL_IDS` there if the family has moved on.
 
 **Note:** If these configuration files don't exist in the downstream project, copy them from the template to enable AI safety hooks.
 

--- a/tests/template/test_model_pins.py
+++ b/tests/template/test_model_pins.py
@@ -1,0 +1,103 @@
+"""Pinned Claude model IDs must be current and must agree with the docs.
+
+A model pin in a *template* is different from a pin in an ordinary repo: every
+project spawned from it inherits the value, and nothing in the update-checking
+machinery looks at model IDs. `CLAUDE_CODE_SUBAGENT_MODEL` sat at
+`claude-sonnet-4-6` for two model generations, and the same stale ID had spread
+into `precompact-checkpoint.py`, which passes it to a live `claude -p`
+invocation (#696).
+
+The pin itself is deliberate — `AI_SETUP.md` records it as a cost/quality
+trade-off, with `implement-worker` intentionally not overriding it. So these
+tests do not forbid pinning. They make a *stale* pin loud.
+
+Two properties are checked:
+
+1. **Currency** — every pinned ID is in `CURRENT_MODEL_IDS` below. That list is
+   the single place a model-family change has to be applied; the test failing
+   is how the change surfaces at all.
+2. **Consistency** — `.claude/settings.json` and the `AI_SETUP.md` table quote
+   the same ID. This one needs no maintenance and catches the two drifting
+   apart, which is how the docs came to describe a value nobody had checked.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+AI_SETUP = REPO_ROOT / "docs" / "development" / "AI_SETUP.md"
+
+# Update when the Claude model family changes. Deliberately a short list rather
+# than a pattern: a regex for "looks like a model ID" would have happily
+# accepted claude-sonnet-4-6 forever.
+CURRENT_MODEL_IDS = frozenset(
+    {
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-haiku-4-5-20251001",
+    }
+)
+
+# Any `claude-<family>-<version>` token, so a stale ID is found wherever it hides.
+_MODEL_RE = re.compile(r"claude-(?:opus|sonnet|haiku|fable)-[0-9][0-9a-z-]*")
+
+# Files that legitimately name a model ID.
+_SCANNED = (
+    SETTINGS,
+    AI_SETUP,
+    REPO_ROOT / "tools" / "hooks" / "ai" / "precompact-checkpoint.py",
+    REPO_ROOT / "docs" / "development" / "ai" / "auto-checkpoint-hook.md",
+)
+
+
+def _subagent_pin() -> str:
+    """The subagent model pinned in `.claude/settings.json`."""
+    env = json.loads(SETTINGS.read_text(encoding="utf-8")).get("env", {})
+    pin = env.get("CLAUDE_CODE_SUBAGENT_MODEL")
+    assert pin, "CLAUDE_CODE_SUBAGENT_MODEL is absent from .claude/settings.json"
+    return str(pin)
+
+
+@pytest.mark.parametrize("path", _SCANNED, ids=lambda p: p.name)
+def test_model_ids_are_current(path: Path) -> None:
+    """No file may name a model outside the current family."""
+    stale = sorted(set(_MODEL_RE.findall(path.read_text(encoding="utf-8"))) - CURRENT_MODEL_IDS)
+    assert not stale, (
+        f"{path.name} names non-current model IDs: {stale}\n"
+        "Update them, or add the new family to CURRENT_MODEL_IDS in this test."
+    )
+
+
+def test_settings_and_docs_quote_the_same_pin() -> None:
+    """The documented subagent model must match the one actually shipped.
+
+    Needs no maintenance, unlike the currency check: it fails whenever the two
+    drift, whatever the current model happens to be.
+    """
+    pin = _subagent_pin()
+    row = re.search(
+        r"^\| `CLAUDE_CODE_SUBAGENT_MODEL` \| `([^`]+)` \|",
+        AI_SETUP.read_text(encoding="utf-8"),
+        re.M,
+    )
+    assert row, "AI_SETUP.md no longer documents CLAUDE_CODE_SUBAGENT_MODEL in its env table"
+    assert row.group(1) == pin, (
+        f"settings.json pins {pin!r} but AI_SETUP.md documents {row.group(1)!r}"
+    )
+
+
+def test_the_scanner_actually_finds_model_ids() -> None:
+    """Guard against the pattern silently matching nothing.
+
+    Without this, a regex change could make every assertion above pass
+    vacuously — the same silent-success shape the pin itself had.
+    """
+    total = sum(len(_MODEL_RE.findall(p.read_text(encoding="utf-8"))) for p in _SCANNED)
+    assert total >= 4, f"expected the scanned files to name model IDs, found {total}"

--- a/tools/hooks/ai/precompact-checkpoint.py
+++ b/tools/hooks/ai/precompact-checkpoint.py
@@ -131,7 +131,7 @@ def synthesize_checkpoint(transcript_tail: str) -> dict[str, object] | None:
                 "-p",
                 "--bare",
                 "--model",
-                "claude-sonnet-4-6",
+                "claude-sonnet-5",
                 prompt,
             ],
             capture_output=True,


### PR DESCRIPTION
## Description

`.claude/settings.json` pinned `CLAUDE_CODE_SUBAGENT_MODEL` to `claude-sonnet-4-6` — two model
generations behind the current family.

In a template this matters more than in an ordinary repo: every spawned project inherits the
setting, and nothing in the update-check machinery looks at model IDs, so the pin would have
survived indefinitely and silently.

## Related Issue

Addresses #696

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## Two corrections to the issue's premise

**1. Removing the pin would have been wrong.** The issue suggests removal, "since it cannot go
stale". But `AI_SETUP.md:138` records the pin as deliberate:

> This template's `.claude/agents/implement-worker.md` **deliberately does not override** —
> implement-worker runs on Sonnet as an explicit cost/quality trade-off. Future high-stakes
> subagents can opt into Opus on a per-file basis.

Removing it would put every downstream project's implementation subagent on Opus, discarding a
documented decision and raising cost for every consumer. **The defect is the stale ID, not the
strategy** — so the ID is updated and the pin kept.

**2. "The rationale is not recorded anywhere" is not accurate.** `AI_SETUP.md:123-129` documents
all three env vars with effect *and* risk, including `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` and its
mitigation via the PreCompact handoff hook, plus per-agent and per-developer override mechanisms.
No further documentation was needed for that setting, so it is unchanged.

## The stale ID had spread further than the issue named

The issue cites `.claude/settings.json`. A repo-wide audit found five occurrences, one of them in
live code:

| File | Role |
| :--- | :--- |
| `.claude/settings.json` | the pin itself |
| **`tools/hooks/ai/precompact-checkpoint.py:134`** | **passes the ID to a running `claude -p --bare --model …`** |
| `docs/development/ai/auto-checkpoint-hook.md` | documents that invocation |
| `docs/development/AI_SETUP.md` (×3) | env table, prose, and an example using `claude-opus-4-7` |

The checkpoint hook is the one with real failure potential — it spawns the CLI at runtime, so a
retired model ID becomes a broken hook rather than a cosmetic wart.

## Changes Made

- Update all five occurrences to the current family (`claude-sonnet-5`, `claude-opus-5`).
- Add `tests/template/test_model_pins.py`.
- Add a "review pinned model IDs" step to `docs/template/ai-sync-checklist.md` (issue item 4).
- **Audit result (issue item 3):** no other agent config pins a model ID. The only other match,
  `.claude/statusline-command.sh`, reads the model dynamically from its JSON input. `.gemini/`
  no longer exists since #712, so the config that previously mirrored these settings is gone.

### The guard checks two different properties

| Test | Property | Maintenance |
| :--- | :--- | :--- |
| `test_model_ids_are_current` | No file names a model outside `CURRENT_MODEL_IDS` | Update the list when the family moves — that failure *is* the surfacing mechanism |
| `test_settings_and_docs_quote_the_same_pin` | `settings.json` and the `AI_SETUP.md` table agree | **None** — fails on drift whatever the current model is |

The second is the one that would have caught this class earliest: the docs described a value nobody
had re-checked. `CURRENT_MODEL_IDS` is a short explicit list rather than a pattern on purpose — a
regex for "looks like a model ID" would have happily accepted `claude-sonnet-4-6` forever.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green.

**Verified the guard bites:** reintroducing `claude-sonnet-4-6` into `settings.json` fails **both**
`test_model_ids_are_current[settings.json]` and `test_settings_and_docs_quote_the_same_pin`.
Restoring makes all 6 pass.

There is also a `test_the_scanner_actually_finds_model_ids` check, asserting the pattern matches at
least 4 IDs — otherwise a regex refactor could make the assertions pass by matching nothing, which
is the same silent-success shape as the stale pin itself.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` and `ENABLE_PROMPT_CACHING_1H` are unchanged. The former is
already documented with its trade-off and its mitigation; changing it would alter behaviour for
every downstream project on a guess about intent.
