### PR TITLE
fix: keep the tests a spawned project's coverage gate depends on

### DIFF
--- a/docs/template/new-project.md
+++ b/docs/template/new-project.md
@@ -194,7 +194,27 @@ source ~/.bashrc   # For Bash
 source ~/.zshrc    # For Zsh
 ```
 
-### Step 4: Verify Setup
+### Step 4: Remove the Template Management Suite
+
+The automated setup does this for you; the manual route has to be told:
+
+```bash
+uv run doit template_clean --all
+```
+
+This deletes `tools/pyproject_template/`, `docs/template/` and `bootstrap.py` —
+the template's own management code, which your project does not use. Keeping it
+also leaves your coverage gate measuring several thousand statements of tooling
+whose tests are template-owned and were shed during configuration, which puts a
+fresh project under `fail_under` on its first CI run.
+
+To reinstall the template-sync suite later:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3 - --sync
+```
+
+### Step 5: Verify Setup
 
 ```bash
 # Run all checks
@@ -208,7 +228,7 @@ doit check
 # ✓ All checks passed!
 ```
 
-### Step 5: Configure GitHub Repository
+### Step 6: Configure GitHub Repository
 
 Manually configure what the automated setup does automatically:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,16 +184,24 @@ branch = true
 # project deletes. See docs/development/ci-cd-testing.md for the downstream/template
 # split.
 source = ["package_name", "tools"]
+# tools/pyproject_template/ is the template's own management suite. It is the
+# one part of tools/ that does not belong to the spawned project: ADR-9017 makes
+# its tests template-owned, and both spawn routes delete the suite itself. Left
+# in scope it is measured downstream but never tested there, which put a spawned
+# project 19 points under the gate (#731). Its tests still run in template CI.
+omit = ["tools/pyproject_template/*"]
 
 [tool.coverage.report]
 skip_covered = false
 show_missing = true
 precision = 2
-# Measured over package_name + tools/. Currently 58.29% here, and 62.98% in a
-# downstream project once `cleanup` sheds tools/pyproject_template/, so the same
-# gate holds in both shapes. Ratchet upward as tooling coverage improves (there
-# is ~4pp of headroom now, tracked in #708); treat lowering it as a change that
-# needs justification.
+# Measured over package_name + tools/doit + tools/hooks — code that ships to and
+# runs in the spawned project. Scope is deliberately shape-independent: the same
+# code is measured by the same tests in the template and in a spawned project, so
+# both report 64.34% and one threshold is honest in both. Before #731 the two
+# shapes read 59.16% and 33.98%, and only the first was ever measured.
+# Ratchet upward as tooling coverage improves (~10pp of headroom now, tracked in
+# #708); treat lowering it as a change that needs justification.
 fail_under = 54
 exclude_lines = [
     "pragma: no cover",

--- a/tests/template/test_ai_agent_assets.py
+++ b/tests/template/test_ai_agent_assets.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -276,8 +278,15 @@ def test_multi_orchestrators_recognize_antigravity() -> None:
 
 
 def test_migration_tool_copies_agents_dir() -> None:
-    """The migration tool must copy the shared .agents/ dir (Codex + Antigravity config)."""
-    src = (REPO_ROOT / "tools" / "pyproject_template" / "migrate_existing_project.py").read_text(
-        encoding="utf-8"
-    )
+    """The migration tool must copy the shared .agents/ dir (Codex + Antigravity config).
+
+    Skipped in a spawned project: ``migrate_existing_project.py`` is one of the
+    setup-only files ``cleanup --setup`` sheds, so there is nothing to assert
+    against once the template has been consumed (#731).
+    """
+    migration_tool = REPO_ROOT / "tools" / "pyproject_template" / "migrate_existing_project.py"
+    if not migration_tool.is_file():
+        pytest.skip("migrate_existing_project.py is shed by cleanup --setup")
+
+    src = migration_tool.read_text(encoding="utf-8")
     assert '".agents"' in src, "migrate_existing_project.py must include .agents in the copy list"

--- a/tests/template/test_coverage_gate.py
+++ b/tests/template/test_coverage_gate.py
@@ -32,10 +32,49 @@ def _coverage_config() -> dict[str, Any]:
 def test_gate_measures_both_the_package_and_tools() -> None:
     """`tools/` is in scope, not just the replaceable package skeleton."""
     source = _coverage_config()["run"]["source"]
-    assert "package_name" in source
     assert "tools" in source, (
         "tools/ runs releases, PRs and the dangerous-command hook; it must be measured"
     )
+
+    # The package entry is `package_name` here and the real package name in a
+    # spawned project, because configure.py rewrites it. Assert that it resolves
+    # to a package rather than pinning the placeholder, so this test keeps
+    # working downstream (#731).
+    packages = [entry for entry in source if entry != "tools"]
+    assert packages, "the project's own package must be measured alongside tools/"
+    for pkg in packages:
+        assert (REPO_ROOT / "src" / pkg).is_dir(), (
+            f"coverage source {pkg!r} is not a package under src/"
+        )
+
+
+def test_template_management_suite_is_out_of_scope() -> None:
+    """`tools/pyproject_template/` must stay omitted from the gate.
+
+    It is the one part of `tools/` that does not ship to the spawned project:
+    ADR-9017 makes its tests template-owned and both spawn routes delete the
+    suite itself. Measuring it means measuring code that is never tested
+    downstream, which put a spawned project 19 points under the gate (#731).
+
+    Dropping the omit re-breaks that shape silently — the template's own number
+    would still pass, because here the suite *is* tested.
+    """
+    omit = _coverage_config()["run"].get("omit", [])
+    assert "tools/pyproject_template/*" in omit, (
+        "tools/pyproject_template/* must stay in [tool.coverage.run] omit so the "
+        "gate measures the same code in the template and in a spawned project"
+    )
+
+
+def test_shipped_tooling_is_not_omitted() -> None:
+    """The omit must not be widened to the tooling the spawned project runs."""
+    omit = _coverage_config()["run"].get("omit", [])
+    for shipped in ("tools/doit", "tools/hooks"):
+        offenders = [pattern for pattern in omit if pattern.startswith(shipped)]
+        assert not offenders, (
+            f"{offenders} would drop {shipped}/ from the gate. That code ships to "
+            "and runs in the spawned project; it must stay measured."
+        )
 
 
 def test_threshold_is_enforced_and_not_aspirational() -> None:

--- a/tests/template/test_downstream_test_retention.py
+++ b/tests/template/test_downstream_test_retention.py
@@ -1,0 +1,200 @@
+"""Guards that a spawned project keeps the tests for the code it actually runs.
+
+Three code paths turn the template into a real project, and all three used to
+delete ``tests/template/`` wholesale:
+
+- ``configure.py`` (the "Use this template" route)
+- ``setup_repo.py`` (the ``bootstrap.py`` new-project wizard)
+- ``cleanup --setup`` (an existing project adopting the template)
+
+Only the third consulted ``TEMPLATE_OWNED_TEST_FILES``. The other two also removed
+the suites covering ``tools/doit/`` and ``tools/hooks/`` — code that ships to the
+spawned project and that the coverage gate in ``pyproject.toml`` measures. The
+result was a generated project that failed its own first CI run at 33.98% against
+a ``fail_under`` of 54 (#731).
+
+These tests pin the shed set to one list and assert that the shipped tooling keeps
+test coverage on the far side of it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from tools.pyproject_template.cleanup import CleanupMode, get_files_to_delete
+from tools.pyproject_template.utils import (
+    TEMPLATE_OWNED_TEST_FILES,
+    remove_template_owned_tests,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_TESTS = REPO_ROOT / "tests" / "template"
+
+# Tooling directories that ship to and run in the spawned project. Unlike
+# tools/pyproject_template/, this code is not shed by any cleanup mode, so
+# deleting its tests leaves the project running untested code — and short of
+# the coverage gate it also inherits.
+SHIPPED_TOOLING = ("tools/doit", "tools/hooks")
+
+# The two wizard entry points that turn a clone into a real project. Both must
+# shed through the shared helper rather than naming the directory themselves.
+WIZARDS = (
+    REPO_ROOT / "tools" / "pyproject_template" / "configure.py",
+    REPO_ROOT / "tools" / "pyproject_template" / "setup_repo.py",
+)
+
+
+def _template_test_filenames() -> list[str]:
+    """Every ``test_*.py`` filename currently in ``tests/template/``."""
+    return sorted(p.name for p in TEMPLATE_TESTS.glob("test_*.py"))
+
+
+def _populate(root: Path) -> Path:
+    """Build a throwaway ``tests/template/`` mirroring the real filenames."""
+    tests_dir = root / "tests" / "template"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    for name in _template_test_filenames():
+        (tests_dir / name).write_text("# stub\n", encoding="utf-8")
+    return tests_dir
+
+
+def _uncovered_shipped_tooling(surviving: set[str]) -> list[str]:
+    """Return the shipped tooling dirs no *surviving* test file references.
+
+    Reads the real test bodies, so it reflects what the suite actually covers
+    rather than a filename convention.
+    """
+    bodies = [(TEMPLATE_TESTS / name).read_text(encoding="utf-8") for name in sorted(surviving)]
+    uncovered = []
+    for shipped in SHIPPED_TOOLING:
+        dotted = shipped.replace("/", ".")
+        if not any(shipped in body or dotted in body for body in bodies):
+            uncovered.append(shipped)
+    return uncovered
+
+
+def _path_literals(script: Path) -> set[str]:
+    """Return every string passed to a ``Path(...)`` call in *script*."""
+    tree = ast.parse(script.read_text(encoding="utf-8"), filename=str(script))
+    literals: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "Path"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            literals.add(node.args[0].value)
+    return literals
+
+
+def test_wizards_shed_through_the_shared_helper() -> None:
+    """Neither wizard may name ``tests/template/`` and remove it wholesale again.
+
+    The parity test below checks the helper. This checks that the wizards still
+    *use* it — the pre-#731 defect was two hand-rolled ``shutil.rmtree`` calls
+    sitting next to a list neither consulted.
+    """
+    for wizard in WIZARDS:
+        source = wizard.read_text(encoding="utf-8")
+        assert "remove_template_owned_tests(" in source, (
+            f"{wizard.name} must shed template tests via remove_template_owned_tests()"
+        )
+        offenders = {literal for literal in _path_literals(wizard) if "tests/template" in literal}
+        assert not offenders, (
+            f"{wizard.name} names {offenders} directly. Shedding belongs in "
+            "remove_template_owned_tests() so all paths stay in agreement (#731)."
+        )
+
+
+def test_wizard_and_cleanup_shed_the_same_tests(tmp_path: Path) -> None:
+    """configure.py/setup_repo.py must shed exactly what ``cleanup --setup`` sheds.
+
+    ADR-9017 calls ``TEMPLATE_OWNED_TEST_FILES`` the single authoritative list.
+    This asserts that claim behaviourally rather than trusting the constant.
+    """
+    _populate(tmp_path)
+
+    # Must be collected before the shed runs — get_files_to_delete only reports
+    # files that still exist.
+    cleanup_sheds = {
+        path.relative_to(tmp_path).as_posix()
+        for path in get_files_to_delete(CleanupMode.SETUP_ONLY, tmp_path)
+        if path.as_posix().find("tests/template/") != -1
+    }
+    wizard_sheds = {
+        path.relative_to(tmp_path).as_posix() for path in remove_template_owned_tests(tmp_path)
+    }
+
+    assert wizard_sheds == cleanup_sheds, (
+        "The wizard and cleanup paths disagree about what is template-owned. "
+        "Both must derive from TEMPLATE_OWNED_TEST_FILES (ADR-9017)."
+    )
+
+
+def test_shipped_tooling_keeps_its_tests(tmp_path: Path) -> None:
+    """After shedding, surviving tests must still cover tools/doit/ and tools/hooks/."""
+    _populate(tmp_path)
+    shed = {path.name for path in remove_template_owned_tests(tmp_path)}
+    surviving = {name for name in _template_test_filenames() if name not in shed}
+
+    uncovered = _uncovered_shipped_tooling(surviving)
+    assert not uncovered, (
+        f"No surviving test covers {uncovered}. That code ships to the spawned "
+        "project and is measured by the coverage gate in pyproject.toml; shedding "
+        "its tests puts the generated project below fail_under on its first CI run."
+    )
+
+
+def test_retention_check_detects_the_regression() -> None:
+    """The check above must fail when the tooling tests are gone.
+
+    Without this, ``test_shipped_tooling_keeps_its_tests`` could pass because the
+    scanner finds nothing to complain about rather than because coverage survives.
+    Feeding it the pre-#731 shape — everything removed — must flag both dirs.
+    """
+    assert _uncovered_shipped_tooling(set()) == list(SHIPPED_TOOLING)
+
+
+def test_template_only_tests_are_shed(tmp_path: Path) -> None:
+    """Tests whose target does not survive configuration must still be removed."""
+    _populate(tmp_path)
+    shed = {path.name for path in remove_template_owned_tests(tmp_path)}
+
+    for name in ("test_configure_paths.py", "test_readme_split.py", "test_cleanup.py"):
+        assert name in shed, f"{name} targets a template-only artifact and must be shed"
+
+
+def test_package_dir_survives_when_tests_remain(tmp_path: Path) -> None:
+    """``tests/template/`` stays when downstream-owned tests are left in it."""
+    tests_dir = _populate(tmp_path)
+    remove_template_owned_tests(tmp_path)
+
+    assert tests_dir.is_dir(), "tests/template/ must survive — it still holds tooling tests"
+    assert (tests_dir / "test_doit_quality.py").is_file()
+
+
+def test_package_dir_removed_once_empty(tmp_path: Path) -> None:
+    """``tests/template/`` is dropped when shedding leaves nothing behind."""
+    tests_dir = tmp_path / "tests" / "template"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+    for rel in TEMPLATE_OWNED_TEST_FILES:
+        (tmp_path / rel).write_text("# stub\n", encoding="utf-8")
+
+    remove_template_owned_tests(tmp_path)
+
+    assert not tests_dir.exists(), "an emptied tests/template/ should not be left behind"
+    assert (tmp_path / "tests").is_dir(), "the parent tests/ directory must remain"
+
+
+def test_shed_is_a_noop_when_already_clean(tmp_path: Path) -> None:
+    """Running against a project with no tests/template/ must not raise."""
+    (tmp_path / "tests").mkdir()
+
+    assert remove_template_owned_tests(tmp_path) == []
+    assert (tmp_path / "tests").is_dir()

--- a/tests/template/test_pyproject_template_main.py
+++ b/tests/template/test_pyproject_template_main.py
@@ -676,8 +676,14 @@ class TestConfigureModule:
         finally:
             os.chdir(old_cwd)
 
-    def test_run_configure_removes_template_tests_directory(self, tmp_path: Path) -> None:
-        """Test that tests/template/ is removed during configure."""
+    def test_run_configure_sheds_template_owned_tests_only(self, tmp_path: Path) -> None:
+        """Test that configure sheds the owned list but keeps tests for shipped tooling.
+
+        Before #731 this removed ``tests/template/`` wholesale, taking the suites
+        covering ``tools/doit/`` and ``tools/hooks/`` with it. That code ships to
+        the spawned project and is measured by its coverage gate, so the generated
+        project failed its own first CI run.
+        """
         from tools.pyproject_template.configure import run_configure
 
         # Create minimal project structure
@@ -685,19 +691,29 @@ class TestConfigureModule:
         (tmp_path / "src" / "test_pkg").mkdir(parents=True)
         (tmp_path / "src" / "test_pkg" / "__init__.py").write_text("", encoding="utf-8")
 
-        # Create template-only tests directory that should be removed
+        # One template-owned test (shed) and one covering shipped tooling (kept).
         template_tests_dir = tmp_path / "tests" / "template"
         template_tests_dir.mkdir(parents=True)
         (template_tests_dir / "__init__.py").write_text("", encoding="utf-8")
         (template_tests_dir / "test_utils.py").write_text("# test file", encoding="utf-8")
+        (template_tests_dir / "test_doit_adr.py").write_text("# tooling test", encoding="utf-8")
 
         import os
 
         old_cwd = os.getcwd()
         os.chdir(tmp_path)
+
+        # Suppress only configure.py's self-destruct; a blanket Path.unlink mock
+        # would also neuter the shedding this test is asserting.
+        real_unlink = Path.unlink
+
+        def _unlink_unless_self_destruct(self: Path, *args: object, **kwargs: object) -> None:
+            if self.name == "configure.py":
+                return
+            real_unlink(self, *args, **kwargs)  # type: ignore[arg-type]
+
         try:
-            # Mock Path.unlink to prevent configure.py self-destruct
-            with patch.object(Path, "unlink"):
+            with patch.object(Path, "unlink", _unlink_unless_self_destruct):
                 result = run_configure(
                     auto=True,
                     yes=True,
@@ -713,9 +729,11 @@ class TestConfigureModule:
                 )
             assert result == 0
 
-            # Verify template-only tests directory was removed
-            assert not template_tests_dir.exists()
-            # But tests directory itself should still exist
+            # The template-owned test is shed...
+            assert not (template_tests_dir / "test_utils.py").exists()
+            # ...but the test for tooling that ships downstream survives, and so
+            # does the package it lives in.
+            assert (template_tests_dir / "test_doit_adr.py").exists()
             assert (tmp_path / "tests").exists()
         finally:
             os.chdir(old_cwd)

--- a/tests/template/test_setup_repo.py
+++ b/tests/template/test_setup_repo.py
@@ -567,10 +567,15 @@ class TestVerifyPostCleanup:
 class TestConfigurePlaceholdersTemplateTestsRemoval:
     """Tests for RepositorySetup.configure_placeholders() template-tests removal.
 
-    Issue #463: spawned consumer projects must not ship with
-    ``tests/template/`` (the template-only test suite). This verifies that
-    ``configure_placeholders()`` removes the directory and that the removal
-    is a no-op when the directory is absent.
+    Issue #463: spawned consumer projects must not ship with the template-only
+    test suite. Issue #731 narrowed *which* tests that means: the wizard sheds
+    ``TEMPLATE_OWNED_TEST_FILES`` and keeps the suites covering ``tools/doit/``
+    and ``tools/hooks/``, because that code ships to the spawned project and is
+    measured by its coverage gate. Removing the directory wholesale left the
+    generated project failing its own first CI run.
+
+    This verifies the narrowed contract and that shedding is a no-op when
+    ``tests/template/`` is absent.
     """
 
     @staticmethod
@@ -586,17 +591,19 @@ class TestConfigurePlaceholdersTemplateTestsRemoval:
             "author_email": "test@example.com",
         }
 
-    def test_configure_placeholders_removes_tests_template_directory(
+    def test_configure_placeholders_sheds_template_owned_tests_only(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """configure_placeholders() removes tests/template/ when present."""
+        """configure_placeholders() sheds the owned list and keeps tooling tests."""
         from tools.pyproject_template.setup_repo import RepositorySetup
 
-        # Simulate a cloned consumer project with a tests/template/ directory.
+        # Simulate a cloned consumer project: one template-owned test and one
+        # test covering tools/doit/, which ships to the spawned project.
         template_tests_dir = tmp_path / "tests" / "template"
         template_tests_dir.mkdir(parents=True)
         (template_tests_dir / "__init__.py").write_text("", encoding="utf-8")
-        (template_tests_dir / "test_doit_adr.py").write_text("# template test", encoding="utf-8")
+        (template_tests_dir / "test_cleanup.py").write_text("# template test", encoding="utf-8")
+        (template_tests_dir / "test_doit_adr.py").write_text("# tooling test", encoding="utf-8")
 
         monkeypatch.chdir(tmp_path)
 
@@ -608,8 +615,11 @@ class TestConfigurePlaceholdersTemplateTestsRemoval:
             mock_run.return_value = MagicMock(returncode=0)
             setup.configure_placeholders()
 
-        assert not template_tests_dir.exists(), (
-            "tests/template/ should have been removed by configure_placeholders()"
+        assert not (template_tests_dir / "test_cleanup.py").exists(), (
+            "template-owned tests should have been shed by configure_placeholders()"
+        )
+        assert (template_tests_dir / "test_doit_adr.py").exists(), (
+            "tests covering tools/doit/ must survive — that code ships downstream (#731)"
         )
         # The parent tests/ directory should still exist.
         assert (tmp_path / "tests").exists()

--- a/tools/pyproject_template/configure.py
+++ b/tools/pyproject_template/configure.py
@@ -28,6 +28,7 @@ from utils import (  # noqa: E402
     parse_github_url,
     prompt,
     prompt_confirm,
+    remove_template_owned_tests,
     update_file,
     update_test_files,
     validate_email,
@@ -452,11 +453,18 @@ def run_configure(
         print("  ✓ Updating test files")
         update_test_files(test_dir, package_name)
 
-    # Remove template-only tests (they're only for the template itself)
-    template_tests_dir = Path("tests/template")
-    if template_tests_dir.exists():
-        print("  ✓ Removing template-only tests (tests/template/)")
-        shutil.rmtree(template_tests_dir)
+    # Shed template-only tests. This must shed exactly what `cleanup --setup`
+    # sheds — ADR-9017 makes TEMPLATE_OWNED_TEST_FILES the single authoritative
+    # list, and cleanup.py already consumes it.
+    #
+    # Removing the whole directory instead (as this did until #731) also deleted
+    # the tests covering tools/doit/ and tools/hooks/ — code that ships to and
+    # runs in the spawned project, and that the coverage gate in pyproject.toml
+    # measures. A spawned project failed its first CI run at 33.98% against a
+    # fail_under of 54.
+    shed = remove_template_owned_tests(Path.cwd())
+    if shed:
+        print(f"  ✓ Removing {len(shed)} template-only test files")
 
     # Seed v0.0.0 baseline tag so `doit release --prerelease=alpha` works on the
     # first release (see issue #447). Idempotent and skipped gracefully when
@@ -469,9 +477,13 @@ def run_configure(
     print("2. Initialize git repository: git init")
     print("3. Install dependencies: uv sync --all-extras --dev")
     print("4. Install pre-commit hooks: uv run doit pre_commit_install")
-    print("5. Run tests: uv run pytest")
-    print("6. Cut a prerelease (if desired): uv run doit release --prerelease=alpha")
-    print("7. Start coding!")
+    # The bootstrap wizard (setup_repo.py) runs this automatically. The manual
+    # route has to be told, or the project keeps a template management suite it
+    # does not use (#731).
+    print("5. Remove the template suite: uv run doit template_clean --all")
+    print("6. Run tests: uv run pytest")
+    print("7. Cut a prerelease (if desired): uv run doit release --prerelease=alpha")
+    print("8. Start coding!")
     print("━" * 60)
 
     # Self-destruct

--- a/tools/pyproject_template/setup_repo.py
+++ b/tools/pyproject_template/setup_repo.py
@@ -59,6 +59,7 @@ from utils import (  # noqa: E402
     get_git_config,
     prompt,
     prompt_confirm,
+    remove_template_owned_tests,
     update_file,
     update_test_files,
 )
@@ -374,11 +375,12 @@ class RepositorySetup:
             if tests_dir.exists():
                 update_test_files(tests_dir, self.config["package_name"])
 
-            # Remove template-only tests (they're only for the template itself)
-            template_tests_dir = Path("tests/template")
-            if template_tests_dir.exists():
-                shutil.rmtree(template_tests_dir)
-                Logger.info("Removed template-only tests (tests/template/)")
+            # Shed template-only tests. Shares one implementation with
+            # configure.py so the two wizard paths cannot disagree about what
+            # "template-owned" means; see remove_template_owned_tests (#731).
+            shed = remove_template_owned_tests(Path.cwd())
+            if shed:
+                Logger.info(f"Removed {len(shed)} template-only test files")
 
             # Update source files
             src_dir = Path("src")

--- a/tools/pyproject_template/utils.py
+++ b/tools/pyproject_template/utils.py
@@ -23,10 +23,16 @@ except ModuleNotFoundError:  # pragma: no cover
 TEMPLATE_REPO = "endavis/pyproject-template"
 TEMPLATE_URL = f"https://github.com/{TEMPLATE_REPO}"
 
-# Tooling tests that are template-owned: they live in the template's own CI,
-# are excluded from the drift checker, and are shed from downstreams by cleanup.
-# Both check_template_updates.py and cleanup.py import this list — never
-# hardcode it in either consumer.
+# Tests that are template-owned: they live in the template's own CI, are
+# excluded from the drift checker, and are shed from downstreams by cleanup
+# and by configure.py. All three consumers — check_template_updates.py,
+# cleanup.py and configure.py — import this list; never hardcode it in any of
+# them (ADR-9017).
+#
+# The membership test is whether the test's *target* survives configuration.
+# Tests covering tools/doit/ and tools/hooks/ are deliberately absent: that
+# code ships to the spawned project, runs there, and is measured by the
+# coverage gate in pyproject.toml (#731).
 TEMPLATE_OWNED_TEST_FILES: list[str] = [
     "tests/template/test_pyproject_template_main.py",
     "tests/template/test_check_template_updates.py",
@@ -36,7 +42,50 @@ TEMPLATE_OWNED_TEST_FILES: list[str] = [
     "tests/template/test_bootstrap.py",
     "tests/template/test_utils.py",
     "tests/template/test_utils_properties.py",
+    # Targets consumed by configure.py itself: configure.py self-destructs at
+    # the end of its run, and README.template.md is renamed onto README.md.
+    "tests/template/test_configure_paths.py",
+    "tests/template/test_readme_split.py",
+    "tests/template/test_downstream_test_retention.py",
 ]
+
+
+def remove_template_owned_tests(root: Path) -> list[Path]:
+    """Delete the template-owned test files under *root*, returning what was removed.
+
+    The single shedding implementation for every path that turns the template
+    into a real project: ``configure.py`` and ``setup_repo.py`` both call this,
+    and ``cleanup --setup`` sheds the same list through ``SETUP_FILES``. That
+    keeps ADR-9017's "single authoritative list" claim true in practice rather
+    than only in the constant.
+
+    Tests covering ``tools/doit/`` and ``tools/hooks/`` are deliberately kept:
+    that code ships to the spawned project, runs there, and is measured by the
+    coverage gate in ``pyproject.toml``. All three paths used to remove
+    ``tests/template/`` wholesale, which left the spawned project failing its
+    own coverage gate at 33.98% against a ``fail_under`` of 54 (#731).
+    """
+    removed: list[Path] = []
+    for rel in TEMPLATE_OWNED_TEST_FILES:
+        path = root / rel
+        if path.is_file():
+            path.unlink()
+            removed.append(path)
+
+    # Drop the package directory only if shedding emptied it. A project that
+    # keeps tooling tests keeps the package they live in.
+    template_tests_dir = root / "tests" / "template"
+    if template_tests_dir.is_dir():
+        survivors = [
+            entry
+            for entry in template_tests_dir.iterdir()
+            if entry.name not in {"__init__.py", "__pycache__"}
+        ]
+        if not survivors:
+            shutil.rmtree(template_tests_dir)
+
+    return removed
+
 
 # Files to update during placeholder replacement (single source of truth)
 # Used by both configure.py and setup_repo.py


### PR DESCRIPTION
## Description

Three code paths turn the template into a real project, and all three removed
`tests/template/` wholesale — including the 17 suites covering `tools/doit/` and
`tools/hooks/`, code that ships to and runs in the spawned project. `pyproject.toml`
ships a coverage gate scoped at that same code (`source = ["package_name", "tools"]`,
`fail_under = 54`), whose threshold was only ever measured against the one path that
keeps those tests.

The result: a generated project failed its own first CI run at **33.98%** against a
`fail_under` of 54. This is the same family as #469 and #474 — spawn-time shedding
leaving the generated repo unable to pass its own checks.

## Related Issue

Addresses #731

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

**Scope grew twice from the issue as filed. Both are called out here rather than
shipped quietly.**

**1. A third shed path, found during implementation.** The issue named `configure.py`
and `cleanup.py`. `setup_repo.py:378` had its own copy of the same `rmtree`, so the
`bootstrap.py` wizard lost the tests too. Both wizards now shed through one helper,
`remove_template_owned_tests()` in `utils.py`, driven by `TEMPLATE_OWNED_TEST_FILES` —
making ADR-9017's "single authoritative list" claim true in practice rather than only
in the constant.

**2. Fixing that alone was not enough.** It moved the spawned project from 33.98% to
35.05% — still failing. `tools/pyproject_template/` (2,344 statements) stayed in the
gate's scope but is never tested downstream, because ADR-9017 makes its tests
template-owned. It is now omitted from the gate, **and** the manual setup route runs
`template_clean --all`, matching what `setup_repo.py` already did automatically.

**Reclassified as template-owned** — their targets do not survive configuration:

| file | target | why it cannot survive |
| :--- | :--- | :--- |
| `test_configure_paths.py` | `configure.py` | self-destructs at the end of its own run |
| `test_readme_split.py` | `README.template.md` | `configure.py:399` renames it onto `README.md` |

**Straddlers fixed rather than shed** — one assertion each broke downstream:

- `test_ai_agent_assets.py` read `migrate_existing_project.py`, which `cleanup --setup`
  sheds. Now skips when absent.
- `test_coverage_gate.py` asserted the literal `"package_name"` in the coverage source,
  which `configure.py` renames. Now asserts the entry *resolves* to a package under
  `src/` — stronger than the original and portable downstream.

The remaining 17 files are downstream-safe and are now kept. The `bootstrap.py`
references in the `test_doit_*` files are all `tmp_path` fixtures asserting the
both-present-and-absent behaviour.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Two existing tests broke by design** — they pinned the old wholesale-removal
contract, which this PR deliberately removes:

- `test_setup_repo.py::test_configure_placeholders_removes_tests_template_directory`
- `test_pyproject_template_main.py::test_run_configure_removes_template_tests_directory`

Both now assert the narrowed contract. The second also blanket-mocked `Path.unlink` to
suppress configure's self-destruct, which silently neutered the very shedding it was
testing; it now suppresses only the self-destruct and lets real deletions through.

**New guards, each confirmed to fail when the defect is reintroduced** — not merely
asserted. `tests/template/test_downstream_test_retention.py`:

| regression simulated | guard that fired |
| :--- | :--- |
| shed list re-broadened to include the doit/hooks suites | `test_shipped_tooling_keeps_its_tests` |
| a wizard hand-rolls `rmtree` again | `test_wizards_shed_through_the_shared_helper` |

`test_retention_check_detects_the_regression` is the companion that proves the scanner
finds something rather than passing because it looks at nothing.

**Coverage, measured both ways:**

| shape | before | after |
| :--- | ---: | ---: |
| template | 59.16% | **64.34%** |
| spawned project | **33.98%** (fails) | **64.34%** |

Identical after the fix, because both now measure the same code with the same tests.
That makes the gate shape-independent: one threshold is honest in both, instead of a
number justified against whichever path happened to be measured.

`doit check`: all passed (1,383 tests).

**Not verified:** no real end-to-end spawn (clone → configure → push → CI) was run. The
spawned-project shape is simulated by shedding the owned list from the local suite.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

**No ADR change.** This applies ADR-9017's existing definition rather than redefining
it: the membership test is whether a test's target survives configuration, which is what
the ADR already says. #691 stays open for the parts this does not cover — recording the
`test_doit_*` ownership decision in the ADR, and widening the classification guard
`test_every_tooling_importing_test_is_classified`, which is blind to all 21 gap files by
design (`_imports_pyproject_tooling` is deliberately anchored to `tools.pyproject_template`
imports and explicitly excludes `tools.doit`). That blindness is why six new template
tests were added last round without tripping anything.

**On narrowing the gate's scope:** omitting `tools/pyproject_template/*` does not reverse
#689. That issue's intent was to stop measuring only the 66-statement skeleton and start
measuring `tools/`; 2,686 statements of `tools/doit` + `tools/hooks` remain gated. The
omitted suite is the one part of `tools/` the spawned project deletes, and its tests still
run in template CI — they just no longer feed the ratchet. `test_shipped_tooling_is_not_omitted`
guards against the omit being widened to cover code that does ship.
