### PR TITLE
chore: split the landing-page README from the consumer README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,16 @@
-# __PROJECT_NAME__
+# pyproject-template
 
-[![CI](https://github.com/__GH_OWNER__/__PACKAGE_NAME__/actions/workflows/ci.yml/badge.svg)](https://github.com/__GH_OWNER__/__PACKAGE_NAME__/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/__GH_OWNER__/__PACKAGE_NAME__/branch/main/graph/badge.svg)](https://codecov.io/gh/__GH_OWNER__/__PACKAGE_NAME__)
-[![PyPI version](https://badge.fury.io/py/__PYPI_NAME__.svg)](https://badge.fury.io/py/__PYPI_NAME__)
+[![CI](https://github.com/endavis/pyproject-template/actions/workflows/ci.yml/badge.svg)](https://github.com/endavis/pyproject-template/actions/workflows/ci.yml)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-__DESCRIPTION__
+A batteries-included GitHub template for modern Python projects — `uv`, `doit`, `ruff`, `mypy`,
+`pytest`, GitHub Actions, MkDocs, and a first-class AI-agent workflow.
 
-## Features
+Spawn a project and you get the tooling, the CI, the release automation, and the agent
+configuration already wired together and tested.
 
-- Modern tooling: `uv` for deps, `ruff` for format/lint, `mypy` in strict mode
-- CI/CD ready: GitHub Actions for checks, coverage upload, and releases
-- Release automation: hatch-vcs + commitizen-driven tagging and changelog
-
-## Installation
-
-```bash
-pip install __PYPI_NAME__
-```
-
-## Quick Start
-
-```python
-from __PACKAGE_NAME__ import greet
-
-# Example usage
-message = greet("Python")
-print(message)  # Output: Hello, Python!
-```
-
-## Documentation
-
-📚 **Full documentation is available in the [docs/](docs/) directory**
-
-Build and view locally:
-```bash
-doit docs_serve  # Opens at http://127.0.0.1:8000
-```
-
-Key documentation files:
-- [Installation Guide](docs/getting-started/installation.md) - Setup instructions
-- [Usage Guide](docs/usage/basics.md) - Development workflows and commands
-- [API Reference](docs/reference/api.md) - Complete API documentation
-- [Extensions Guide](docs/development/extensions.md) - Optional tools and extensions
+---
 
 ## Quick Setup (Automated)
 
@@ -53,6 +21,7 @@ curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/boot
 ```
 
 The script will:
+
 - ✅ Create a new repository from this template on GitHub
 - ✅ Configure repository settings (merge options, features)
 - ✅ Set up branch protection rules
@@ -60,325 +29,99 @@ The script will:
 - ✅ Run placeholder replacement automatically
 - ✅ Provide a checklist of manual steps (secrets, etc.)
 
-**Requirements:**
-- [GitHub CLI](https://cli.github.com/) installed and authenticated (`gh auth login`)
-- Git installed
-- Python 3.12+
+**Requirements:** [GitHub CLI](https://cli.github.com/) authenticated (`gh auth login`), Git, and
+Python 3.12+.
 
-**What you'll need to add manually:**
-- PyPI tokens (for publishing packages)
-- Codecov token (optional, for coverage reports)
-- Collaborators/team access
+**You add manually afterwards:** PyPI tokens, a Codecov token (optional), and collaborator access.
 
-📖 See [New Project Setup](docs/template/new-project.md) for detailed instructions.
+📖 [New Project Setup](docs/template/new-project.md) has the detailed walkthrough.
 
 ## Using This Template (Manual)
 
-**First time setup:** This is a template repository. If you prefer to clone manually:
+If you would rather clone than use the bootstrap script:
 
 ```bash
-# Clone the template
-git clone https://github.com/username/package_name.git my-project
+git clone https://github.com/endavis/pyproject-template.git my-project
 cd my-project
-
-# Run the interactive configuration script
 python3 tools/pyproject_template/configure.py
 ```
 
-The script will prompt you for:
-- Project name, description
-- Package name (Python import name)
-- PyPI package name
-- Author name and email
-- GitHub username
+`configure.py` prompts for the project name, package name, PyPI name, author and GitHub user, then
+renames the package directory, replaces every placeholder, installs `README.template.md` as the
+project's `README.md`, and removes itself.
 
-It will automatically:
-- Rename the package directory
-- Update all template placeholders
-- Self-destruct after completion
+## What you get
 
-📖 See [New Project Setup](docs/template/new-project.md) for detailed instructions and post-setup steps.
+| | |
+| :--- | :--- |
+| **Dependencies** | `uv` — lockfile-based, fast, reproducible |
+| **Tasks** | `doit` — 50 tasks covering test, lint, type-check, docs, release, issues and PRs |
+| **Quality** | `ruff` (format + lint), `mypy` (strict), `bandit`, `pip-audit`, `vulture`, `codespell` |
+| **Testing** | `pytest` with `xdist`, coverage gating, benchmarks, Hypothesis property tests |
+| **CI/CD** | GitHub Actions across Linux/macOS/Windows and Python 3.12–3.14, with a merge gate |
+| **Releases** | `hatch-vcs` versioning plus commitizen-driven tagging and changelog |
+| **Docs** | MkDocs Material, built with `--strict` so broken links fail CI |
+| **Decisions** | 17 ADRs recording why the tooling is the way it is |
 
-## Development Setup
+## AI agent workflow
 
-### Prerequisites
+Four CLIs are supported as first-class agents — **Claude Code**, **GitHub Copilot CLI**,
+**Codex CLI**, and **Antigravity CLI** (`agy`) — each able to act on itself or delegate to any of
+the others.
 
-- Python 3.12+
-- [uv](https://github.com/astral-sh/uv) - Fast Python package installer
-- [direnv](https://direnv.net/) - Automatic environment variable loading (optional but recommended)
+- **Enforced workflow.** Issue → branch → `doit check` → PR → merge gate. Agents cannot commit to
+  `main`, skip hooks, or apply the `ready-to-merge` label.
+- **A shared safety hook** blocks dangerous commands for every agent, and fails *closed* — a hook
+  that cannot evaluate a command denies it rather than allowing it.
+- **Cross-agent delegation.** `/claude:plan`, `$codex-implement`, `/copilot-review`, and the
+  `/multi-*` orchestrators that fan a task out to several agents and synthesize the results.
 
-### Quick Start
+📖 [AI Agent Setup](docs/development/AI_SETUP.md) ·
+[First 5 Minutes](docs/development/ai/first-5-minutes.md) ·
+[Cross-Agent Delegation](docs/development/ai/cross-agent-delegation.md) ·
+[Command Blocking](docs/development/ai/command-blocking.md)
+
+## Documentation
+
+| Guide | |
+| :--- | :--- |
+| [Template Overview](docs/template/index.md) | What the template ships and how it fits together |
+| [New Project Setup](docs/template/new-project.md) | Creating a project, start to finish |
+| [Template Manager](docs/template/manage.md) | The `manage.py` entry point |
+| [Keeping Up to Date](docs/template/updates.md) | Pulling template changes into an existing project |
+| [Migration Guide](docs/template/migration.md) | Adopting the template in an existing project |
+| [Tools Reference](docs/template/tools-reference.md) | Every script under `tools/` |
+| [Contributing](.github/CONTRIBUTING.md) | Workflow, commit format, code style |
+| [All Documents](docs/TABLE_OF_CONTENTS.md) | Full index |
+
+## Developing the template itself
+
+This is the workflow for working on *this* repository, not on a project spawned from it.
 
 ```bash
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Clone repository
-git clone https://github.com/username/package_name.git
-cd __PACKAGE_NAME__
-
-# Create virtual environment and install dependencies
+git clone https://github.com/endavis/pyproject-template.git
+cd pyproject-template
 uv sync --all-extras --dev
-
-# Install pre-commit hooks
-doit pre_commit_install
-
-# Optional: Install direnv for automatic environment management
-# macOS:
-brew install direnv
-
-# Linux (using doit helper):
-doit install_direnv
-
-# Hook direnv into your shell (one-time setup)
-# Bash:
-echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
-source ~/.bashrc
-
-# Zsh:
-echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
-source ~/.zshrc
-
-# Allow direnv to load .envrc
-direnv allow
-
-# Optional: Create .envrc.local for personal overrides
-cp .envrc.local.example .envrc.local
+uv run pre-commit install
+doit check          # test, lint, type-check, security, spelling
 ```
 
-## Versioning & Releases
+`doit list` shows every task. `doit check` is the gate CI enforces — run it before staging.
 
-This project uses automated versioning and releases powered by `commitizen` and `hatch-vcs`.
+Contributions follow the same workflow the template ships: an issue, a branch, `doit check`, a PR
+via `doit pr`, and a human-applied `ready-to-merge` label. See
+[CONTRIBUTING](.github/CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
 
-- **Single Source of Truth:** The Git tag is the definitive version. `pyproject.toml` and `_version.py` are generated at build time from tags (no manual edits).
-- **Versioning Scheme:**
-    - **Production:** Standard SemVer (e.g., `v1.0.0`).
-    - **Development:** SemVer Pre-release (e.g., `v1.0.0-alpha.1`, `v1.0.0-beta.0`).
-
-### Migrating an Existing Project
-
-Bring your existing Python project into this template:
-
-```bash
-python tools/pyproject_template/migrate_existing_project.py --target /path/to/your/project
-```
-
-The script backs up existing files, copies template tooling/workflows/configs, and prints a summary. After running, complete the migration by configuring placeholders, moving your code, and merging dependencies.
-
-📖 See [Migration Guide](docs/template/migration.md) for the complete step-by-step checklist.
-
-### Keeping Up to Date
-
-Already using this template? Stay in sync with improvements:
-
-```bash
-python tools/pyproject_template/check_template_updates.py
-```
-
-This compares your project against the latest template and shows what's changed.
-
-📖 See [Keeping Up to Date](docs/template/updates.md) for the update workflow.
-
-### Creating a Release
-
-**Production Release (PyPI):**
-```bash
-doit release
-```
-This automated task will:
-1.  Calculate the next version based on conventional commits.
-2.  Update `CHANGELOG.md`, merging any pre-release entries (commitizen `--merge-prerelease`).
-3.  Create a git tag (e.g., `v1.0.0`).
-4.  Push commits and tags to GitHub, triggering the `release` workflow.
-
-**Development/Pre-release (TestPyPI):**
-```bash
-doit release_dev              # Defaults to alpha
-doit release_dev --type beta  # Specify type (alpha, beta, rc)
-```
-This automated task will:
-1.  Bump the version to the next pre-release (e.g., `v1.0.0-alpha.1`).
-2.  Update `CHANGELOG.md` for the prerelease.
-3.  Create a prerelease git tag (e.g., `v1.0.0-alpha.1`).
-4.  Push to GitHub, triggering the `testpypi` workflow.
-
-### Environment Variables
-
-This project uses direnv for automatic environment management. After setup:
-- `.envrc` (committed) contains project defaults and is loaded automatically
-- `.envrc.local` (git-ignored) is for personal overrides and credentials
-- Environment variables are set automatically when you enter the project directory
-- Virtual environment is activated automatically
-
-### Manual Setup (without direnv)
-
-If you prefer not to use direnv:
-
-```bash
-# Create virtual environment and activate it
-uv venv
-source .venv/bin/activate
-
-# Set environment variables manually
-export UV_CACHE_DIR="$(pwd)/tmp/.uv_cache"
-
-# Install dependencies
-uv sync --all-extras --dev
-```
-
-## Available Tasks
-
-View all available tasks:
-
-```bash
-doit list
-```
-
-### Quick Commands
-
-```bash
-# Testing
-doit test          # Run tests (parallel execution with pytest-xdist)
-doit coverage      # Run tests with coverage report
-
-# Code Quality
-doit format        # Format code with ruff
-doit lint          # Run linting
-doit type_check    # Run type checking with mypy
-doit check         # Run ALL checks (format, lint, type check, security, audit, spell, test)
-
-# Security
-doit security      # Run security scan with bandit
-doit audit         # Run dependency vulnerability audit
-doit spell_check   # Check for typos with codespell
-doit licenses      # Check licenses of dependencies
-
-# Code Formatting
-doit fmt_pyproject # Format pyproject.toml with pyproject-fmt
-
-# Version Management (Commitizen)
-doit commit        # Interactive commit with conventional format
-doit release       # Production release (commitizen-driven)
-doit release_dev   # Pre-release/TestPyPI (commitizen-driven)
-
-# Documentation
-doit docs_serve    # Serve docs locally with live reload
-doit docs_build    # Build documentation site
-doit docs_deploy   # Deploy docs to GitHub Pages
-
-# Maintenance
-doit cleanup       # Clean build artifacts and caches
-doit update_deps   # Update dependencies and run tests
-```
-
-See the [Usage Guide](docs/usage/basics.md) for comprehensive documentation of all development workflows.
-
-## Running Tests
-
-```bash
-# Run all tests (parallel execution - fast!)
-doit test
-
-# Run with coverage
-doit coverage
-
-# View coverage report
-open tmp/htmlcov/index.html
-
-# Advanced: Run specific test directly
-uv run pytest tests/test_example.py::test_version -v
-```
-
-## Code Quality
-
-This project includes comprehensive tooling:
-
-### Core Tools
-- **uv** - Fast Python package installer and dependency manager
-- **ruff** - Extremely fast Python linter and formatter
-- **mypy** - Static type checker with strict mode
-- **pytest** - Testing framework with parallel execution (pytest-xdist)
-
-### Quality & Security
-- **bandit** - Security vulnerability scanner
-- **codespell** - Spell checker for code and documentation
-- **pip-audit** - Dependency vulnerability auditor
-- **pip-licenses** - License compliance checker
-- **pre-commit** - Git hooks for automated quality checks
-- **pyproject-fmt** - Keep pyproject.toml formatted and organized
-- **commitizen** - Enforce conventional commit message standards
-
-### Documentation
-- **MkDocs** - Documentation site generator
-- **mkdocs-material** - Material Design theme for MkDocs
-
-Run all quality checks:
-
-```bash
-doit check
-```
-
-### Pre-commit Hooks
-
-Install hooks to run checks automatically before each commit:
-
-```bash
-doit pre_commit_install
-```
-
-Hooks include:
-- Code formatting (ruff)
-- Type checking (mypy)
-- Security scanning (bandit)
-- Spell checking (codespell)
-- YAML/TOML validation
-- Trailing whitespace removal
-- Private key detection
-
-## AI Agent Support
-
-This template supports **Claude Code**, **GitHub Copilot CLI**, **Codex CLI**, and **Antigravity CLI** (`agy`). All four agents ship a complete cross-agent command surface for self-action and cross-agent delegation, with slash names that differ by host: Claude uses colon separators (`/claude:plan`, `/claude:implement`); Copilot and Codex use hyphen separators (`/copilot-review`, `$codex-adversarial-review`) because their command surface is skills and skill names cannot contain colons; Antigravity activates skills by `description:` match with no prefix. The shared workflow is: `/<currentai>:plan → /<currentai>:implement → /ghi-finalize → doit pr_merge --auto-close` (substitute `-` for `:` in Copilot/Codex).
-
-### Requirements
-
-> **Important:** [GitHub CLI (`gh`)](https://cli.github.com/) is **required** for AI-assisted workflows.
->
-> Many `doit` tasks use `gh` for issue creation, PR management, and repository operations.
-> Install and authenticate before using AI agents:
-> ```bash
-> # Install (macOS)
-> brew install gh
->
-> # Install (Linux) - see https://github.com/cli/cli/blob/trunk/docs/install_linux.md
->
-> # Authenticate
-> gh auth login
-> ```
-
-### Features
-
-- **AGENTS.md** - Instructions and protocols for AI agents
-- **Dangerous command blocking** - Hooks prevent destructive operations (force push to main, branch deletion, etc.)
-- **Workflow automation** - `doit issue` and `doit pr` for GitHub operations
-
-See [AI Agent Setup](docs/development/AI_SETUP.md) and [AI Command Blocking](docs/development/ai/command-blocking.md) for details.
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run tests and checks (`doit check`)
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
-
-See [CHANGELOG.md](CHANGELOG.md) for release history.
+> **Note on `README.template.md`:** that file is the README your *spawned project* gets, complete
+> with placeholders. `configure.py` moves it into place. This page describes the template itself,
+> so the two never have to compromise on each other.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE).
 
 ## Acknowledgments
 
-- Add acknowledgments here
+Built on [uv](https://github.com/astral-sh/uv), [doit](https://pydoit.org/),
+[ruff](https://github.com/astral-sh/ruff), [mypy](https://mypy-lang.org/),
+[pytest](https://pytest.org/), and [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).

--- a/README.template.md
+++ b/README.template.md
@@ -1,0 +1,305 @@
+# __PROJECT_NAME__
+
+[![CI](https://github.com/__GH_OWNER__/__PACKAGE_NAME__/actions/workflows/ci.yml/badge.svg)](https://github.com/__GH_OWNER__/__PACKAGE_NAME__/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/__GH_OWNER__/__PACKAGE_NAME__/branch/main/graph/badge.svg)](https://codecov.io/gh/__GH_OWNER__/__PACKAGE_NAME__)
+[![PyPI version](https://badge.fury.io/py/__PYPI_NAME__.svg)](https://badge.fury.io/py/__PYPI_NAME__)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+
+__DESCRIPTION__
+
+## Features
+
+- Modern tooling: `uv` for deps, `ruff` for format/lint, `mypy` in strict mode
+- CI/CD ready: GitHub Actions for checks, coverage upload, and releases
+- Release automation: hatch-vcs + commitizen-driven tagging and changelog
+
+## Installation
+
+```bash
+pip install __PYPI_NAME__
+```
+
+## Quick Start
+
+```python
+from __PACKAGE_NAME__ import greet
+
+# Example usage
+message = greet("Python")
+print(message)  # Output: Hello, Python!
+```
+
+## Documentation
+
+📚 **Full documentation is available in the [docs/](docs/) directory**
+
+Build and view locally:
+```bash
+doit docs_serve  # Opens at http://127.0.0.1:8000
+```
+
+Key documentation files:
+- [Installation Guide](docs/getting-started/installation.md) - Setup instructions
+- [Usage Guide](docs/usage/basics.md) - Development workflows and commands
+- [API Reference](docs/reference/api.md) - Complete API documentation
+- [Extensions Guide](docs/development/extensions.md) - Optional tools and extensions
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.12+
+- [uv](https://github.com/astral-sh/uv) - Fast Python package installer
+- [direnv](https://direnv.net/) - Automatic environment variable loading (optional but recommended)
+
+### Quick Start
+
+```bash
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone repository
+git clone https://github.com/username/package_name.git
+cd __PACKAGE_NAME__
+
+# Create virtual environment and install dependencies
+uv sync --all-extras --dev
+
+# Install pre-commit hooks
+doit pre_commit_install
+
+# Optional: Install direnv for automatic environment management
+# macOS:
+brew install direnv
+
+# Linux (using doit helper):
+doit install_direnv
+
+# Hook direnv into your shell (one-time setup)
+# Bash:
+echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh:
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+source ~/.zshrc
+
+# Allow direnv to load .envrc
+direnv allow
+
+# Optional: Create .envrc.local for personal overrides
+cp .envrc.local.example .envrc.local
+```
+
+## Versioning & Releases
+
+This project uses automated versioning and releases powered by `commitizen` and `hatch-vcs`.
+
+- **Single Source of Truth:** The Git tag is the definitive version. `pyproject.toml` and `_version.py` are generated at build time from tags (no manual edits).
+- **Versioning Scheme:**
+    - **Production:** Standard SemVer (e.g., `v1.0.0`).
+    - **Development:** SemVer Pre-release (e.g., `v1.0.0-alpha.1`, `v1.0.0-beta.0`).
+
+### Creating a Release
+
+**Production Release (PyPI):**
+```bash
+doit release
+```
+This automated task will:
+1.  Calculate the next version based on conventional commits.
+2.  Update `CHANGELOG.md`, merging any pre-release entries (commitizen `--merge-prerelease`).
+3.  Create a git tag (e.g., `v1.0.0`).
+4.  Push commits and tags to GitHub, triggering the `release` workflow.
+
+**Development/Pre-release (TestPyPI):**
+```bash
+doit release_dev              # Defaults to alpha
+doit release_dev --type beta  # Specify type (alpha, beta, rc)
+```
+This automated task will:
+1.  Bump the version to the next pre-release (e.g., `v1.0.0-alpha.1`).
+2.  Update `CHANGELOG.md` for the prerelease.
+3.  Create a prerelease git tag (e.g., `v1.0.0-alpha.1`).
+4.  Push to GitHub, triggering the `testpypi` workflow.
+
+### Environment Variables
+
+This project uses direnv for automatic environment management. After setup:
+- `.envrc` (committed) contains project defaults and is loaded automatically
+- `.envrc.local` (git-ignored) is for personal overrides and credentials
+- Environment variables are set automatically when you enter the project directory
+- Virtual environment is activated automatically
+
+### Manual Setup (without direnv)
+
+If you prefer not to use direnv:
+
+```bash
+# Create virtual environment and activate it
+uv venv
+source .venv/bin/activate
+
+# Set environment variables manually
+export UV_CACHE_DIR="$(pwd)/tmp/.uv_cache"
+
+# Install dependencies
+uv sync --all-extras --dev
+```
+
+## Available Tasks
+
+View all available tasks:
+
+```bash
+doit list
+```
+
+### Quick Commands
+
+```bash
+# Testing
+doit test          # Run tests (parallel execution with pytest-xdist)
+doit coverage      # Run tests with coverage report
+
+# Code Quality
+doit format        # Format code with ruff
+doit lint          # Run linting
+doit type_check    # Run type checking with mypy
+doit check         # Run ALL checks (format, lint, type check, security, audit, spell, test)
+
+# Security
+doit security      # Run security scan with bandit
+doit audit         # Run dependency vulnerability audit
+doit spell_check   # Check for typos with codespell
+doit licenses      # Check licenses of dependencies
+
+# Code Formatting
+doit fmt_pyproject # Format pyproject.toml with pyproject-fmt
+
+# Version Management (Commitizen)
+doit commit        # Interactive commit with conventional format
+doit release       # Production release (commitizen-driven)
+doit release_dev   # Pre-release/TestPyPI (commitizen-driven)
+
+# Documentation
+doit docs_serve    # Serve docs locally with live reload
+doit docs_build    # Build documentation site
+doit docs_deploy   # Deploy docs to GitHub Pages
+
+# Maintenance
+doit cleanup       # Clean build artifacts and caches
+doit update_deps   # Update dependencies and run tests
+```
+
+See the [Usage Guide](docs/usage/basics.md) for comprehensive documentation of all development workflows.
+
+## Running Tests
+
+```bash
+# Run all tests (parallel execution - fast!)
+doit test
+
+# Run with coverage
+doit coverage
+
+# View coverage report
+open tmp/htmlcov/index.html
+
+# Advanced: Run specific test directly
+uv run pytest tests/test_example.py::test_version -v
+```
+
+## Code Quality
+
+This project includes comprehensive tooling:
+
+### Core Tools
+- **uv** - Fast Python package installer and dependency manager
+- **ruff** - Extremely fast Python linter and formatter
+- **mypy** - Static type checker with strict mode
+- **pytest** - Testing framework with parallel execution (pytest-xdist)
+
+### Quality & Security
+- **bandit** - Security vulnerability scanner
+- **codespell** - Spell checker for code and documentation
+- **pip-audit** - Dependency vulnerability auditor
+- **pip-licenses** - License compliance checker
+- **pre-commit** - Git hooks for automated quality checks
+- **pyproject-fmt** - Keep pyproject.toml formatted and organized
+- **commitizen** - Enforce conventional commit message standards
+
+### Documentation
+- **MkDocs** - Documentation site generator
+- **mkdocs-material** - Material Design theme for MkDocs
+
+Run all quality checks:
+
+```bash
+doit check
+```
+
+### Pre-commit Hooks
+
+Install hooks to run checks automatically before each commit:
+
+```bash
+doit pre_commit_install
+```
+
+Hooks include:
+- Code formatting (ruff)
+- Type checking (mypy)
+- Security scanning (bandit)
+- Spell checking (codespell)
+- YAML/TOML validation
+- Trailing whitespace removal
+- Private key detection
+
+## AI Agent Support
+
+This template supports **Claude Code**, **GitHub Copilot CLI**, **Codex CLI**, and **Antigravity CLI** (`agy`). All four agents ship a complete cross-agent command surface for self-action and cross-agent delegation, with slash names that differ by host: Claude uses colon separators (`/claude:plan`, `/claude:implement`); Copilot and Codex use hyphen separators (`/copilot-review`, `$codex-adversarial-review`) because their command surface is skills and skill names cannot contain colons; Antigravity activates skills by `description:` match with no prefix. The shared workflow is: `/<currentai>:plan → /<currentai>:implement → /ghi-finalize → doit pr_merge --auto-close` (substitute `-` for `:` in Copilot/Codex).
+
+### Requirements
+
+> **Important:** [GitHub CLI (`gh`)](https://cli.github.com/) is **required** for AI-assisted workflows.
+>
+> Many `doit` tasks use `gh` for issue creation, PR management, and repository operations.
+> Install and authenticate before using AI agents:
+> ```bash
+> # Install (macOS)
+> brew install gh
+>
+> # Install (Linux) - see https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+>
+> # Authenticate
+> gh auth login
+> ```
+
+### Features
+
+- **AGENTS.md** - Instructions and protocols for AI agents
+- **Dangerous command blocking** - Hooks prevent destructive operations (force push to main, branch deletion, etc.)
+- **Workflow automation** - `doit issue` and `doit pr` for GitHub operations
+
+See [AI Agent Setup](docs/development/AI_SETUP.md) and [AI Command Blocking](docs/development/ai/command-blocking.md) for details.
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Make your changes
+4. Run tests and checks (`doit check`)
+5. Commit your changes (`git commit -m 'Add amazing feature'`)
+6. Push to the branch (`git push origin feature/amazing-feature`)
+7. Open a Pull Request
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Acknowledgments
+
+- Add acknowledgments here

--- a/tests/template/test_cleanup.py
+++ b/tests/template/test_cleanup.py
@@ -412,74 +412,6 @@ overrides = [
 minversion = "8.0"
 """
 
-    _README_WITH_TEMPLATE_SECTIONS = """\
-# My Project
-
-Intro text.
-
-## Features
-
-- feature one
-
-## Quick Setup (Automated)
-
-Stuff about bootstrap.py.
-
-## Using This Template (Manual)
-
-Manual instructions about tools/pyproject_template/configure.py.
-
-## Development Setup
-
-Dev instructions.
-"""
-
-    _README_WITHOUT_TEMPLATE_SECTIONS = """\
-# My Project
-
-Intro text.
-
-## Features
-
-- feature one
-
-## Development Setup
-
-Dev instructions.
-"""
-
-    _README_WITH_TEMPLATE_SUBSECTIONS = """\
-# My Project
-
-Intro text.
-
-## Versioning & Releases
-
-Commitizen + hatch-vcs.
-
-### Migrating an Existing Project
-
-Bring your existing Python project into this template:
-
-```bash
-python tools/pyproject_template/migrate_existing_project.py --target /path/to/your/project
-```
-
-### Keeping Up to Date
-
-Already using this template? Stay in sync with improvements:
-
-```bash
-python tools/pyproject_template/check_template_updates.py
-```
-
-### Creating a Release
-
-```bash
-doit release
-```
-"""
-
     _DOIT_REF_WITH_TEMPLATE_CLEAN = """\
 # Doit Tasks Reference
 
@@ -671,35 +603,6 @@ git push origin v0.0.0
         assert pyproject not in changed
         assert pyproject.read_text(encoding="utf-8") == self._PYPROJECT_WITHOUT_STANZA
 
-    def test_scrubs_readme_when_sections_present(self, tmp_path: Path) -> None:
-        """Both template sections are removed; surrounding headings survive."""
-        from tools.pyproject_template.cleanup import scrub_template_references
-
-        readme = tmp_path / "README.md"
-        readme.write_text(self._README_WITH_TEMPLATE_SECTIONS, encoding="utf-8")
-
-        changed = scrub_template_references(tmp_path)
-
-        new = readme.read_text(encoding="utf-8")
-        assert "## Quick Setup (Automated)" not in new
-        assert "## Using This Template (Manual)" not in new
-        # Surrounding headings intact.
-        assert "## Features" in new
-        assert "## Development Setup" in new
-        assert readme in changed
-
-    def test_readme_noop_when_sections_absent(self, tmp_path: Path) -> None:
-        """Already-scrubbed README.md is left unchanged."""
-        from tools.pyproject_template.cleanup import scrub_template_references
-
-        readme = tmp_path / "README.md"
-        readme.write_text(self._README_WITHOUT_TEMPLATE_SECTIONS, encoding="utf-8")
-
-        changed = scrub_template_references(tmp_path)
-
-        assert readme not in changed
-        assert readme.read_text(encoding="utf-8") == self._README_WITHOUT_TEMPLATE_SECTIONS
-
     def test_scrubs_doit_reference_section_and_toc(self, tmp_path: Path) -> None:
         """doit-tasks-reference.md section removed and TOC row rewritten."""
         from tools.pyproject_template.cleanup import scrub_template_references
@@ -808,30 +711,6 @@ git push origin v0.0.0
         assert '".codex/"' in new
         assert pyproject in changed
 
-    def test_scrubs_readme_template_subsections(self, tmp_path: Path) -> None:
-        """README's ``### Migrating``/``### Keeping Up to Date`` are removed (#469 follow-up).
-
-        Both subsections point at deleted template-management scripts; the
-        preceding ``## Versioning & Releases`` heading and the following
-        ``### Creating a Release`` subsection must survive.
-        """
-        from tools.pyproject_template.cleanup import scrub_template_references
-
-        readme = tmp_path / "README.md"
-        readme.write_text(self._README_WITH_TEMPLATE_SUBSECTIONS, encoding="utf-8")
-
-        changed = scrub_template_references(tmp_path)
-
-        new = readme.read_text(encoding="utf-8")
-        assert "### Migrating an Existing Project" not in new
-        assert "### Keeping Up to Date" not in new
-        assert "migrate_existing_project.py" not in new
-        assert "check_template_updates.py" not in new
-        # Surrounding headings survive.
-        assert "## Versioning & Releases" in new
-        assert "### Creating a Release" in new
-        assert readme in changed
-
     def test_scrub_is_idempotent(self, tmp_path: Path) -> None:
         """Running the scrubber twice must change nothing on the second pass."""
         from tools.pyproject_template.cleanup import scrub_template_references
@@ -840,12 +719,6 @@ git push origin v0.0.0
         # check exercises every new pattern introduced in the #469 follow-up.
         (tmp_path / "pyproject.toml").write_text(
             self._PYPROJECT_POST_FMT_WITH_TEMPLATE_REFS, encoding="utf-8"
-        )
-        # README gets both the top-level template sections AND the subsections
-        # so the two README patterns are both exercised.
-        (tmp_path / "README.md").write_text(
-            self._README_WITH_TEMPLATE_SECTIONS + "\n" + self._README_WITH_TEMPLATE_SUBSECTIONS,
-            encoding="utf-8",
         )
         doit_ref = tmp_path / "docs" / "development" / "doit-tasks-reference.md"
         doit_ref.parent.mkdir(parents=True)

--- a/tests/template/test_readme_split.py
+++ b/tests/template/test_readme_split.py
@@ -1,0 +1,77 @@
+"""The landing-page README and the consumer README must not be confused.
+
+`README.md` is this repository's GitHub landing page. `README.template.md` is
+the README a spawned project gets; `configure.py` moves it into place before
+placeholder replacement.
+
+Before the split, one file served both purposes, so the landing page opened
+with `# __PROJECT_NAME__`, four broken badge images and `pip install
+__PYPI_NAME__` (#697). Nothing detected that, because a placeholder is only
+wrong depending on which file it is in.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LANDING = REPO_ROOT / "README.md"
+CONSUMER = REPO_ROOT / "README.template.md"
+CONFIGURE = REPO_ROOT / "tools" / "pyproject_template" / "configure.py"
+
+_PLACEHOLDER_RE = re.compile(r"__[A-Z][A-Z_]*__")
+
+
+def test_landing_page_has_no_placeholders() -> None:
+    """The repository's front page must render as finished content.
+
+    This is the whole point of the split: anyone browsing to the repository
+    sees the template described, not a half-configured project.
+    """
+    found = sorted(set(_PLACEHOLDER_RE.findall(LANDING.read_text(encoding="utf-8"))))
+    assert not found, (
+        f"README.md is the repository landing page and still contains {found}. "
+        "Consumer-facing content belongs in README.template.md."
+    )
+
+
+def test_consumer_readme_exists_and_is_a_template() -> None:
+    """`README.template.md` must exist and still carry its placeholders.
+
+    An empty placeholder set would mean the consumer README had been flattened
+    into a copy of the landing page — the failure this split exists to prevent,
+    in the opposite direction.
+    """
+    assert CONSUMER.is_file(), "README.template.md is missing; spawned projects would get no README"
+    found = set(_PLACEHOLDER_RE.findall(CONSUMER.read_text(encoding="utf-8")))
+    assert found, "README.template.md has no placeholders; it is not a template"
+    assert "__PACKAGE_NAME__" in found
+
+
+def test_configure_installs_the_consumer_readme() -> None:
+    """`configure.py` must move README.template.md over README.md.
+
+    Without this the spawned project keeps the template's landing page, which
+    describes a repository the consumer does not have.
+    """
+    source = CONFIGURE.read_text(encoding="utf-8")
+    assert 'Path("README.template.md")' in source, (
+        "configure.py no longer references README.template.md; spawned projects "
+        "would inherit the template's landing page"
+    )
+
+
+def test_landing_page_points_at_the_template_docs() -> None:
+    """The orientation material must be reachable from the front page.
+
+    #697's substantive complaint was not only the placeholders but that the
+    useful guides were several clicks away and unlinked.
+    """
+    text = LANDING.read_text(encoding="utf-8")
+    for target in (
+        "docs/template/index.md",
+        "docs/template/new-project.md",
+        "docs/development/AI_SETUP.md",
+    ):
+        assert target in text, f"landing page does not link to {target}"

--- a/tests/test_markdown_links.py
+++ b/tests/test_markdown_links.py
@@ -27,7 +27,7 @@ DOCS_DIR = REPO_ROOT / "docs"
 # Root-level files matter as much as `docs/`: README.md and
 # .github/CONTRIBUTING.md are the first thing a new contributor opens, and
 # their links were broken for as long as nothing checked them (#686).
-_ROOT_MARKDOWN = ("README.md", "AGENTS.md", "CHANGELOG.md")
+_ROOT_MARKDOWN = ("README.md", "README.template.md", "AGENTS.md", "CHANGELOG.md")
 _GITHUB_MARKDOWN_DIR = REPO_ROOT / ".github"
 
 # Markdown inline links: [text](target). Reference-style and bare autolinks are

--- a/tools/doit/docs.py
+++ b/tools/doit/docs.py
@@ -40,7 +40,10 @@ def task_spell_check() -> dict[str, Any]:
     return {
         "actions": [
             "uv run codespell src/ tests/ tools/ docs/"
-            + optional_root_files("bootstrap.py")
+            # README.template.md is the consumer README; `configure` moves it
+            # over README.md, so it is absent in spawned projects -- hence the
+            # optional helper rather than a literal path.
+            + optional_root_files("bootstrap.py", "README.template.md")
             + " README.md"
         ],
         "title": title_with_actions,

--- a/tools/pyproject_template/cleanup.py
+++ b/tools/pyproject_template/cleanup.py
@@ -242,26 +242,6 @@ _PYPROJECT_TEMPLATE_MYPY_EXCLUDE_ENTRY_RE = re.compile(
     r'"tools/pyproject_template/",\s*',
 )
 
-# README.md block containing both template-only top-level setup sections.
-# Starts at ``## Quick Setup (Automated)`` and runs up to (but not including)
-# the next top-level heading ``## Development Setup``. The non-greedy body
-# match plus explicit terminator keeps the scrubber from devouring unrelated
-# sections if the consumer has reshuffled headings.
-_README_TEMPLATE_SECTIONS_RE = re.compile(
-    r"## Quick Setup \(Automated\)\n.*?(?=## Development Setup\b)",
-    re.DOTALL,
-)
-
-# README.md ``### Migrating an Existing Project`` and ``### Keeping Up to
-# Date`` subsections (under ``## Versioning & Releases``). Both reference
-# template-management scripts that no longer exist in the consumer project
-# (``migrate_existing_project.py`` and ``check_template_updates.py``). The
-# terminator ``### Creating a Release`` is the next subsection that stays.
-_README_TEMPLATE_SUBSECTIONS_RE = re.compile(
-    r"### Migrating an Existing Project\n.*?(?=### Creating a Release\b)",
-    re.DOTALL,
-)
-
 # doit-tasks-reference.md ``### template_clean`` section. Runs from the heading
 # up to (but not including) the next ``### build`` heading. The non-greedy body
 # match guards against consuming adjacent sections.
@@ -341,13 +321,14 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
       entry (and its explanatory comment), and the mypy override (in both
       stanza and inline-array form, because ``doit fmt_pyproject`` rewrites
       the file before cleanup runs in the wizard).
-    * ``README.md`` — removes the ``## Quick Setup (Automated)`` and
-      ``## Using This Template (Manual)`` top-level sections plus the
-      ``### Migrating an Existing Project`` and ``### Keeping Up to Date``
-      subsections of ``## Versioning & Releases``.
     * ``docs/development/doit-tasks-reference.md`` — removes the
       ``### template_clean`` section and rewrites the TOC table row so the
       remaining ``cleanup`` entry is listed alone.
+
+    ``README.md`` is deliberately absent from this list. It used to be scrubbed
+    of template-only sections here; since #697 the consumer README ships
+    separately as ``README.template.md``, which ``configure`` moves into place
+    and which never contained those sections.
     * ``docs/development/github-repository-settings.md`` — strips the
       broken-link sentence in the intro paragraph that points at
       ``tools/pyproject_template/repo_settings.py``, and removes the
@@ -402,23 +383,7 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
                 Logger.success("Removed template-only references from pyproject.toml")
             changed.append(pyproject)
 
-    # 2. README.md — scrub both top-level template sections and the two
-    #    template-management subsections under "Versioning & Releases".
-    readme = root / "README.md"
-    if readme.is_file():
-        original = readme.read_text(encoding="utf-8")
-        new_content = original
-        new_content = _README_TEMPLATE_SECTIONS_RE.sub("", new_content)
-        new_content = _README_TEMPLATE_SUBSECTIONS_RE.sub("", new_content)
-        if new_content != original:
-            if dry_run:
-                Logger.info("Would scrub template-only sections in README.md")
-            else:
-                readme.write_text(new_content, encoding="utf-8")
-                Logger.success("Removed template-only sections from README.md")
-            changed.append(readme)
-
-    # 3. docs/development/doit-tasks-reference.md — remove the template_clean
+    # 2. docs/development/doit-tasks-reference.md — remove the template_clean
     #    section and rewrite the TOC row.
     doit_ref = root / "docs" / "development" / "doit-tasks-reference.md"
     if doit_ref.is_file():
@@ -440,7 +405,7 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
                 )
             changed.append(doit_ref)
 
-    # 4. docs/development/github-repository-settings.md — strip the broken
+    # 3. docs/development/github-repository-settings.md — strip the broken
     #    intro-link sentence and the Security Settings introductory paragraph.
     github_settings = root / "docs" / "development" / "github-repository-settings.md"
     if github_settings.is_file():
@@ -462,7 +427,7 @@ def scrub_template_references(root: Path | None = None, dry_run: bool = False) -
                 )
             changed.append(github_settings)
 
-    # 5. docs/development/release-and-automation.md — rewrite the "New
+    # 4. docs/development/release-and-automation.md — rewrite the "New
     #    projects (bootstrap flow)" paragraph so the broken configure.py link
     #    is gone but the surrounding instruction and code block survive.
     release_auto = root / "docs" / "development" / "release-and-automation.md"

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -385,6 +385,19 @@ def run_configure(
         # variables (e.g. in extensions.md)
     }
 
+    # Install the consumer README before placeholder replacement.
+    #
+    # README.md in the template is the repository's landing page: it describes
+    # the template itself and carries working badges, so browsing the repo does
+    # not show a placeholder title and four broken badge images (#697).
+    # README.template.md is the README the spawned project actually wants.
+    # Moving it into place here means it is then picked up by the
+    # FILES_TO_UPDATE pass below like any other file.
+    consumer_readme = Path("README.template.md")
+    if consumer_readme.exists():
+        print("  ✓ Installing README.template.md as README.md")
+        consumer_readme.replace(Path("README.md"))
+
     # Update files (using shared constant from utils.py)
     for file_path in FILES_TO_UPDATE:
         path = Path(file_path)


### PR DESCRIPTION
## Description

`README.md` was the *spawned project's* README, and it is also the repository's landing page. So
anyone browsing to `github.com/endavis/pyproject-template` saw:

```markdown
# __PROJECT_NAME__

[![CI](https://github.com/__GH_OWNER__/__PACKAGE_NAME__/...)]   ← four broken badges

__DESCRIPTION__

## Installation
pip install __PYPI_NAME__
```

A placeholder title, four broken badge images, and install instructions for a package that does not
exist — with the genuinely useful orientation material several clicks away and unlinked.

The design constraint noted in #697 is real: the file has to become the consumer's README after
`configure` runs. This splits the two roles rather than compromising between them.

## Related Issue

Addresses #697

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

- **`README.md`** is now the template's landing page: working badges, what the project actually
  ships (50 `doit` tasks, 17 ADRs, four agent CLIs, the enforced workflow), the bootstrap
  instructions, and links to all six `docs/template/` guides plus the AI docs.
- **`README.template.md`** (new) is the consumer README. It was produced by applying `cleanup.py`'s
  **own scrub regexes** to the previous README, so it is byte-for-byte what cleanup used to
  generate — 305 lines, 79 fewer than before.
- **`configure.py`** installs it over `README.md` *before* the placeholder pass, so
  `FILES_TO_UPDATE` picks it up unchanged and needs no edit.
- **`cleanup.py`** drops both README scrub regexes and the step that ran them.
- **codespell and the markdown link test** extended to the new file. codespell goes through
  `optional_root_files`, so it is skipped in spawned projects where `configure` has already
  consumed it.

### Why the cleanup scrub had to go

Once the consumer README ships pre-stripped, the regexes match nothing — but leaving them would be
worse than dead code. The new landing page legitimately contains `## Quick Setup (Automated)` and
`## Using This Template (Manual)`; a future edit adding a `## Development Setup` heading would give
the scrubber a terminator and let it silently eat the middle of the landing page.

## Tests removed, deliberately

Three tests in `tests/template/test_cleanup.py` covered the scrub:

| Test | Before | Why removed |
| :--- | :--- | :--- |
| `test_scrubs_readme_when_sections_present` | failed | asserts removed behaviour |
| `test_scrubs_readme_template_subsections` | failed | asserts removed behaviour |
| `test_readme_noop_when_sections_absent` | **passed** | now vacuous — nothing can change the README |

These are not failures that were silenced: the capability they protect is intentionally gone. The
third is worth calling out — it still passed, but could no longer fail, so keeping it would have
been decorative. Their fixtures were removed too, and the idempotency test no longer writes a
README it has no reason to.

Total: **1342 → 1339**, exactly those three.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green.

**End-to-end simulation** of the new configure ordering, in a temp directory:

```
after install, README.md starts: # __PROJECT_NAME__
placeholders available: ['__DESCRIPTION__','__GH_OWNER__','__PACKAGE_NAME__','__PROJECT_NAME__','__PYPI_NAME__']
after replacement, leftover placeholders: []
first line: # My Project
README.template.md still present: False
```

Install → replace → clean consumer README, with the template file consumed rather than left behind.

**Guard verified:** appending `__PROJECT_NAME__` to the landing page fails
`test_landing_page_has_no_placeholders`.

`tests/template/test_readme_split.py` checks four properties — the landing page has no
placeholders, the consumer README exists *and still has them* (catching the split collapsing in
either direction), `configure.py` still installs it, and the landing page still links the
orientation docs, which was #697's other substantive complaint.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**The landing page figures are measured, not asserted** — 50 tasks from `doit list`, 17 ADRs from
`docs/decisions/`, four agent CLIs after #712 removed Gemini. #697 quoted "5 agent integrations,
1,079 tests" from before those changes.

**`cleanup.py`'s docstring** now records *why* README is absent from its scrub list, so the next
reader does not treat the omission as an oversight and add it back.
