### PR TITLE
feat: add secret-exposure controls that reach every agent

### DIFF
--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -315,6 +315,55 @@ HOOK_BLOCKCOMMAND_DEBUG=1 agy -p 'run: git status' --add-dir "$(git rev-parse --
 cat tools/hooks/ai/hook-debug.jsonl   # a new line means the hook ran
 ```
 
+### Secret exposure
+
+Two different controls, because only one CLI can do the stronger one.
+
+#### Environment allowlists — Codex only
+
+`.codex/config.toml` strips secret-shaped variables from the child environment before a command
+runs:
+
+```toml
+[shell_environment_policy]
+inherit = "core"
+include_only = ["PATH", "HOME", "USER", "UV_CACHE_DIR", "VIRTUAL_ENV", "PYTHONPATH"]
+exclude = ["*_API_KEY", "*_SECRET", "*_TOKEN", "PASSWORD", "PYPI_TOKEN", "CODECOV_TOKEN"]
+```
+
+**The other three agents have no native environment allowlist.** This was checked against each CLI
+rather than assumed:
+
+| Agent | Mechanism | Coverage |
+| :--- | :--- | :--- |
+| Codex | `[shell_environment_policy]` — `include_only` + `exclude` | Secrets removed from the child environment |
+| Claude | `permissions` supports `allow` / `ask` / `deny` / `additionalDirectories` / `defaultMode` only | **No native environment allowlist** — hook only |
+| Copilot | `--deny-tool` is tool-level; `--bash-env` *enables* `BASH_ENV` rather than restricting it | **No native environment allowlist** — hook only |
+| Antigravity | no environment options | **No native environment allowlist** — hook only |
+
+`SECRET_ENV_PATTERNS` in `block-dangerous-commands.py` is the single source of truth for the
+pattern list; `.codex/config.toml`'s `exclude` must match it, and
+`tests/template/test_secret_env_policy.py` fails if the two drift.
+
+#### Environment dumps and credential stores — all four agents
+
+Since three of four cannot restrict the environment, the shared hook carries the part that reaches
+everyone:
+
+| Command | Outcome |
+| :--- | :--- |
+| `env`, `printenv` (no command following) | **Blocked** — prints the whole environment |
+| `printenv PYPI_TOKEN` | **Blocked** — secret-named variable |
+| `printenv PATH` | Allowed — not secret-shaped |
+| `env -u FORCE_COLOR doit check`, `env VAR=1 make` | Allowed — an *invocation*, not a dump |
+| `cat ~/.pypirc`, `~/.netrc`, `~/.aws/credentials`, `~/.docker/config.json`, `gh/hosts.yml` | **Blocked** — credential stores |
+
+**What this is and is not.** It reduces *accidental* exposure — a secret dumped into a transcript
+that is then pasted into an issue, or read by a later summarisation step. It is not a boundary
+against a determined agent, which has many other routes to the same value. `$VAR` interpolation is
+deliberately **not** blocked: legitimate uses are common, and blocking it would give false
+assurance while being trivially avoided.
+
 ### Failure Behaviour
 
 The hook uses two deny contracts, and they diverge on *failure*:

--- a/tests/template/test_secret_env_policy.py
+++ b/tests/template/test_secret_env_policy.py
@@ -1,0 +1,105 @@
+"""The secret-pattern list must exist once, and be enforced where it can be.
+
+Only Codex has a native environment allowlist (`[shell_environment_policy]`).
+Claude, Copilot and Antigravity have no equivalent setting — verified against
+each CLI, see `docs/development/ai/command-blocking.md` (#682).
+
+That leaves two enforcement points, and they must not drift:
+
+* `.codex/config.toml` removes secret-shaped variables from the child
+  environment outright.
+* The shared PreToolUse hook — the only control that reaches all four agents —
+  blocks environment dumps and credential-store reads.
+
+`SECRET_ENV_PATTERNS` in the hook is the single source of truth; these tests
+hold the Codex config to it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import tomllib
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / "tools" / "hooks" / "ai" / "block-dangerous-commands.py"
+CODEX_CONFIG = REPO_ROOT / ".codex" / "config.toml"
+
+
+def _hook() -> types.ModuleType:
+    """Load the hook module (its filename has hyphens, so import by path)."""
+    spec = importlib.util.spec_from_file_location("block_dangerous_commands", HOOK_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"could not load hook from {HOOK_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_codex_exclude_list_matches_the_hook_patterns() -> None:
+    """The one CLI that can enforce natively must use the shared list.
+
+    Two copies of a secret-pattern list drift silently: the config would keep
+    excluding yesterday's variable names while the hook checked today's.
+    """
+    with CODEX_CONFIG.open("rb") as fh:
+        policy = tomllib.load(fh)["shell_environment_policy"]
+
+    assert tuple(policy["exclude"]) == _hook().SECRET_ENV_PATTERNS, (
+        "`.codex/config.toml` exclude list has drifted from SECRET_ENV_PATTERNS; "
+        "the hook is the single source of truth"
+    )
+
+
+def test_codex_still_restricts_the_inherited_environment() -> None:
+    """The allowlist is the stronger half of Codex's control; keep it."""
+    with CODEX_CONFIG.open("rb") as fh:
+        policy = tomllib.load(fh)["shell_environment_policy"]
+
+    assert policy["inherit"] == "core"
+    assert "PATH" in policy["include_only"]
+    # An allowlist that grew to include a secret-shaped name would defeat itself.
+    hook = _hook()
+    leaked = [name for name in policy["include_only"] if hook._is_secret_name(name)]
+    assert not leaked, f"include_only lets secret-shaped vars through: {leaked}"
+
+
+def test_patterns_are_declared_once() -> None:
+    """No second literal copy of the pattern list anywhere in the tree.
+
+    Written as a search rather than a review note because the failure mode is a
+    well-meaning copy-paste into another agent's config.
+    """
+    hook_source = HOOK_PATH.read_text(encoding="utf-8")
+    # The tuple literal should appear exactly once: its definition.
+    assert hook_source.count('"CODECOV_TOKEN",') == 1
+
+    strays = []
+    for path in REPO_ROOT.rglob("*"):
+        if not path.is_file() or path in (HOOK_PATH, CODEX_CONFIG, Path(__file__)):
+            continue
+        if any(part in {".git", "site", "tmp", ".venv", "__pycache__"} for part in path.parts):
+            continue
+        if path.suffix not in {".py", ".toml", ".json", ".yaml", ".yml"}:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if '"*_API_KEY"' in text and '"*_SECRET"' in text:
+            strays.append(str(path.relative_to(REPO_ROOT)))
+    assert not strays, f"secret patterns are duplicated in: {strays}"
+
+
+def test_documentation_records_per_agent_coverage() -> None:
+    """The docs must say which agents are covered by what.
+
+    #682's point was that silence about the gap is worse than the gap: a reader
+    should not have to diff four configs to learn Claude has no env allowlist.
+    """
+    doc = (REPO_ROOT / "docs" / "development" / "ai" / "command-blocking.md").read_text(
+        encoding="utf-8"
+    )
+    assert "shell_environment_policy" in doc
+    assert re.search(r"no native environment allowlist", doc, re.I), (
+        "command-blocking.md must state which agents cannot restrict the environment"
+    )

--- a/tests/test_hook_dangerous_command_matrix.py
+++ b/tests/test_hook_dangerous_command_matrix.py
@@ -1089,3 +1089,61 @@ def test_codex_shell_tool_uses_the_default_schema() -> None:
     `^Bash$` matcher in `.codex/config.toml` rests on.
     """
     assert "Bash" in _load_hook()._BASH_TOOL_NAMES
+
+
+# --- Secret exposure cases (issue #682) ------------------------------------
+#
+# Only Codex can strip secrets from the child environment; Claude, Copilot and
+# Antigravity have no such setting, so the shared hook carries the part that
+# reaches all four: environment dumps and credential-store reads.
+#
+# Two distinctions are load-bearing, and both were found by the control firing
+# on this repository's own workflow within minutes of being written:
+#
+#   * invocation vs dump -- `env -u VAR cmd` is used constantly here
+#   * running vs mentioning -- a heredoc body tokenizes exactly like an
+#     argument list, so a scan over every token treats test fixtures and
+#     documentation as invocations
+#
+# The last two cases pin the second distinction directly.
+
+SECRET_EXPOSURE_CASES: list[tuple[str, str, str]] = [
+    ("env", "BLOCK", "bare env dumps the environment"),
+    ("printenv", "BLOCK", "bare printenv dumps the environment"),
+    ("printenv PYPI_TOKEN", "BLOCK", "printenv of a secret-named var"),
+    ("printenv MY_API_KEY", "BLOCK", "printenv matching the *_API_KEY pattern"),
+    ("printenv PATH", "ALLOW", "printenv of a non-secret var"),
+    ("env -u FORCE_COLOR doit check", "ALLOW", "env -u is an invocation not a dump"),
+    ("env VAR=1 make", "ALLOW", "env with assignment is an invocation"),
+    ("env -i PATH=/usr/bin sh -c true", "ALLOW", "env -i is an invocation"),
+    ("git status && env", "BLOCK", "env dump after a shell separator"),
+    ("cat ~/.pypirc", "BLOCK", "reads the PyPI credential store"),
+    ("cat ~/.aws/credentials", "BLOCK", "reads AWS credentials"),
+    ("cp ~/.docker/config.json /tmp/x", "BLOCK", "copies the docker credential store"),
+    ("cat credentials", "ALLOW", "a bare 'credentials' file outside .aws"),
+    ("grep -rn pypirc docs/", "ALLOW", "searching for the name is not reading the file"),
+    ("cat README.md", "ALLOW", "an ordinary file read"),
+    ("python3 - <<EOF\nprintenv PYPI_TOKEN\nEOF", "ALLOW", "heredoc mentioning a dump"),
+    ("cat >> notes.md <<EOF\ncat ~/.netrc\nEOF", "ALLOW", "heredoc mentioning a credential path"),
+    # Deliberately NOT blocked -- see docs/development/ai/command-blocking.md.
+    # Blocking $VAR interpolation gives false assurance while being trivially
+    # avoided, and legitimate uses are common.
+    ("echo $PYPI_TOKEN", "ALLOW", "var interpolation is deliberately not blocked"),
+]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected", "description"),
+    SECRET_EXPOSURE_CASES,
+    ids=_ids(SECRET_EXPOSURE_CASES, 2),
+)
+def test_secret_exposure(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    expected: str,
+    description: str,
+) -> None:
+    """Environment dumps and credential reads are blocked for every agent."""
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+    assert _outcome_exit_code(hook, monkeypatch, payload) == expected, description

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -16,6 +16,7 @@ Exit codes:
 For full documentation, see: docs/development/ai/command-blocking.md
 """
 
+import fnmatch
 import json
 import os
 import re
@@ -69,6 +70,70 @@ GOVERNANCE_LABELS = {
         "or set ALLOW_AI_READY_TO_MERGE=1 in the shell before launching the AI CLI."
     ),
 }
+
+# Secret-shaped environment variable names. THIS IS THE SINGLE SOURCE OF TRUTH:
+# `.codex/config.toml`'s `[shell_environment_policy] exclude` list must match it,
+# and tests/template/test_secret_env_policy.py asserts the two agree so the
+# patterns cannot drift between the hook and the one CLI that can enforce them
+# natively (#682).
+SECRET_ENV_PATTERNS: tuple[str, ...] = (
+    "*_API_KEY",
+    "*_SECRET",
+    "*_TOKEN",
+    "PASSWORD",
+    "PYPI_TOKEN",
+    "CODECOV_TOKEN",
+)
+
+# Credential stores. Reading one dumps live secrets into the transcript, which
+# is the accidental-exposure case this guards; a determined agent has other
+# routes, so this is a guardrail rather than a boundary.
+CREDENTIAL_FILE_BASENAMES: dict[str, str] = {
+    ".pypirc": "",
+    ".netrc": "",
+    "credentials": ".aws",
+    "hosts.yml": "gh",
+    "config.json": ".docker",
+}
+
+# Commands that read a file's contents. The credential check is anchored on
+# these rather than scanning every token, so a file that merely *mentions* a
+# credential path is not mistaken for one that reads it.
+_CREDENTIAL_READER_COMMANDS = frozenset(
+    {
+        "cat",
+        "bat",
+        "less",
+        "more",
+        "head",
+        "tail",
+        "strings",
+        "xxd",
+        "od",
+        "base64",
+        "cp",
+        "mv",
+        "scp",
+        "rsync",
+        "install",
+        "openssl",
+        "shasum",
+    }
+)
+
+# Tokens that end one command's argument list. Output redirection is included
+# because it flips the reader into a writer: `cat >> file <<EOF` streams a
+# heredoc *into* a file, and the body must not be scanned as if it were
+# arguments. Input redirection is deliberately absent so `cat < ~/.netrc`
+# is still caught.
+_SHELL_OPERATORS = frozenset({"&&", "||", ";", "|", "&", ">", ">>", "1>", "2>", "&>"})
+
+# Commands that print the whole environment when given no command to run.
+_ENV_DUMP_COMMANDS = frozenset({"env", "printenv"})
+
+# `env` options that consume a following token, so the scan can tell an
+# invocation (`env -u FOO cmd`) from a dump (`env`).
+_ENV_OPTS_WITH_VALUE = frozenset({"-u", "--unset"})
 
 # Env var name the human can set to allow AI to apply ready-to-merge
 ALLOW_AI_READY_TO_MERGE_VAR = "ALLOW_AI_READY_TO_MERGE"
@@ -780,6 +845,112 @@ def check_merge_to_protected(tokens: list[str]) -> tuple[bool, str]:
     return False, ""
 
 
+def _command_start_indices(tokens: list[str]) -> list[int]:
+    """Return the indices at which a command begins.
+
+    A command starts at position 0 and after any shell separator. Anchoring on
+    these is what separates *running* a command from merely *mentioning* it:
+    a heredoc body tokenizes exactly like an argument list, so a scan over all
+    positions treats documentation and test fixtures as invocations. Both
+    checks below hit that while this repository's own tests were being written.
+    """
+    starts = [0]
+    for index, token in enumerate(tokens):
+        if token in _SHELL_OPERATORS and index + 1 < len(tokens):
+            starts.append(index + 1)
+    return starts
+
+
+def _is_secret_name(name: str) -> bool:
+    """Return True when *name* matches one of SECRET_ENV_PATTERNS."""
+    return any(fnmatch.fnmatchcase(name.upper(), pattern) for pattern in SECRET_ENV_PATTERNS)
+
+
+def check_env_dump(tokens: list[str]) -> tuple[bool, str]:
+    """Block commands that print the environment, or a secret-named variable.
+
+    Distinguishes a *dump* from an *invocation*: ``env`` with no trailing
+    command prints everything, while ``env -u FOO cmd`` and ``env VAR=1 cmd``
+    merely run ``cmd`` with a modified environment and are left alone.
+    """
+    for index in _command_start_indices(tokens):
+        if index >= len(tokens) or tokens[index] not in _ENV_DUMP_COMMANDS:
+            continue
+        token = tokens[index]
+        # Stop at the next separator: later tokens belong to another command.
+        rest = []
+        for candidate in tokens[index + 1 :]:
+            if candidate in _SHELL_OPERATORS:
+                break
+            rest.append(candidate)
+
+        # nosec B105 - bandit's hardcoded-password heuristic fires on this
+        # string comparison; the literal is a shell command name.
+        if token == "printenv":  # nosec B105
+            # `printenv` alone dumps everything; `printenv NAME` prints one.
+            if not rest:
+                return True, "Prints the entire environment, which may contain secrets"
+            if any(_is_secret_name(arg) for arg in rest if not arg.startswith("-")):
+                return True, "Prints a secret-named environment variable"
+            continue
+
+        # `env`: walk past its own options and assignments looking for a command.
+        position = 0
+        while position < len(rest):
+            argument = rest[position]
+            if argument in _ENV_OPTS_WITH_VALUE:
+                position += 2
+                continue
+            if argument.startswith("-") or "=" in argument:
+                position += 1
+                continue
+            break  # a command follows, so this is an invocation
+        else:
+            return True, "Prints the entire environment, which may contain secrets"
+
+        if position >= len(rest):
+            return True, "Prints the entire environment, which may contain secrets"
+
+    return False, ""
+
+
+def _is_credential_store(token: str) -> bool:
+    """Return True when *token* names a known credential store."""
+    if not token or token.startswith("-"):
+        return False
+    try:
+        path = Path(token).expanduser()
+    except (ValueError, RuntimeError):
+        return False
+    required_parent = CREDENTIAL_FILE_BASENAMES.get(path.name)
+    if required_parent is None:
+        return False
+    return not required_parent or required_parent in path.parent.as_posix()
+
+
+def check_credential_file_read(tokens: list[str]) -> tuple[bool, str]:
+    """Block a reader command pointed at a known credential store.
+
+    Anchored on the reading command rather than scanning every token. A bare
+    scan flagged any command whose text merely *contained* a credential path --
+    writing this project's own test data tripped it immediately -- because
+    heredoc bodies and file contents tokenize like arguments. Requiring a
+    reader in command position keeps `cat ~/.netrc` blocked while leaving
+    prose, test fixtures and documentation alone.
+    """
+    for index in _command_start_indices(tokens):
+        if index >= len(tokens) or tokens[index] not in _CREDENTIAL_READER_COMMANDS:
+            continue
+        for argument in tokens[index + 1 :]:
+            # Stop at a shell operator: later tokens belong to another command,
+            # which gets its own turn through this loop.
+            if argument in _SHELL_OPERATORS:
+                break
+            if _is_credential_store(argument):
+                return True, (f"Reads the credential store '{argument}', which holds live secrets")
+    return False, ""
+
+
 def check_command(command: str, _depth: int = 0) -> tuple[bool, str]:
     """
     Check if command contains dangerous patterns.
@@ -807,6 +978,15 @@ def check_command(command: str, _depth: int = 0) -> tuple[bool, str]:
 
     # Check for dangerous sequences
     is_dangerous, reason = check_dangerous_sequences(tokens)
+    if is_dangerous:
+        return True, reason
+
+    # Check for environment dumps and credential-store reads
+    is_dangerous, reason = check_env_dump(tokens)
+    if is_dangerous:
+        return True, reason
+
+    is_dangerous, reason = check_credential_file_read(tokens)
     if is_dangerous:
         return True, reason
 


### PR DESCRIPTION
## Description

`.codex/config.toml` was the only agent config with a secret-exfiltration control. #682 proposed
propagating it to the others "using each CLI's native mechanism".

**Those mechanisms do not exist.** Checked against each CLI rather than assumed:

| Agent | What it actually supports | Env restriction |
| :--- | :--- | :--- |
| Codex | `[shell_environment_policy]` — `include_only` + `exclude` | **Yes** |
| Claude | `permissions`: `allow` / `ask` / `deny` / `additionalDirectories` / `defaultMode` | **No native environment allowlist** |
| Copilot | `--deny-tool` is tool-level; `--bash-env` *enables* `BASH_ENV` rather than restricting it | **No native environment allowlist** |
| Antigravity | no environment options | **No native environment allowlist** |

(Gemini is no longer in this table — removed in #712.)

So this does what the issue's own fallback prescribes — documents the gap explicitly — and adds the
one control that *does* reach all four agents.

## Related Issue

Addresses #682

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## The shared hook had no secret awareness at all

Before this change, for **every** agent:

```
printenv          ALLOWED
env               ALLOWED
cat ~/.pypirc     ALLOWED
```

The hook now blocks environment **dumps** and credential-store reads, so the three agents that
cannot restrict their environment natively still get a floor.

| Command | Outcome |
| :--- | :--- |
| `env`, `printenv` (no command following) | **Blocked** |
| `printenv PYPI_TOKEN`, `printenv MY_API_KEY` | **Blocked** |
| `printenv PATH` | Allowed |
| `env -u FORCE_COLOR doit check`, `env VAR=1 make` | Allowed — invocation, not dump |
| `cat ~/.pypirc`, `~/.netrc`, `~/.aws/credentials`, `~/.docker/config.json`, `gh/hosts.yml` | **Blocked** |
| `grep -rn pypirc docs/`, `cat README.md` | Allowed |

## The control caught this repository's own workflow, twice

Both while the change was being written, and both improved the design:

1. **`cat >> file <<EOF` whose heredoc contained `~/.netrc` as test data** was blocked. Writing the
   test fixtures for this feature tripped the feature.
2. Fixing that by anchoring on reader commands exposed **the same latent flaw in the env check**: a
   heredoc containing `printenv PYPI_TOKEN` as a case was read as an invocation.

The general fix is that **both checks are anchored to command position** — position 0 or after a
shell separator. A heredoc body tokenizes exactly like an argument list, so scanning every token
treats documentation and fixtures as commands. Two matrix cases pin that distinction directly:

```python
("python3 - <<EOF\nprintenv PYPI_TOKEN\nEOF", "ALLOW", "heredoc mentioning a dump"),
("cat >> notes.md <<EOF\ncat ~/.netrc\nEOF",  "ALLOW", "heredoc mentioning a credential path"),
```

`env -u FORCE_COLOR doit check` staying allowed is the canary that matters most — this repository's
own tooling uses it constantly, so a regression there is immediate and obvious.

## Changes Made

- `SECRET_ENV_PATTERNS` in the hook is the **single source of truth**; `.codex/config.toml`'s
  `exclude` list must match it.
- `check_env_dump` and `check_credential_file_read`, both anchored to command position.
- Per-agent coverage table in `docs/development/ai/command-blocking.md`, stating plainly which
  agents cannot restrict the environment.
- `tests/template/test_secret_env_policy.py` — 4 tests: the Codex list matches the hook's, the
  allowlist does not itself leak a secret-shaped name, the patterns are not duplicated anywhere
  else in the tree, and the docs record per-agent coverage.
- 18 new matrix cases (163 total).

### Deliberately not blocked

Variable interpolation — `echo $PYPI_TOKEN` — stays allowed, and there is a matrix case asserting
so. Legitimate uses are common, and blocking it would give false assurance while being trivially
avoided.

**What this is:** a guardrail against *accidental* exposure — a secret dumped into a transcript
that later gets pasted into an issue or read by a summarisation step. **What it is not:** a
boundary against a determined agent, which has many other routes to the same value. That framing is
in the docs rather than implied.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` green. 163 matrix tests, 4 policy tests.

Verified in both directions, including the two false positives above and the `cat < ~/.netrc` case
(input redirection is deliberately *not* a stop token, so that read is still caught while
`cat >> file <<EOF` is not).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings

CHANGELOG unchecked: `CHANGELOG.md` is commitizen-generated at release
(`update_changelog_on_bump = true`) and is not hand-edited per PR.

## Additional Notes

**One suppression.** Bandit's B105 hardcoded-password heuristic fires on `token == "printenv"`.
It is a comparison against a shell command name, so it carries `# nosec B105` with that reason
inline rather than being silenced globally.

**Success criteria mapping:** each of the four configs now either restricts the environment (Codex)
or documents why it cannot (the other three); the pattern list has one home; `command-blocking.md`
states per-agent coverage; and a test asserts the patterns are present where they can be enforced.
