### PR TITLE
refactor: assert the cross-agent workflow contract, don't just check existence

### DIFF
--- a/.agents/skills/antigravity-adversarial-review/SKILL.md
+++ b/.agents/skills/antigravity-adversarial-review/SKILL.md
@@ -22,6 +22,8 @@ The user may include focus text.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 1. Check the current state of changes:
    ```bash
    git status

--- a/.agents/skills/antigravity-review/SKILL.md
+++ b/.agents/skills/antigravity-review/SKILL.md
@@ -22,6 +22,8 @@ The user may include optional focus text.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 1. Verify a PR exists for the current branch:
    ```bash
    gh pr view --json number,title,body,headRefName

--- a/.agents/skills/codex-adversarial-review/SKILL.md
+++ b/.agents/skills/codex-adversarial-review/SKILL.md
@@ -20,6 +20,8 @@ The user may include focus text after the trigger.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 1. Check the current state of changes:
    ```bash
    git status

--- a/.agents/skills/codex-review/SKILL.md
+++ b/.agents/skills/codex-review/SKILL.md
@@ -20,6 +20,8 @@ The user may include optional focus text after the trigger.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 1. Verify a PR exists for the current branch:
    ```bash
    gh pr view --json number,title,body,headRefName

--- a/.claude/commands/claude/adversarial-review.md
+++ b/.claude/commands/claude/adversarial-review.md
@@ -4,6 +4,8 @@ Run a steerable adversarial review using Claude — pressure-tests design choice
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 This command runs in the main conversation context. Claude performs the adversarial review directly — no external CLI invocation needed.
 
 ### Step 1: Gather review context

--- a/.claude/commands/claude/review.md
+++ b/.claude/commands/claude/review.md
@@ -4,6 +4,8 @@ Run a single-agent PR review using Claude. Optional focus area: $ARGUMENTS.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 This command runs in the main conversation context. Claude reviews the current branch's PR directly — no external CLI invocation needed.
 
 ### Step 1: Verify a PR exists

--- a/.github/skills/copilot-adversarial-review/SKILL.md
+++ b/.github/skills/copilot-adversarial-review/SKILL.md
@@ -15,6 +15,8 @@ Optional focus area can be given as a freeform argument.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 This skill runs inline in the active Copilot session. Copilot performs the adversarial review directly.
 
 ### Step 1: Gather review context

--- a/.github/skills/copilot-review/SKILL.md
+++ b/.github/skills/copilot-review/SKILL.md
@@ -15,6 +15,8 @@ Optional focus area can be given as a freeform argument.
 
 ## Instructions
 
+**Read-only.** Review and report — do not edit files, commit, or push. Findings go to the user and the PR; any fix is a separate change the user asks for.
+
 This skill runs inline in the active Copilot session. Copilot reviews the current branch's PR directly.
 
 ### Step 1: Verify a PR exists

--- a/docs/development/ai/cross-agent-delegation.md
+++ b/docs/development/ai/cross-agent-delegation.md
@@ -37,6 +37,52 @@ Self-action and cross-agent delegation share the same naming convention within e
 | `review` | optional focus area | Reviews current PR or branch-vs-main changes. |
 | `adversarial-review` | optional focus | Steerable challenge review — pressure-tests design, hidden assumptions, alternatives, failure modes. |
 
+## Workflow contract
+
+The naming convention above says where the files live. This says what they must **say**.
+
+Because a user can switch agents mid-workflow — plan with Codex, implement with Claude,
+review with Copilot — the workflow files carry a handful of literal strings that let the
+next agent pick up the state the previous one left. These are a contract, not prose
+choices: if one host stops emitting the plan-comment header, the next agent cannot find
+the plan.
+
+| Element | Literal | Required in | Why it is load-bearing |
+| :--- | :--- | :--- | :--- |
+| Plan-comment header | `Implementation Plan for` | every `plan` file | How `implement` locates the plan comment on the issue |
+| Branch-name pattern | `<type>/` | every `implement` file | `doit pr` derives the issue number from the branch name |
+| Validation command | `doit check` | every `implement` file | The pre-commit gate the workflow promises |
+| Finalize handoff | `ghi-finalize` | every `implement` file | Tells the user the next step; implement never opens a PR |
+| Issue reference | `Addresses #` | every `ghi-finalize` file | Links the PR to its issue; `doit pr_merge --auto-close` depends on it |
+| Read-only constraint | the sentence below | every `review` and `adversarial-review` file | A review that edits code is not a review |
+
+The read-only constraint must appear **verbatim** on every surface, because a
+constraint paraphrased per host drifts into a weaker version on one of them, and
+whichever agent is driving decides which version applies:
+
+> **Read-only.** Review and report — do not edit files, commit, or push. Findings go to
+> the user and the PR; any fix is a separate change the user asks for.
+
+### Declared exemptions
+
+Uniform prose is not the goal — agreement on the contract is. Where a host genuinely
+differs, the difference is declared rather than papered over:
+
+| Element | Host | Why |
+| :--- | :--- | :--- |
+| `doit check` in `implement` | Claude | Claude delegates implementation to `.claude/agents/implement-worker.md`, which runs it. The command file itself never names it. |
+
+### Enforcement
+
+`tests/test_cross_agent_contract.py` asserts every element above, and its `EXEMPTIONS`
+table mirrors the one here. **This document is the specification**; when the two
+disagree, the test is the bug. Adding an exemption to the test without adding a row here
+is how a contract quietly becomes a suggestion.
+
+The checks are scoped to the agents a project actually wires (see
+`tests/agent_roster.py`), so a project that keeps one agent is held to the contract for
+that agent only.
+
 ## Matrix
 
 The 4 sources × 4 targets × 4 actions = 64 cells (including self-action). Cross-agent delegation is 4 × 3 × 4 = 48 cells, across **40 distinct files** — Codex and Antigravity share the host-agnostic `.agents/skills/delegate-*` files, so the 8 `antigravity → {claude, copilot}` cells reuse Codex's files.

--- a/tests/test_cross_agent_contract.py
+++ b/tests/test_cross_agent_contract.py
@@ -1,0 +1,214 @@
+"""The cross-agent workflow files must agree, not merely exist.
+
+`test_delegation_matrix.py` checks that every command/skill file is present.
+Presence is not agreement: the files encode a shared workflow contract — the plan
+comment header, the branch-name pattern, the finalize handoff — that lets a user
+switch agents mid-workflow without losing state. Until now nothing checked that
+they still said the same things, so the contract held only by manual discipline
+across 74 files (#692).
+
+The contract itself is documented in
+``docs/development/ai/cross-agent-delegation.md``; this module is its enforcement.
+When the two disagree, the doc is the specification and this file is the bug.
+
+Per-agent exemptions are declared in `EXEMPTIONS` with a reason, because uniform
+prose is not the goal — agreement on the contract is. Claude's `implement`
+command legitimately omits `doit check` because it delegates to
+`.claude/agents/implement-worker.md`, which runs it.
+
+Assertions are scoped to the agents a project actually wires, following the
+convention in `tests/agent_roster.py` (#690).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agent_roster import agent_is_present, present_agents
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Where each agent keeps its self-action workflow file for a given action.
+SELF_ACTION_LAYOUTS = {
+    "claude": lambda action: REPO_ROOT / ".claude" / "commands" / "claude" / f"{action}.md",
+    "copilot": lambda action: REPO_ROOT / ".github" / "skills" / f"copilot-{action}" / "SKILL.md",
+    "codex": lambda action: REPO_ROOT / ".agents" / "skills" / f"codex-{action}" / "SKILL.md",
+    "antigravity": (
+        lambda action: REPO_ROOT / ".agents" / "skills" / f"antigravity-{action}" / "SKILL.md"
+    ),
+}
+
+# The finalize step is host-agnostic: Claude has its own copy, and every other
+# host reaches the `.agents/skills/` one (Copilot reads that directory too).
+FINALIZE_FILES = (
+    REPO_ROOT / ".claude" / "commands" / "ghi-finalize.md",
+    REPO_ROOT / ".agents" / "skills" / "ghi-finalize" / "SKILL.md",
+)
+
+# Contract elements, by the action whose files must carry them. Each entry is
+# (label, substring). Substrings rather than regexes: the contract is a literal
+# string the agents must reproduce, so a literal check is the honest test.
+CONTRACT = {
+    "plan": [
+        ("plan-comment header", "Implementation Plan for"),
+    ],
+    "implement": [
+        ("branch-name pattern", "<type>/"),
+        ("validation command", "doit check"),
+        ("finalize handoff", "ghi-finalize"),
+    ],
+    "review": [
+        ("read-only constraint", "**Read-only.**"),
+    ],
+    "adversarial-review": [
+        ("read-only constraint", "**Read-only.**"),
+    ],
+}
+
+# (action, agent) pairs that legitimately omit an element, with the reason.
+# An exemption is a documented architectural difference, not a licence to drift.
+EXEMPTIONS: dict[tuple[str, str, str], str] = {
+    ("implement", "claude", "validation command"): (
+        "Claude delegates implementation to .claude/agents/implement-worker.md, "
+        "which runs `doit check` itself"
+    ),
+}
+
+# The identical sentence every review file must carry, so the constraint cannot
+# be reworded into something weaker on one surface.
+READ_ONLY_SENTENCE = (
+    "**Read-only.** Review and report — do not edit files, commit, or push. "
+    "Findings go to the user and the PR; any fix is a separate change the user asks for."
+)
+
+
+def _self_action_files(action: str) -> list[tuple[str, Path]]:
+    """Return (agent, path) for each wired agent's file for *action*."""
+    return [(agent, SELF_ACTION_LAYOUTS[agent](action)) for agent in present_agents()]
+
+
+def _contract_violations(action: str, agent: str, text: str) -> list[str]:
+    """Return the contract elements *text* is missing for (*action*, *agent*).
+
+    Shared by the real check and its non-vacuity companion, so the companion
+    exercises the logic that actually runs rather than a restatement of it.
+    """
+    return [
+        f"{agent}/{action} is missing the {label} ({needle!r})"
+        for label, needle in CONTRACT[action]
+        if needle not in text and (action, agent, label) not in EXEMPTIONS
+    ]
+
+
+@pytest.mark.parametrize("action", sorted(CONTRACT))
+def test_self_action_files_carry_the_contract(action: str) -> None:
+    """Every wired agent's file for *action* contains that action's contract elements."""
+    missing: list[str] = []
+
+    for agent, path in _self_action_files(action):
+        if not path.is_file():
+            missing.append(f"{agent}: {path.relative_to(REPO_ROOT)} does not exist")
+            continue
+        missing += _contract_violations(action, agent, path.read_text(encoding="utf-8"))
+
+    assert not missing, (
+        "cross-agent contract violations:\n  "
+        + "\n  ".join(missing)
+        + "\n\nThe contract is specified in docs/development/ai/cross-agent-delegation.md. "
+        "If an agent legitimately differs, declare it in EXEMPTIONS with a reason."
+    )
+
+
+def test_read_only_constraint_is_worded_identically() -> None:
+    """The review constraint must be the same sentence everywhere.
+
+    A constraint that is paraphrased per host drifts into a weaker version on one
+    surface, and whichever agent is driving decides which version applies — the
+    same failure mode the rule-file mirror guards against.
+    """
+    divergent = []
+    for action in ("review", "adversarial-review"):
+        for agent, path in _self_action_files(action):
+            if not path.is_file():
+                continue
+            if READ_ONLY_SENTENCE not in path.read_text(encoding="utf-8"):
+                divergent.append(f"{agent}/{action}")
+
+    assert not divergent, (
+        f"these files do not carry the exact read-only sentence: {divergent}. "
+        "Reword all of them together or none."
+    )
+
+
+def test_finalize_files_carry_the_issue_reference_contract() -> None:
+    """`Addresses #` lives in the finalize step, which is what opens the PR.
+
+    Asserted here rather than on `implement` because no implement file opens a
+    PR — a distinction #692 originally had the other way round.
+    """
+    missing = [
+        str(path.relative_to(REPO_ROOT))
+        for path in FINALIZE_FILES
+        if path.is_file() and "Addresses #" not in path.read_text(encoding="utf-8")
+    ]
+    assert not missing, f"finalize files missing the 'Addresses #' contract: {missing}"
+
+
+def test_at_least_one_finalize_file_exists() -> None:
+    """Guard the check above against silently passing on an empty set."""
+    assert any(path.is_file() for path in FINALIZE_FILES), (
+        "no ghi-finalize file found; the contract check above would be vacuous"
+    )
+
+
+def test_the_contract_scanner_detects_a_violation() -> None:
+    """Feeding the checker a file with none of the contract must flag every element.
+
+    Without this, `test_self_action_files_carry_the_contract` could pass because
+    the checker finds nothing to complain about rather than because the files
+    comply. Uses an agent with no exemptions so nothing is silently skipped.
+    """
+    empty = "an unrelated document with none of the contract in it"
+
+    for action, elements in CONTRACT.items():
+        violations = _contract_violations(action, "copilot", empty)
+        assert len(violations) == len(elements), (
+            f"scanner found {len(violations)} of {len(elements)} missing elements "
+            f"for {action!r}; the needles are too weak to assert on"
+        )
+
+
+def test_declared_exemptions_actually_suppress() -> None:
+    """An exemption must change the outcome, or it is decoration.
+
+    Claude's implement file is exempt from `doit check`; the same empty text
+    scored against Copilot must therefore yield one more violation.
+    """
+    empty = "an unrelated document with none of the contract in it"
+    claude = _contract_violations("implement", "claude", empty)
+    copilot = _contract_violations("implement", "copilot", empty)
+
+    assert len(claude) == len(copilot) - 1, (
+        "the Claude implement exemption did not suppress anything; "
+        f"claude={claude} copilot={copilot}"
+    )
+
+
+def test_exemptions_are_real_and_documented() -> None:
+    """Every exemption must name a live agent/action and actually be needed.
+
+    Stops the exemption table from outliving the difference it excuses — the way
+    an allowlist quietly becomes a list of things nobody checks.
+    """
+    stale: list[str] = []
+    for (action, agent, label), reason in EXEMPTIONS.items():
+        assert reason.strip(), f"exemption ({action}, {agent}, {label}) needs a reason"
+        if not agent_is_present(agent):
+            continue
+        path = SELF_ACTION_LAYOUTS[agent](action)
+        needle = next(n for lbl, n in CONTRACT[action] if lbl == label)
+        if path.is_file() and needle in path.read_text(encoding="utf-8"):
+            stale.append(f"({action}, {agent}, {label}) — the file now carries {needle!r}")
+
+    assert not stale, f"these exemptions are no longer needed and should be removed: {stale}"


### PR DESCRIPTION
## Description

The cross-agent command and skill files encode a shared workflow contract — the
plan-comment header, the branch-name pattern, the finalize handoff — that lets a user
switch agents mid-workflow without losing state. `tests/test_delegation_matrix.py`
verified all 74 files **exist**. Nothing verified they **agree**.

This documents the contract in one place and asserts it in CI.

## Related Issue

Addresses #692

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

**The contract is now written down.** `docs/development/ai/cross-agent-delegation.md`
already covered naming, paths, invocation and payload schema in 158 lines, but never said
what the files must *say*. A new "Workflow contract" section lists six elements with why
each is load-bearing — for example `<type>/` matters because `doit pr` derives the issue
number from the branch name, and `Addresses #` matters because `doit pr_merge
--auto-close` depends on it.

**The read-only constraint now exists.** It is added verbatim to all eight `review` and
`adversarial-review` files. Before this, no review file stated it in its body; only
Copilot's adversarial-review mentioned it, in `description:` frontmatter.

**`tests/test_cross_agent_contract.py`** asserts the contract. It is scoped to the agents
a project actually wires (the `tests/agent_roster.py` convention from #690), so a project
that keeps one agent is held to the contract for that agent only.

Divergence is handled by a declared `EXEMPTIONS` table rather than forced uniformity —
uniform prose is not the goal, agreement on the contract is.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

Each guard was verified by reintroducing the regression it exists to catch:

| regression simulated | caught by |
| :--- | :--- |
| read-only sentence deleted from one surface | contract check **and** wording check |
| sentence **reworded weaker** on one surface ("try not to edit files") | wording check only |
| plan-comment header dropped from `claude/plan.md` | contract check |

The middle row is why there are two checks rather than one: the reworded sentence still
contains `**Read-only.**`, so the substring check passed and only byte-equality caught the
weakening. That is the exact failure mode the rule-file mirror guards against — a
constraint that disagrees with itself across agents, where whichever agent is driving
decides which version applies.

Two structural guards back the rest:

- `test_declared_exemptions_actually_suppress` — proves an exemption changes the outcome
  rather than decorating the table.
- `test_exemptions_are_real_and_documented` — fails when an exemption outlives the
  difference it excuses.
- `test_the_contract_scanner_detects_a_violation` — feeds the real checking function text
  with none of the contract and requires it to flag every element, so the main check
  cannot pass by finding nothing.

`doit check`: all passed. `mkdocs build --strict`: clean. Downstream shape (Claude-only):
1329 passed, 16 skipped, 0 failed.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### Corrections to the issue's premise

**Stale, from Gemini's removal (#712):**

| issue claims | actual |
| :--- | :--- |
| 112 files, ~304 KB | **74 files, 185 KB** (ratio to the 6.6 KB payload is ~28x, not ~48x) |
| five self-action `plan` commands | **four** — `.gemini/commands/gemini/plan.toml` is gone |
| `.gemini/settings.json` `skills.disabled` covers 34 of 34 | moot |

The 29-line spread across the `plan` files survives (84–113); Gemini's 104 sat in the
middle of the range.

**Wrong independent of Gemini** — two of the issue's proposed assertions would have failed
on all four agents:

- **`Addresses #` is not an `implement` element.** It lives in `ghi-finalize`, and no
  implement file opens a PR. Asserted there instead.
- **No `review` file stated a read-only constraint.** That was not drift to catch but a
  convention that did not exist. Per discussion this PR adds it rather than dropping the
  criterion.

**Confirmed:** nothing asserted content agreement, and the contract was undocumented. The
contract that does exist held 4/4 on every element before this PR — so the measurable
drift was line count, not contract violation. The value here is preventing the next
divergence, not repairing an existing one.

### A near-miss worth recording

`.github/skills/copilot-implement/SKILL.md:103` tells the user to run `/ghi-finalize`, and
there is no `ghi-finalize` under `.github/skills/`. It resolves only because Copilot also
reads `.agents/skills/`, where the skill lives. Not a defect — but telling a real break
from a working cross-surface reference required checking `AGENTS.md`'s skill-discovery
rules, which is precisely the problem the issue describes.

### Direction B not taken

The issue offered generating the surface from one contract definition plus per-host
templates. This is Direction A, which the issue calls the pragmatic first step and which
does not preclude B. Worth noting that B's value drops now that the contract is asserted:
generation prevents drift, and so does a failing test, at a fraction of the cost.
