### PR TITLE
fix: drop the Hypothesis deadline in CI so property tests stop flaking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,32 @@ from unittest.mock import MagicMock, patch
 import pytest
 from hypothesis import HealthCheck, settings
 
-# CI profile: fewer examples, relaxed deadline for slow CI runners
+# CI profile: fewer examples, no deadline.
+#
+# `deadline=None` rather than a larger number (#736). These are property tests
+# over string validation — they assert what a value *is*, never how long it took,
+# and `benchmark.yml` covers timing separately. A wall-clock budget on a shared
+# runner only adds a way for them to fail for reasons unrelated to the property.
+#
+# Windows runners were seen taking 1506ms on an example's first call and 0.01ms
+# on the retry: interpreter and import warmup, not the code under test. The
+# earlier 200ms -> 500ms relaxation did not survive that, and any finite
+# replacement is a threshold a bad runner can still cross.
+#
+# Note that `suppress_health_check=[HealthCheck.too_slow]` does *not* cover this.
+# The health check and the per-example deadline are separate mechanisms, which is
+# why the profile looked protected against slow runners while still failing on
+# them.
 settings.register_profile(
     "ci",
     max_examples=50,
-    deadline=500,
+    deadline=None,
     suppress_health_check=[HealthCheck.too_slow, HealthCheck.differing_executors],
 )
 
-# Default profile: more thorough exploration for local development
+# Default profile: more thorough exploration for local development.
+# Keeps Hypothesis's default deadline — a developer machine is not a shared
+# runner, so a genuinely pathological slowdown is worth surfacing locally.
 settings.register_profile(
     "default",
     max_examples=200,

--- a/tests/test_hypothesis_profiles.py
+++ b/tests/test_hypothesis_profiles.py
@@ -1,0 +1,84 @@
+"""The Hypothesis CI profile must exist, be loaded, and impose no deadline.
+
+Property tests were failing on `windows-latest` because a runner took 1506ms on an
+example's first call and 0.01ms on the retry — warmup, not the code under test.
+The `ci` profile looked protected against that (it suppressed
+`HealthCheck.too_slow`) while still failing on it, because the health check and
+the per-example deadline are separate mechanisms (#736).
+
+The load check matters as much as the value check: a profile that is registered
+but never loaded is configuration that reports success while doing nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from hypothesis import settings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFTEST = REPO_ROOT / "tests" / "conftest.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+CI_PROFILE = "ci"
+
+
+def test_ci_profile_is_registered() -> None:
+    """`settings.get_profile` must find it — guards the checks below from vacuity."""
+    assert settings.get_profile(CI_PROFILE) is not None
+
+
+def test_ci_profile_imposes_no_deadline() -> None:
+    """A wall-clock budget on a shared runner fails for reasons unrelated to the property.
+
+    These tests assert what a generated value *is*, never how long producing it
+    took; `benchmark.yml` covers timing. Any finite deadline is a threshold a slow
+    runner can cross, which is how the earlier 200ms -> 500ms relaxation still
+    flaked (#736).
+    """
+    assert settings.get_profile(CI_PROFILE).deadline is None, (
+        "the ci Hypothesis profile must set deadline=None; a finite deadline "
+        "makes property tests fail on runner warmup (#736)"
+    )
+
+
+def test_ci_workflow_actually_loads_the_ci_profile() -> None:
+    """CI must set `HYPOTHESIS_PROFILE=ci`, or the profile above is dead config.
+
+    `conftest.py` loads whatever `HYPOTHESIS_PROFILE` names, defaulting to
+    `default`. Without this the ci profile could be tuned indefinitely while CI
+    quietly ran the local one.
+    """
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    test_job = workflow["jobs"]["test"]
+    env = test_job.get("env", {})
+
+    assert env.get("HYPOTHESIS_PROFILE") == CI_PROFILE, (
+        f"ci.yml's test job must set HYPOTHESIS_PROFILE: {CI_PROFILE}; "
+        f"found {env.get('HYPOTHESIS_PROFILE')!r}"
+    )
+
+
+def test_conftest_reads_the_profile_from_the_environment() -> None:
+    """The wiring between the workflow env var and the profile must stay intact."""
+    source = CONFTEST.read_text(encoding="utf-8")
+    assert re.search(r"load_profile\(\s*os\.environ\.get\(\s*[\"']HYPOTHESIS_PROFILE", source), (
+        "conftest.py must load the profile named by HYPOTHESIS_PROFILE, or the "
+        "workflow's env var has nothing to act on"
+    )
+
+
+@pytest.mark.parametrize("profile", [CI_PROFILE, "default"])
+def test_profiles_keep_a_bounded_example_budget(profile: str) -> None:
+    """Dropping the deadline must not turn into an unbounded run.
+
+    `max_examples` is what keeps the suite finite now that nothing times it out.
+    """
+    max_examples = settings.get_profile(profile).max_examples
+    assert 0 < max_examples <= 500, (
+        f"{profile} profile has max_examples={max_examples}; keep it bounded so the "
+        "suite stays finite without a deadline"
+    )


### PR DESCRIPTION
## Description

Hypothesis property tests failed intermittently on `windows-latest` with
`DeadlineExceeded`, then passed on a re-run with no code change. A runner took
**1506ms** on an example's first call and **0.01ms** on the retry — a ~150,000x spread
that is interpreter and import warmup, not the code under test.

## Related Issue

Addresses #736

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## Changes Made

**`tests/conftest.py`** — the `ci` profile goes from `deadline=500` to `deadline=None`.

The profile *looked* protected against slow runners: it already suppressed
`HealthCheck.too_slow` and had been relaxed from Hypothesis's 200ms default to 500ms. But
`suppress_health_check` and the per-example `deadline` are separate mechanisms, so that
relaxation only half-applied — the health check was silenced while the deadline kept
firing.

`deadline=None` rather than a larger number, because the deadline is not protecting
anything here. These are property tests over string validation: they assert what a
generated package name *is* — only valid characters, never leading with a digit — and
never how long producing it took. `benchmark.yml` covers timing separately. Any finite
budget is just a threshold a slow shared runner can still cross, which is the situation
the 200ms -> 500ms change already left us in.

The `default` profile keeps its deadline: a developer machine is not a shared runner, so a
genuinely pathological slowdown is still worth surfacing locally.

**`tests/test_hypothesis_profiles.py`** — six guards.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**The failure was reproduced, not reasoned about.** Injecting a 1.5s first-call stall into
a property test, matching the observed Windows warmup:

| profile | result |
| :--- | :--- |
| `deadline=None` (this PR) | **passed** in 1.56s |
| `deadline=500` (before) | `FlakyFailure` + `DeadlineExceeded: Test took 1500.11ms, which exceeds the deadline of 500.00ms` |

That second row is the same error class seen on PR #733, at the same magnitude.

**Each guard was verified by breaking what it guards:**

| regression simulated | guard that fired |
| :--- | :--- |
| finite deadline reintroduced | `test_ci_profile_imposes_no_deadline` |
| `ci.yml` stops setting `HYPOTHESIS_PROFILE: ci` | `test_ci_workflow_actually_loads_the_ci_profile` |
| `conftest.py` stops reading the env var | `test_conftest_reads_the_profile_from_the_environment` |

The last two matter more than the deadline assertion. A profile can be tuned indefinitely
while CI quietly runs a different one — configuration that reports success while doing
nothing, which is the failure shape this repository keeps finding. The original bug was a
milder version of it: `suppress_health_check=[HealthCheck.too_slow]` read as slow-runner
protection but never touched the deadline.

`test_profiles_keep_a_bounded_example_budget` covers the obvious follow-on risk: with
nothing timing the tests out, `max_examples` is what keeps the suite finite, so it is now
asserted for both profiles.

`doit check`: all passed. Full suite under `HYPOTHESIS_PROFILE=ci`: **1393 passed**.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — no documented behaviour changes; the rationale lives in the profile comment and the guard docstrings
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

**Blast radius was 16 property tests, and it reached downstream projects:**

| file | `@given` tests | ships downstream? |
| :--- | ---: | :--- |
| `tests/template/test_utils_properties.py` | 12 | no — template-owned (ADR-9017) |
| `tests/template/test_properties.py` | 4 | **yes** |

`tests/conftest.py` ships too, so every project spawned from the template inherited the
same tripwire. Fixing it here fixes it for them.

**Found while merging PR #733**, where it cost a re-run of the `windows-latest, 3.12` job.
Worth stating plainly: the cost of leaving this is not only the re-runs, but that it
teaches people to re-run red CI reflexively instead of reading it.
