### PR TITLE
refactor: make the template-owned test rule explicit and self-enforcing

### DIFF
--- a/docs/decisions/9017-template-tooling-and-its-tests-are-template-owned.md
+++ b/docs/decisions/9017-template-tooling-and-its-tests-are-template-owned.md
@@ -4,12 +4,29 @@
 Accepted
 
 ## Decision
-Template tooling tests (`tests/template/test_*.py` that test `tools/pyproject_template/`) are
-**template-owned**: they run only in the template's own CI, are excluded from the drift checker,
-and are shed from downstream projects by `cleanup --setup`.
+A test in `tests/template/` is **template-owned** when its target does not survive
+configuration. Template-owned tests run only in the template's own CI, are excluded from the
+drift checker, and are shed from downstream projects by every path that turns the template
+into a real project.
+
+That membership test resolves the question `tests/template/` had grown ambiguous about
+(#691). Applying it:
+
+| test target | owner | why |
+| :--- | :--- | :--- |
+| `tools/pyproject_template/` | **template** | Both spawn routes delete the suite; a downstream that keeps it holds tests for a namespace that no longer exists. |
+| `configure.py`, `README.template.md` | **template** | Consumed by configuration itself — `configure.py` self-destructs, `README.template.md` is renamed onto `README.md`. |
+| `tools/doit/`, `tools/hooks/` | **downstream** | This code ships to the spawned project, runs there (`doit check`, `doit pr`, the dangerous-command hook), and is measured by the project's own coverage gate. |
+| `.claude/`, `.agents/`, `.github/` assets | **downstream** | Ship with the project and are the project's to maintain. |
+
+`test_doit_*.py` is therefore **downstream-owned** and travels with the project. The earlier
+implied answer — shed everything under `tests/template/` — left a spawned project running
+several thousand statements of untested tooling and failing its own coverage gate on the first
+CI run (#731).
 
 A single constant `TEMPLATE_OWNED_TEST_FILES` in `utils.py` is the authoritative list.
-Both `check_template_updates.py` and `cleanup.py` import from it; neither hardcodes the list.
+`check_template_updates.py`, `cleanup.py`, `configure.py` and `setup_repo.py` all import from
+it; none hardcodes the list.
 
 ## Rationale
 Before this decision, tooling tests lived alongside skeleton tests with no distinction.
@@ -29,14 +46,24 @@ tooling that has also drifted, so users know to run `bootstrap --sync` before ad
 that test.
 
 ## Consequences
-- **Downstream projects carry no tests for the tooling they run.** The tooling
+- **Downstream projects carry no tests for the *management suite*.** The suite
   (`manage.py`, `check_template_updates.py`, `cleanup.py`, …) still ships via
   `bootstrap.py` `SYNC_FILES`, but its tests do not. We accept this: downstreams
-  consume the tooling without modifying it, and these tests depend on template-only
+  consume that tooling without modifying it, and these tests depend on template-only
   fixtures (the `package_name` skeleton) that no longer exist once a downstream is
   configured. This is why the alternative — adding the tests to `SYNC_FILES` so
   tooling and tests travel together — was rejected: it would push non-runnable,
   skeleton-coupled tests into every downstream.
+
+  This clause is scoped to the management suite and **does not** extend to
+  `tools/doit/` or `tools/hooks/`, which keep their tests (#731). It was stated
+  broadly enough at first to read as a blessing for shedding those too.
+
+- **The coverage gate excludes `tools/pyproject_template/`.** Because its tests are
+  template-owned while the code itself may linger in a downstream, measuring it would
+  count code that is never tested there. Omitting it makes the gate report the same
+  number in the template and in a spawned project (#731). The suite's tests still run
+  in template CI; they no longer feed the ratchet.
 - **Existing downstreams need a one-time cleanup.** Projects that adopted these
   tests in an earlier sync are not cleaned up automatically; they should run
   `cleanup --setup` once to shed them (see
@@ -51,7 +78,12 @@ that test.
 
 ## Related Issues
 - Issue #631: Make template tooling tests template-owned
+- Issue #731: `configure.py`/`setup_repo.py` shed tests the spawned project's coverage gate
+  depends on (PR #732) — established the membership test recorded above
+- Issue #691: `configure.py` and `cleanup.py` disagree on what is template-owned
 
 ## Related Documentation
 - [Template Tooling](../template/tools-reference.md)
 - [AI Sync Checklist – Phase 1](../template/ai-sync-checklist.md)
+- [CI/CD and Testing](../development/ci-cd-testing.md) — the downstream/template coverage split
+- [New Project Setup](../template/new-project.md) — where the manual route sheds the suite

--- a/tests/template/test_downstream_test_retention.py
+++ b/tests/template/test_downstream_test_retention.py
@@ -15,6 +15,11 @@ a ``fail_under`` of 54 (#731).
 
 These tests pin the shed set to one list and assert that the shipped tooling keeps
 test coverage on the far side of it.
+
+They also guard the opposite direction (#691). A test kept downstream must not
+depend on something configuration deletes, or the spawned project inherits a test
+that cannot pass. ADR-9017 states the membership rule both directions share: a
+test is template-owned when its target does not survive configuration.
 """
 
 from __future__ import annotations
@@ -22,7 +27,13 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from tools.pyproject_template.cleanup import CleanupMode, get_files_to_delete
+from tools.pyproject_template.cleanup import (
+    ALL_TEMPLATE_DIRS,
+    ALL_TEMPLATE_FILES,
+    SETUP_FILES,
+    CleanupMode,
+    get_files_to_delete,
+)
 from tools.pyproject_template.utils import (
     TEMPLATE_OWNED_TEST_FILES,
     remove_template_owned_tests,
@@ -198,3 +209,108 @@ def test_shed_is_a_noop_when_already_clean(tmp_path: Path) -> None:
 
     assert remove_template_owned_tests(tmp_path) == []
     assert (tmp_path / "tests").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# The other direction (#691): a kept test must not depend on something that
+# configuration deletes.
+# ---------------------------------------------------------------------------
+
+# Paths that do not survive configuration, derived from cleanup's own lists so
+# the two definitions cannot drift apart.
+SHED_FILES = frozenset(SETUP_FILES) | frozenset(ALL_TEMPLATE_FILES)
+SHED_DIRS = tuple(ALL_TEMPLATE_DIRS)
+
+# Kept tests that legitimately reference a shed path because they *guard* the
+# read at runtime. Add here — with a reason — rather than deleting the check.
+GUARDED_READS: dict[str, str] = {
+    "test_ai_agent_assets.py": (
+        "reads migrate_existing_project.py but skips when it is absent (#731)"
+    ),
+}
+
+
+def _repo_root_reads(source: str) -> set[str]:
+    """Return relative paths built from ``REPO_ROOT / "a" / "b"`` chains.
+
+    Anchored to the repo root deliberately. References inside ``tmp_path``
+    fixtures are how several tests assert the *absent* case (``task_lint``
+    includes ``bootstrap.py`` iff it exists), and docstrings cite shed files by
+    name; neither is a real dependency, and a plain substring scan flags six
+    such false positives.
+    """
+    reads: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.BinOp) or not isinstance(node.op, ast.Div):
+            continue
+        parts: list[str] = []
+        cursor: ast.expr = node
+        while isinstance(cursor, ast.BinOp) and isinstance(cursor.op, ast.Div):
+            if isinstance(cursor.right, ast.Constant) and isinstance(cursor.right.value, str):
+                parts.insert(0, cursor.right.value)
+            cursor = cursor.left
+        if isinstance(cursor, ast.Name) and cursor.id in {"REPO_ROOT", "PROJECT_ROOT"} and parts:
+            reads.add("/".join(parts))
+    return reads
+
+
+def _shed_paths_read_by(test_file: Path) -> list[str]:
+    """Return the shed paths *test_file* reads from the repo root."""
+    reads = _repo_root_reads(test_file.read_text(encoding="utf-8"))
+    return sorted(rel for rel in reads if rel in SHED_FILES or rel.startswith(SHED_DIRS))
+
+
+def _kept_test_files() -> list[str]:
+    """Filenames of the tests a spawned project keeps."""
+    owned = {rel.split("/")[-1] for rel in TEMPLATE_OWNED_TEST_FILES}
+    return [name for name in _template_test_filenames() if name not in owned]
+
+
+def test_kept_tests_do_not_depend_on_shed_paths() -> None:
+    """A test kept downstream must not read something configuration deletes.
+
+    This is how ``test_readme_split.py`` and ``test_configure_paths.py`` came to
+    be misfiled: both read artefacts that configuration consumes, and nothing
+    noticed. The existing classification guard cannot catch them — it keys on
+    ``tools.pyproject_template`` imports, which neither file has.
+    """
+    offenders = {}
+    for name in _kept_test_files():
+        if name in GUARDED_READS:
+            continue
+        shed_reads = _shed_paths_read_by(TEMPLATE_TESTS / name)
+        if shed_reads:
+            offenders[name] = shed_reads
+
+    assert not offenders, (
+        f"These tests ship downstream but read paths configuration deletes: {offenders}. "
+        "Either add the file to TEMPLATE_OWNED_TEST_FILES, or guard the read and record "
+        "it in GUARDED_READS with a reason (ADR-9017)."
+    )
+
+
+def test_shed_path_scanner_detects_template_only_tests() -> None:
+    """The scanner must flag the two files that proved it was needed.
+
+    Without this, the check above could pass because the scanner finds nothing
+    anywhere rather than because the kept set is clean.
+    """
+    for name in ("test_configure_paths.py", "test_readme_split.py"):
+        assert _shed_paths_read_by(TEMPLATE_TESTS / name), (
+            f"{name} reads a path configuration consumes; the scanner must see it"
+        )
+
+
+def test_guarded_reads_allowlist_stays_honest() -> None:
+    """Every allowlist entry must name a kept file that really reads a shed path.
+
+    Stops the allowlist from accumulating entries that silence nothing, and from
+    outliving the files it excuses.
+    """
+    kept = set(_kept_test_files())
+    for name, reason in GUARDED_READS.items():
+        assert name in kept, f"GUARDED_READS names {name}, which is not a kept test"
+        assert _shed_paths_read_by(TEMPLATE_TESTS / name), (
+            f"GUARDED_READS excuses {name}, but it no longer reads any shed path — drop the entry"
+        )
+        assert reason.strip(), f"GUARDED_READS[{name}] needs a reason"


### PR DESCRIPTION
## Description

ADR-9017 named `tools/pyproject_template/` tests as template-owned but never said what
to do with the rest of `tests/template/`. That gap is why three shed paths grew three
answers. PR #732 made them agree; this records the rule they now share and makes the
classification self-enforcing.

## Related Issue

Addresses #691

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

**#732 already met three of this issue's five criteria.** What remained:

| criterion | where |
| :--- | :--- |
| `configure.py` and `cleanup.py` shed an identical set | #732 |
| `TEMPLATE_OWNED_TEST_FILES` genuinely the single source of truth | #732 — four consumers, none hardcoding |
| a test enforces parity between the paths | #732 — `test_wizard_and_cleanup_shed_the_same_tests` |
| **ADR-9017 records the decision on `test_doit_*.py`** | **this PR** |
| `doit check` passes | this PR |

**ADR-9017 — the membership test, stated.** A test is template-owned when its target
does not survive configuration. The Decision section now applies that rule per target in
a table, so `test_doit_*.py` is *recorded* as downstream-owned rather than left implied
by whichever code path happened to run.

**A clause narrowed because it was actively misleading.** Consequences said
"Downstream projects carry no tests for the tooling they run" — stated broadly enough to
read as a blessing for shedding the `tools/doit` and `tools/hooks` tests, which is close
to what went wrong in #731. It is now scoped to the management suite, with the exclusion
called out explicitly. A second consequence records why the coverage gate omits
`tools/pyproject_template/`.

**A guard for the other direction.** #732 stops *shipped* tooling from losing its tests.
Nothing stopped a *template-only* test from being kept downstream, where it cannot pass —
which is exactly how `test_readme_split.py` and `test_configure_paths.py` came to be
misfiled. The existing classification guard cannot catch them: `_imports_pyproject_tooling`
keys on `tools.pyproject_template` imports, which neither file has.

The new check flags any kept test that reads a repo-root path configuration deletes,
deriving "deleted" from cleanup's own lists so the two definitions cannot drift apart.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Two design notes worth review:**

1. **A naive substring scan produces 6 false positives** — `test_doit_base`, `_docs`,
   `_quality`, `_security` reference `bootstrap.py` inside `tmp_path` fixtures that
   deliberately assert the *absent* case (`task_lint` includes `bootstrap.py` iff it
   exists at cwd); `test_properties` and `test_coverage_gate` name shed paths in a
   docstring and in the omit assertion. The guard is AST-anchored to `REPO_ROOT / …`
   reads instead, which is the actual dependency signal, and reports zero false
   positives across the 19 kept tests.

2. **`test_ai_agent_assets.py` is a real hit**, allowlisted in `GUARDED_READS` with a
   reason because it guards the read with `pytest.skip` rather than depending on the
   file unconditionally. `test_guarded_reads_allowlist_stays_honest` asserts every entry
   names a kept file that really reads a shed path, so the allowlist cannot accumulate
   entries that silence nothing or outlive the files they excuse.

**Verified by reintroducing the defect, not asserted:**

| check | result |
| :--- | :--- |
| scanner detects the two files that motivated it | flags both |
| `test_readme_split.py` removed from the owned list | guard fires, naming the file and the paths it reads |
| allowlist is load-bearing | confirmed — without it `test_ai_agent_assets.py` is a live hit |

`doit check`: all passed (1,385 tests). `mkdocs build --strict`: clean — this PR adds
two links to the ADR, and `doit check` does not run `docs_build`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

**The issue's framing was right but understated the size.** It described a two-path
disagreement over a "16-file gap" that was "the `test_doit_*.py` files". The gap was
21 files across *three* paths (`setup_repo.py` had its own copy of the `rmtree`), only
12 of which were `test_doit_*`, and six of the rest were added *after* the issue was
filed — by last round's own PRs. That the gap grew while the issue sat open is the
argument for the guard in this PR rather than the classification alone.

**#690 is deliberately untouched.** It applies this same definition to the ~670
root-level tests in `tests/`, which is a materially larger call than the 30 files under
`tests/template/`. The ADR wording lands here first because #690 depends on it.

**ADR title left as-is.** "Template tooling and its tests are template-owned" is now
slightly loose — not all tooling tests are template-owned — but the Decision section
resolves it, and renaming the file would break inbound links.
