### PR TITLE
refactor: size agent-wiring tests to the project, not the template

### DIFF
--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -229,6 +229,33 @@ docs:
       run: uv run doit docs_build
 ```
 
+### Tests of shipped assets must fit the project, not the template
+
+The template wires four AI agents; most projects spawned from it keep one. Tests
+that assert on agent wiring therefore derive the roster from what is on disk
+rather than hardcoding all four:
+
+```python
+from agent_roster import present_agents, agent_is_present, skip_if_absent
+
+AGENTS = present_agents()          # size a matrix to this project
+skip_if_absent("codex")            # or skip a whole agent-specific test
+```
+
+`tests/agent_roster.py` keys presence on each agent's self-action skill directory,
+not its config root — `.agents/` is read by both Codex and Antigravity, so its
+existence cannot distinguish them.
+
+Before this, `test_delegation_matrix.py` and four other files asserted that all
+68 delegation files existed, so a project that dropped an unused agent got 56
+failures on its first run (#690). Dropping an agent should narrow what the suite
+checks, never red it.
+
+The same principle does **not** license shedding these tests. They cover
+`tools/doit/`, `tools/hooks/`, workflows and agent assets — code that ships to and
+runs in the project, and that the gate below measures. Shedding them was measured
+at 40.73% total and 8.27% on `tools/hooks/`, well under `fail_under` (#731).
+
 ### Coverage Requirements
 
 - **Enforced threshold**: `fail_under = 54` in `pyproject.toml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,9 @@ include = [
     "tools",          # Tools directory (migrate_existing_project.py)
     ".github",        # Any Python in GitHub workflows/scripts
 ]
+# tests/ is not a package, so pytest puts it on sys.path; mirror that here so
+# shared test helpers (tests/agent_roster.py) resolve for the LSP too.
+extraPaths = ["tests"]
 exclude = [
     "**/__pycache__",
     "**/.venv",

--- a/tests/agent_roster.py
+++ b/tests/agent_roster.py
@@ -1,0 +1,57 @@
+"""Which AI agents this project actually ships.
+
+The template wires four agents (Claude, Codex, Copilot, Antigravity). A project
+spawned from it may keep only some — most keep one. Tests that assert on agent
+wiring used to hardcode the template's own four and assert every file exists,
+so dropping an unused agent produced 56 failures on the project's first run
+(#690).
+
+These helpers let those tests derive the roster from what is on disk. A project
+that keeps every agent sees exactly the same assertions as before; one that
+drops an agent simply stops asserting about it.
+
+Presence is keyed on each agent's *self-action skill directory* rather than its
+config root, because `.agents/` is shared: both Codex and Antigravity read it,
+so its existence cannot distinguish them.
+
+Not a test module — pytest does not collect it (the filename does not match
+``test_*.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Every agent the template knows how to wire, in matrix order.
+ALL_AGENTS: tuple[str, ...] = ("claude", "codex", "copilot", "antigravity")
+
+# The directory whose presence means "this project uses this agent". Each is
+# specific to one agent; see the module docstring on why `.agents/` alone will
+# not do.
+_PRESENCE_MARKERS: dict[str, Path] = {
+    "claude": REPO_ROOT / ".claude" / "commands" / "claude",
+    "codex": REPO_ROOT / ".agents" / "skills" / "codex-plan",
+    "copilot": REPO_ROOT / ".github" / "skills" / "copilot-plan",
+    "antigravity": REPO_ROOT / ".agents" / "skills" / "antigravity-plan",
+}
+
+
+def agent_is_present(agent: str) -> bool:
+    """Return whether *agent* is wired in this project."""
+    marker = _PRESENCE_MARKERS.get(agent)
+    return marker is not None and marker.is_dir()
+
+
+def present_agents() -> tuple[str, ...]:
+    """Return the agents this project wires, in :data:`ALL_AGENTS` order."""
+    return tuple(agent for agent in ALL_AGENTS if agent_is_present(agent))
+
+
+def skip_if_absent(agent: str) -> None:
+    """Skip the calling test when *agent* is not wired in this project."""
+    import pytest
+
+    if not agent_is_present(agent):
+        pytest.skip(f"{agent} is not wired in this project")

--- a/tests/template/test_ai_agent_assets.py
+++ b/tests/template/test_ai_agent_assets.py
@@ -6,12 +6,15 @@ import json
 from pathlib import Path
 
 import pytest
+from agent_roster import agent_is_present, present_agents, skip_if_absent
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_codex_workflow_skills_exist() -> None:
     """Codex workflow skills should be present in the repo skills directory."""
+    skip_if_absent("codex")
+
     skill_paths = [
         REPO_ROOT / ".agents" / "skills" / "codex-plan" / "SKILL.md",
         REPO_ROOT / ".agents" / "skills" / "codex-implement" / "SKILL.md",
@@ -25,49 +28,47 @@ def test_codex_workflow_skills_exist() -> None:
 
 
 def test_multi_orchestrator_files_exist() -> None:
-    """multi-* orchestrators (plan, review, adversarial-review) should exist for all 4 hosts."""
-    paths = [
-        # Claude
-        REPO_ROOT / ".claude" / "commands" / "multi-plan.md",
-        REPO_ROOT / ".claude" / "commands" / "multi-review.md",
-        REPO_ROOT / ".claude" / "commands" / "multi-adversarial-review.md",
-        # Copilot
-        REPO_ROOT / ".copilot" / "commands" / "multi-plan.md",
-        REPO_ROOT / ".copilot" / "commands" / "multi-review.md",
-        REPO_ROOT / ".copilot" / "commands" / "multi-adversarial-review.md",
-        # Codex
-        REPO_ROOT / ".agents" / "skills" / "multi-plan" / "SKILL.md",
-        REPO_ROOT / ".agents" / "skills" / "multi-review" / "SKILL.md",
-        REPO_ROOT / ".agents" / "skills" / "multi-adversarial-review" / "SKILL.md",
-    ]
+    """multi-* orchestrators exist for every host this project wires.
+
+    The template wires all four hosts (9 files); a project that keeps fewer is
+    checked against the hosts it kept (#690).
+    """
+    actions = ("plan", "review", "adversarial-review")
+    paths: list[Path] = []
+    if agent_is_present("claude"):
+        paths += [REPO_ROOT / ".claude" / "commands" / f"multi-{a}.md" for a in actions]
+    if agent_is_present("copilot"):
+        paths += [REPO_ROOT / ".copilot" / "commands" / f"multi-{a}.md" for a in actions]
+    # Codex and Antigravity share the .agents/skills/ orchestrators.
+    if agent_is_present("codex") or agent_is_present("antigravity"):
+        paths += [REPO_ROOT / ".agents" / "skills" / f"multi-{a}" / "SKILL.md" for a in actions]
 
     for path in paths:
         assert path.exists(), f"Missing multi-orchestrator file: {path}"
 
 
 def test_self_action_grid_exists() -> None:
-    """All 16 self-action files (4 agents x 4 actions) should exist."""
-    paths = [
-        # Claude self-action
-        REPO_ROOT / ".claude" / "commands" / "claude" / "plan.md",
-        REPO_ROOT / ".claude" / "commands" / "claude" / "implement.md",
-        REPO_ROOT / ".claude" / "commands" / "claude" / "review.md",
-        REPO_ROOT / ".claude" / "commands" / "claude" / "adversarial-review.md",
-        # Copilot self-action (skills under .github/skills/ — see docstring in
-        # tests/test_delegation_matrix.py::_expected_path for why .github/ vs .claude/)
-        REPO_ROOT / ".github" / "skills" / "copilot-plan" / "SKILL.md",
-        REPO_ROOT / ".github" / "skills" / "copilot-implement" / "SKILL.md",
-        REPO_ROOT / ".github" / "skills" / "copilot-review" / "SKILL.md",
-        REPO_ROOT / ".github" / "skills" / "copilot-adversarial-review" / "SKILL.md",
-        # Codex self-action (skills)
-        REPO_ROOT / ".agents" / "skills" / "codex-plan" / "SKILL.md",
-        REPO_ROOT / ".agents" / "skills" / "codex-implement" / "SKILL.md",
-        REPO_ROOT / ".agents" / "skills" / "codex-review" / "SKILL.md",
-        REPO_ROOT / ".agents" / "skills" / "codex-adversarial-review" / "SKILL.md",
-    ]
+    """Every wired agent has its four self-action files.
 
-    for path in paths:
-        assert path.exists(), f"Missing self-action file: {path}"
+    The template wires four agents x four actions = 16 files. The grid is built
+    from the agents this project keeps rather than pinned at the template's
+    roster (#690).
+    """
+    actions = ("plan", "implement", "review", "adversarial-review")
+    # Where each host keeps its self-action files. Copilot uses .github/skills/
+    # rather than .claude/skills/ — see tests/test_delegation_matrix.py
+    # ::_expected_path for why.
+    layouts = {
+        "claude": lambda a: REPO_ROOT / ".claude" / "commands" / "claude" / f"{a}.md",
+        "copilot": lambda a: REPO_ROOT / ".github" / "skills" / f"copilot-{a}" / "SKILL.md",
+        "codex": lambda a: REPO_ROOT / ".agents" / "skills" / f"codex-{a}" / "SKILL.md",
+        "antigravity": lambda a: REPO_ROOT / ".agents" / "skills" / f"antigravity-{a}" / "SKILL.md",
+    }
+
+    for agent in present_agents():
+        for action in actions:
+            path = layouts[agent](action)
+            assert path.exists(), f"Missing self-action file: {path}"
 
 
 def test_retired_self_action_aliases_are_removed() -> None:
@@ -109,6 +110,8 @@ def test_retired_workflow_step_aliases_are_removed() -> None:
 
 def test_codex_config_keeps_shared_dangerous_command_hook() -> None:
     """Codex config should keep the shared dangerous-command hook wired."""
+    skip_if_absent("codex")
+
     config = (REPO_ROOT / ".codex" / "config.toml").read_text(encoding="utf-8")
 
     # `codex_hooks` is the deprecated spelling; Codex warns on it and would
@@ -123,6 +126,8 @@ def test_codex_config_keeps_shared_dangerous_command_hook() -> None:
 
 def test_codex_config_uses_current_schema() -> None:
     """Codex config should avoid obsolete keys from older Codex releases."""
+    skip_if_absent("codex")
+
     config = (REPO_ROOT / ".codex" / "config.toml").read_text(encoding="utf-8")
 
     assert 'approval_policy = "on-request"' in config
@@ -163,6 +168,8 @@ def test_enforcement_principles_document_codex_hook_support() -> None:
 
 def test_antigravity_workflow_skills_exist() -> None:
     """Antigravity self-action skills should be present in the shared .agents/skills directory."""
+    skip_if_absent("antigravity")
+
     for action in ("plan", "implement", "review", "adversarial-review"):
         skill_path = REPO_ROOT / ".agents" / "skills" / f"antigravity-{action}" / "SKILL.md"
         assert skill_path.exists(), f"Missing Antigravity skill: {skill_path}"
@@ -170,6 +177,8 @@ def test_antigravity_workflow_skills_exist() -> None:
 
 def test_antigravity_hooks_json_wires_shared_hook() -> None:
     """.agents/hooks.json should wire the shared dangerous-command hook on PreToolUse."""
+    skip_if_absent("antigravity")
+
     hooks_path = REPO_ROOT / ".agents" / "hooks.json"
     assert hooks_path.exists(), f"Missing Antigravity hooks config: {hooks_path}"
 
@@ -227,20 +236,38 @@ def test_stdout_contract_wirings_route_through_the_launcher() -> None:
     Both block only on a stdout deny payload, so a hook that cannot start reads
     as "allow". The launcher denies in that case; calling the .py directly does
     not, because a script that never runs cannot emit its own deny.
-    """
-    agy = json.loads((REPO_ROOT / ".agents" / "hooks.json").read_text(encoding="utf-8"))
-    agy_commands = [
-        handler.get("command", "")
-        for group in agy.values()
-        for entry in group.get("PreToolUse", [])
-        for handler in entry.get("hooks", [])
-    ]
-    copilot = json.loads(
-        (REPO_ROOT / ".github" / "hooks" / "copilot-hooks.json").read_text(encoding="utf-8")
-    )
-    copilot_commands = [e.get("bash", "") for e in copilot.get("hooks", {}).get("preToolUse", [])]
 
-    for label, commands in (("Antigravity", agy_commands), ("Copilot", copilot_commands)):
+    Only the hosts this project wires are checked (#690); the launcher itself is
+    asserted either way, since it is what makes the contract fail closed.
+    """
+    wirings: list[tuple[str, list[str]]] = []
+
+    if agent_is_present("antigravity"):
+        agy = json.loads((REPO_ROOT / ".agents" / "hooks.json").read_text(encoding="utf-8"))
+        wirings.append(
+            (
+                "Antigravity",
+                [
+                    handler.get("command", "")
+                    for group in agy.values()
+                    for entry in group.get("PreToolUse", [])
+                    for handler in entry.get("hooks", [])
+                ],
+            )
+        )
+
+    if agent_is_present("copilot"):
+        copilot = json.loads(
+            (REPO_ROOT / ".github" / "hooks" / "copilot-hooks.json").read_text(encoding="utf-8")
+        )
+        wirings.append(
+            (
+                "Copilot",
+                [e.get("bash", "") for e in copilot.get("hooks", {}).get("preToolUse", [])],
+            )
+        )
+
+    for label, commands in wirings:
         assert any("block-dangerous-commands.sh" in c for c in commands), (
             f"{label} must route through the fail-closed launcher"
         )
@@ -263,14 +290,21 @@ def test_docs_document_antigravity_agent() -> None:
 
 
 def test_multi_orchestrators_recognize_antigravity() -> None:
-    """All 9 multi-* orchestrator files list antigravity and include an agy invocation block."""
+    """Every wired host's multi-* orchestrators offer antigravity as an agent.
+
+    Skipped when the project does not wire Antigravity — there is nothing for the
+    orchestrators to offer (#690).
+    """
+    skip_if_absent("antigravity")
+
     actions = ("plan", "review", "adversarial-review")
-    multi_files = (
-        [REPO_ROOT / ".claude" / "commands" / f"multi-{a}.md" for a in actions]
-        + [REPO_ROOT / ".copilot" / "commands" / f"multi-{a}.md" for a in actions]
-        + [REPO_ROOT / ".agents" / "skills" / f"multi-{a}" / "SKILL.md" for a in actions]
-    )
-    assert len(multi_files) == 9
+    multi_files: list[Path] = []
+    if agent_is_present("claude"):
+        multi_files += [REPO_ROOT / ".claude" / "commands" / f"multi-{a}.md" for a in actions]
+    if agent_is_present("copilot"):
+        multi_files += [REPO_ROOT / ".copilot" / "commands" / f"multi-{a}.md" for a in actions]
+    multi_files += [REPO_ROOT / ".agents" / "skills" / f"multi-{a}" / "SKILL.md" for a in actions]
+
     for f in multi_files:
         content = f.read_text(encoding="utf-8")
         assert "`antigravity`" in content, f"{f} does not list antigravity as an allowed agent"

--- a/tests/template/test_rule_files.py
+++ b/tests/template/test_rule_files.py
@@ -1,7 +1,7 @@
 """Contract tests for per-stack rule files.
 
-Rule files are mirrored across all three agent rule surfaces because every agent
-in the delegation matrix edits this codebase. The checklist body must stay
+Rule files are mirrored across every agent rule surface this project wires,
+because every agent in the delegation matrix edits this codebase. The checklist body must stay
 identical everywhere: a rule that disagrees with itself across agents is worse
 than no rule, because whichever agent is driving decides which version applies.
 
@@ -17,16 +17,33 @@ import re
 from pathlib import Path
 
 import pytest
+from agent_roster import agent_is_present
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 RULE_NAME = "typing-branch-narrowing"
 
-# Every surface that must carry the rule, and how each one is loaded.
-RULE_PATHS = {
+# Every surface the template mirrors the rule to, and how each one is loaded.
+ALL_RULE_PATHS = {
     "claude": REPO_ROOT / ".claude" / "rules" / f"{RULE_NAME}.md",
     "copilot": REPO_ROOT / ".github" / "instructions" / f"{RULE_NAME}.instructions.md",
     "agents": REPO_ROOT / ".agents" / "skills" / RULE_NAME / "SKILL.md",
+}
+
+# Which agents each surface serves. `.agents/` is read by both Codex and
+# Antigravity, so that surface is live if either agent is.
+SURFACE_AGENTS = {
+    "claude": ("claude",),
+    "copilot": ("copilot",),
+    "agents": ("codex", "antigravity"),
+}
+
+# The surfaces this project actually loads. A project that drops an agent drops
+# its rule surface with it, and must not be told the mirror is broken (#690).
+RULE_PATHS = {
+    surface: path
+    for surface, path in ALL_RULE_PATHS.items()
+    if any(agent_is_present(agent) for agent in SURFACE_AGENTS[surface])
 }
 
 MAX_LINES = 30
@@ -48,16 +65,23 @@ def _body(path: Path) -> str:
 
 @pytest.mark.parametrize("surface", sorted(RULE_PATHS))
 def test_rule_exists_on_every_surface(surface: str) -> None:
-    """The rule is present for all three agent families."""
+    """The rule is present for every agent family this project wires."""
     assert RULE_PATHS[surface].exists(), f"missing {surface} copy: {RULE_PATHS[surface]}"
 
 
 def test_rule_bodies_are_identical_across_surfaces() -> None:
     """The checklist must not drift between agents."""
+    if len(RULE_PATHS) < 2:
+        pytest.skip("only one rule surface is live; there is nothing to drift against")
+
     bodies = {name: _body(path) for name, path in RULE_PATHS.items()}
-    reference = bodies["claude"]
+    reference_surface = next(iter(sorted(bodies)))
+    reference = bodies[reference_surface]
     mismatched = [name for name, body in bodies.items() if body != reference]
-    assert not mismatched, f"rule body differs on {mismatched}; update all three surfaces together"
+    assert not mismatched, (
+        f"rule body differs on {mismatched} (compared against {reference_surface}); "
+        "update every live surface together"
+    )
 
 
 @pytest.mark.parametrize("surface", sorted(RULE_PATHS))
@@ -86,6 +110,8 @@ def test_rule_stays_within_the_line_budget(surface: str) -> None:
 
 def test_copilot_copy_declares_a_path_scope() -> None:
     """Copilot's loader requires ``applyTo:`` frontmatter to gate the file."""
+    if "copilot" not in RULE_PATHS:
+        pytest.skip("copilot is not wired in this project")
     text = RULE_PATHS["copilot"].read_text(encoding="utf-8")
     assert text.startswith("---"), "Copilot instructions need YAML frontmatter"
     assert re.search(r"^applyTo:\s*\S+", text, re.MULTILINE)
@@ -93,6 +119,8 @@ def test_copilot_copy_declares_a_path_scope() -> None:
 
 def test_agents_copy_declares_a_skill_gate_description() -> None:
     """``description:`` is the skill-gate trigger for Codex and Antigravity."""
+    if "agents" not in RULE_PATHS:
+        pytest.skip("neither codex nor antigravity is wired in this project")
     text = RULE_PATHS["agents"].read_text(encoding="utf-8")
     assert re.search(r"^name:\s*\S+", text, re.MULTILINE)
     assert re.search(r"^description:\s*\S+", text, re.MULTILINE)
@@ -103,6 +131,8 @@ def test_claude_loads_rule_files() -> None:
 
     A rule file that ships but never loads is a mechanism built and not used.
     """
+    if "claude" not in RULE_PATHS:
+        pytest.skip("claude is not wired in this project")
     text = (REPO_ROOT / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
     assert re.search(r"^@\./rules/\*\.md\s*$", text, re.MULTILINE), (
         "CLAUDE.md must import ./rules/*.md (uncommented)"

--- a/tests/template/test_secret_env_policy.py
+++ b/tests/template/test_secret_env_policy.py
@@ -23,6 +23,8 @@ import tomllib
 import types
 from pathlib import Path
 
+from agent_roster import skip_if_absent
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_PATH = REPO_ROOT / "tools" / "hooks" / "ai" / "block-dangerous-commands.py"
 CODEX_CONFIG = REPO_ROOT / ".codex" / "config.toml"
@@ -44,6 +46,8 @@ def test_codex_exclude_list_matches_the_hook_patterns() -> None:
     Two copies of a secret-pattern list drift silently: the config would keep
     excluding yesterday's variable names while the hook checked today's.
     """
+    skip_if_absent("codex")
+
     with CODEX_CONFIG.open("rb") as fh:
         policy = tomllib.load(fh)["shell_environment_policy"]
 
@@ -55,6 +59,8 @@ def test_codex_exclude_list_matches_the_hook_patterns() -> None:
 
 def test_codex_still_restricts_the_inherited_environment() -> None:
     """The allowlist is the stronger half of Codex's control; keep it."""
+    skip_if_absent("codex")
+
     with CODEX_CONFIG.open("rb") as fh:
         policy = tomllib.load(fh)["shell_environment_policy"]
 

--- a/tests/test_delegation_matrix.py
+++ b/tests/test_delegation_matrix.py
@@ -2,10 +2,15 @@
 
 Static test only — no CLI or model invocations. Verifies that:
 
-- All 48 source x target x action command/skill cells resolve to files at the
-  documented paths (Codex and Antigravity share the host-agnostic
-  `.agents/skills/delegate-*` files, so distinct files number 40, not 48).
+- Every source x target x action command/skill cell resolves to a file at the
+  documented path (Codex and Antigravity share the host-agnostic
+  `.agents/skills/delegate-*` files, so distinct files number fewer than cells).
 - The matrix documentation page exists.
+
+The matrix is sized from the agents this project wires, not from the template's
+own four. In the template that is 48 cells over 40 distinct files; a project that
+keeps one agent has no cross-agent matrix and checks nothing here, rather than
+failing 37 cells for agents it deliberately dropped (#690).
 
 See `docs/development/ai/cross-agent-delegation.md` and issues #550, #640.
 """
@@ -15,15 +20,24 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from agent_roster import present_agents
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-AGENTS = ("claude", "codex", "copilot", "antigravity")
 ACTIONS = ("plan", "implement", "review", "adversarial-review")
+
+# The agents this project actually wires. The template wires all four; a project
+# spawned from it keeps only the ones it uses, and must not be told its suite is
+# broken for declining the rest (#690).
+AGENTS = present_agents()
 
 
 def _cross_pairs() -> list[tuple[str, str]]:
-    """Yield (source, target) pairs where source != target."""
+    """Yield (source, target) pairs where source != target.
+
+    Empty for a single-agent project — there is no cross-agent matrix to check —
+    which parametrizes the cell tests away rather than failing them.
+    """
     return [(s, t) for s in AGENTS for t in AGENTS if s != t]
 
 
@@ -61,14 +75,16 @@ def test_delegation_file_exists(source: str, target: str, action: str) -> None:
 
 
 def test_total_file_count() -> None:
-    """4 sources x 3 targets x 4 actions = 48 cross-agent cells.
+    """Every cross-agent cell resolves, and Codex/Antigravity share their files.
 
-    Codex and Antigravity share the host-agnostic .agents/skills/delegate-*
-    files, so the antigravity->{claude,copilot} cells reuse Codex's files and
-    the distinct-file count is lower than the cell count.
+    The template wires four agents: 4 sources x 3 targets x 4 actions = 48 cells,
+    of which 8 share a file, leaving 40 distinct. Both counts are *derived* from
+    the agents this project wires rather than pinned, so dropping an agent
+    narrows the matrix instead of failing it (#690).
     """
     cells = [(s, t, a) for s, t in _cross_pairs() for a in ACTIONS]
-    assert len(cells) == 48
+    expected_cells = len(AGENTS) * max(len(AGENTS) - 1, 0) * len(ACTIONS)
+    assert len(cells) == expected_cells
 
     missing = [
         str(_expected_path(s, t, a).relative_to(REPO_ROOT))
@@ -77,10 +93,20 @@ def test_total_file_count() -> None:
     ]
     assert not missing, f"missing delegation files: {missing}"
 
+    # Codex and Antigravity both read the host-agnostic .agents/skills/delegate-*
+    # files, so when a project wires both, every cell they aim at a third agent
+    # collapses onto one file.
+    both_share = "codex" in AGENTS and "antigravity" in AGENTS
+    shared_cells = (
+        len([t for t in AGENTS if t not in ("codex", "antigravity")]) * len(ACTIONS)
+        if both_share
+        else 0
+    )
     distinct = {_expected_path(s, t, a) for s, t, a in cells}
-    # antigravity->{claude,copilot} reuses Codex's host-agnostic files:
-    # 8 of the 48 cells share a file, leaving 40 distinct.
-    assert len(distinct) == 40, f"expected 40 distinct files, found {len(distinct)}"
+    assert len(distinct) == expected_cells - shared_cells, (
+        f"expected {expected_cells - shared_cells} distinct files for agents "
+        f"{AGENTS}, found {len(distinct)}"
+    )
 
 
 def test_matrix_doc_exists() -> None:

--- a/tests/test_markdown_links.py
+++ b/tests/test_markdown_links.py
@@ -19,6 +19,7 @@ import re
 from pathlib import Path
 
 import pytest
+from agent_roster import ALL_AGENTS, agent_is_present, present_agents
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_DIR = REPO_ROOT / "docs"
@@ -71,6 +72,31 @@ def _resolve(source: Path, target: str) -> Path:
     return (source.parent / target.split("#")[0]).resolve()
 
 
+# Which agents each config root belongs to. `.agents/` is read by both Codex and
+# Antigravity, so it is only absent when neither is wired.
+_AGENT_CONFIG_ROOTS: dict[Path, tuple[str, ...]] = {
+    REPO_ROOT / ".claude": ("claude",),
+    REPO_ROOT / ".codex": ("codex",),
+    REPO_ROOT / ".copilot": ("copilot",),
+    REPO_ROOT / ".github" / "skills": ("copilot",),
+    REPO_ROOT / ".agents": ("codex", "antigravity"),
+}
+
+
+def _points_into_an_unwired_agent(resolved: Path) -> bool:
+    """Return whether *resolved* lives under a config root this project dropped.
+
+    The template's AI docs describe every agent it can wire. A project that keeps
+    only some still ships that prose, so links into the dropped agents' config
+    dirs dangle — expected, not broken (#690). In the template every agent is
+    wired, so this never fires and the check is exactly as strict as before.
+    """
+    for root, owners in _AGENT_CONFIG_ROOTS.items():
+        if resolved == root or root in resolved.parents:
+            return not any(agent_is_present(agent) for agent in owners)
+    return False
+
+
 @pytest.mark.parametrize("doc", _iter_markdown(), ids=lambda p: str(p.relative_to(REPO_ROOT)))
 def test_relative_links_resolve(doc: Path) -> None:
     """Every relative link in a docs page points at a file that exists.
@@ -81,7 +107,7 @@ def test_relative_links_resolve(doc: Path) -> None:
     broken = []
     for target in _link_targets(doc):
         resolved = _resolve(doc, target)
-        if not resolved.exists():
+        if not resolved.exists() and not _points_into_an_unwired_agent(resolved):
             broken.append(f"{target} -> {resolved}")
     assert not broken, f"{doc.relative_to(REPO_ROOT)} has broken links:\n  " + "\n  ".join(broken)
 
@@ -108,3 +134,28 @@ def test_the_scanner_actually_finds_links() -> None:
     """
     total = sum(len(_link_targets(doc)) for doc in _iter_markdown())
     assert total > 100, f"expected many repo links across docs/, found {total}"
+
+
+def test_unwired_agent_filter_is_inert_in_the_template() -> None:
+    """The absent-agent exemption must not be masking real breakage here.
+
+    When every agent is wired nothing may qualify for the exemption. If this
+    fails, `_points_into_an_unwired_agent` is swallowing links it should be
+    reporting.
+
+    Skipped in a project that dropped an agent — there the exemption firing is
+    the point, not a defect.
+    """
+    if set(present_agents()) != set(ALL_AGENTS):
+        pytest.skip("project does not wire every agent; the exemption is expected to fire")
+
+    exempted = [
+        f"{doc.relative_to(REPO_ROOT)}: {target}"
+        for doc in _iter_markdown()
+        for target in _link_targets(doc)
+        if _points_into_an_unwired_agent(_resolve(doc, target))
+    ]
+    assert not exempted, (
+        "links were exempted as belonging to an unwired agent, but this project "
+        f"wires all of them: {exempted}"
+    )


### PR DESCRIPTION
## Description

The template wires four AI agents; most projects spawned from it keep one. Five test
files asserted that all 68 delegation files existed, so a project that dropped an agent
it does not use got **56 failures on its first run**.

This sizes those tests to the project instead. Dropping an agent now narrows what the
suite checks rather than reddening it.

## Related Issue

Addresses #690

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

`tests/agent_roster.py` resolves which agents a project wires. Presence is keyed on each
agent's **self-action skill directory**, not its config root: `.agents/` is read by both
Codex and Antigravity, so its existence cannot distinguish them.

| file | failures fixed | change |
| :--- | ---: | :--- |
| `test_delegation_matrix.py` | 37 | matrix sized from the roster; cell and distinct-file counts derived rather than pinned at the template's 48 and 40 |
| `test_ai_agent_assets.py` | 9 | per-agent skips; multi-orchestrator and self-action grids built per wired host |
| `test_rule_files.py` | 6 | rule surfaces filtered to the live ones; body-drift check compares only those |
| `test_secret_env_policy.py` | 2 | `.codex/config.toml` assertions skip when Codex is absent |
| `test_markdown_links.py` | 2 | links into an unwired agent's config root are expected, not broken |

`pyproject.toml` gains `[tool.pyright] extraPaths = ["tests"]` so the shared helper
resolves for the LSP the way it already does for pytest and mypy (`tests/` is not a
package, so pytest puts it on `sys.path`).

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Measured by removing the non-Claude agent directories and running the full suite:

| shape | before | after |
| :--- | ---: | ---: |
| Claude-only | **56 failed** | **0 failed** — 1316 passed, 16 skipped |
| Claude + Copilot | — | **0 failed** — 1330 passed, 10 skipped |
| template (all four) | 1384 passed | **1384 passed** — unchanged |
| coverage | 64.34% | **64.34%** — unchanged |

**The non-vacuity guard caught a bug in itself.** `test_unwired_agent_filter_is_inert_in_the_template`
asserts the new broken-link exemption never fires while all four agents are wired. It
failed in the Claude-only run — correctly, because there the exemption *should* fire.
Left as written it would have failed in every real downstream, so it is now scoped to
the full-roster case. Worth noting because it is the failure mode the repo keeps hitting:
a guard that looks like protection and is actually miscalibrated.

**One test got stricter, not looser.** `test_self_action_grid_exists` was documented as
"All 16 self-action files (4 agents x 4 actions)" but only listed 12 — Antigravity's four
were never asserted. Building the grid from the roster picks them up, so the template now
checks what the docstring always claimed.

`doit check`: all passed. `mkdocs build --strict`: clean.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### This does not fully address #690, and should not auto-close it

The issue's premise did not survive verification, and two of its five success criteria
are deliberately **not** met.

**The counts were substantially off.** Measured on `main`:

| issue claims | actual |
| :--- | :--- |
| ~396 infrastructure tests | **625** |
| AI hooks: 10 files, ~90 tests | **13 files, 318 tests** |
| delegation matrix: 83 tests | **50** |
| *(not listed)* | `test_markdown_links.py` — **68 tests** |
| "`configure.py:449` removes `tests/template/` (640 tests)" | stale — #732 changed it to shed 11 files |
| "51 failing tests on day one" | **37** from the matrix, **56** across five files |

**Its core proposal would re-break #731.** Adding those files to
`TEMPLATE_OWNED_TEST_FILES`, measured:

| | before | after 690-as-written |
| :--- | ---: | ---: |
| `tools/hooks/` | 85.09% | **8.27%** |
| total | 64.34% | **40.73%** (under `fail_under = 54`) |

Those are the tests for `tools/doit/` and `tools/hooks/` — code that ships to and runs in
the spawned project. #731/#732 established they must stay, and ADR-9017 defines
template-owned as *the target does not survive configuration*. Hooks, workflows,
statuslines and agent command files all survive.

So these two criteria are rejected, with the measurements above as the reason:

- [ ] ~~A configured project's test suite contains only tests relevant to that project~~
- [ ] ~~`TEMPLATE_OWNED_TEST_FILES` covers every infrastructure test, wherever it lives~~

The remaining criterion — "a test asserts no test file outside the owned list imports
template-only modules or fixtures" — is what PR #733 adds as
`test_kept_tests_do_not_depend_on_shed_paths`, on the #691 branch.

**Recommend merging without `--auto-close`** and deciding #690's disposition separately:
either re-scope it to the accepted criteria, or close it as answered by #731/#732/#733
plus this PR.

### ADR-9017 untouched

This changes no ownership, so the ownership ADR does not apply; and #733 is still open
against that file. The convention — *tests of shipped assets fit the project, not the
template* — went into [CI/CD and Testing](../blob/main/docs/development/ci-cd-testing.md)
instead, alongside the coverage-gate rationale it depends on.
