### PR TITLE
fix: repair three dangling pointers in CLAUDE.md's MANDATORY blocks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,7 +47,7 @@ When creating new code (functions, modules, commands, features), Claude MUST use
 # DEVELOPMENT WORKFLOW (MANDATORY)
 
 Before making ANY changes, Claude MUST:
-1. Read AGENTS.md and locate the "## Development Workflow" section
+1. Read .github/CONTRIBUTING.md and locate the "## Development Workflow" section
 2. Verify the workflow: Issue → Branch → Commit → PR → Merge
 3. **NEVER commit directly to main**
 4. Ensure a GitHub Issue exists for the task
@@ -57,9 +57,12 @@ Before making ANY changes, Claude MUST:
 # COMMIT WORKFLOW (MANDATORY)
 
 When asked to create a commit or PR, Claude MUST:
-1. Read AGENTS.md and locate the "## Commit Guidelines" section
+1. Read .github/CONTRIBUTING.md and locate the "## Commit Guidelines" section
 2. Review the commit message format rules under that section
 3. Draft commit message following the exact format specified
-4. Use /commit-commands:commit (not Bash directly)
+4. Commit with `doit commit` when the session is interactive. It wraps commitizen
+   and enforces the format. When it is not — a headless or delegated run cannot
+   answer its prompts — use `git commit` with a message in the conventional
+   format from step 1. Never `git commit` without that format.
 
-NO EXCEPTIONS. If AGENTS.md has fallen out of context, READ IT FIRST.
+NO EXCEPTIONS. If .github/CONTRIBUTING.md has fallen out of context, READ IT FIRST.

--- a/tests/test_instruction_pointers.py
+++ b/tests/test_instruction_pointers.py
@@ -1,0 +1,239 @@
+"""Instruction pointers must resolve to something that exists.
+
+`.claude/CLAUDE.md` told every Claude session, in blocks marked MANDATORY and
+ending "NO EXCEPTIONS", to find two `AGENTS.md` sections that were not there and
+to run a command that did not exist (#738). Authoritative framing plus no
+destination is the documentation form of a control that reports success while
+doing nothing.
+
+Two pointer shapes are checked:
+
+1. Quoted section references — ``Read <file> and locate the "## Section" section``.
+2. Markdown link anchors — ``[text](path.md#anchor)``. `test_markdown_links.py`
+   splits the fragment off before resolving, so it validates the file and never
+   the section; this closes that half.
+
+Anchors were all resolving when this was written. The check is preventive, and
+`test_anchor_checker_detects_a_broken_anchor` keeps it from passing merely because
+it looks at nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Files that instruct an agent: always-on context, commands, and skills.
+INSTRUCTION_GLOBS = (
+    ".claude/CLAUDE.md",
+    "AGENTS.md",
+    ".claude/commands/**/*.md",
+    ".claude/agents/*.md",
+    ".github/skills/*/SKILL.md",
+    ".agents/skills/*/SKILL.md",
+    ".copilot/commands/*.md",
+    ".github/instructions/*.md",
+)
+
+SKIP_DIRS = {".venv", "node_modules", "site", "tmp", ".git", "__pycache__"}
+
+# A quoted markdown heading. Backslashes are excluded so that shell examples like
+# `--body="## Problem\nDescribe the problem"` in AGENTS.md are not mistaken for
+# section references — they are literal payloads, not pointers.
+QUOTED_HEADING = re.compile(r'"(#{1,6} [^"\\]+)"')
+MD_FILENAME = re.compile(r"([\w./-]+\.md)")
+MD_LINK = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+
+
+def _instruction_files() -> list[Path]:
+    files: list[Path] = []
+    for pattern in INSTRUCTION_GLOBS:
+        files += sorted(REPO_ROOT.glob(pattern))
+    return [f for f in files if f.is_file()]
+
+
+def _markdown_files() -> list[Path]:
+    return sorted(
+        p for p in REPO_ROOT.rglob("*.md") if not SKIP_DIRS.intersection(p.parts) and p.is_file()
+    )
+
+
+def _headings(path: Path) -> set[str] | None:
+    """Return the literal heading lines in *path*, or None if unreadable."""
+    try:
+        return {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.startswith("#")
+        }
+    except OSError:
+        return None
+
+
+def _slug(heading: str) -> str:
+    """GitHub-style anchor slug for a heading line."""
+    text = re.sub(r"^#+\s*", "", heading).strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    return re.sub(r"\s+", "-", text)
+
+
+def _anchors(path: Path) -> set[str] | None:
+    headings = _headings(path)
+    return None if headings is None else {_slug(h) for h in headings}
+
+
+def _section_references() -> list[tuple[Path, int, str, str]]:
+    """Return (source, line_no, quoted_heading, target_filename) for each pointer."""
+    refs = []
+    for source in _instruction_files():
+        for line_no, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+            for match in QUOTED_HEADING.finditer(line):
+                targets = [
+                    name
+                    for name in MD_FILENAME.findall(line)
+                    if name.lower() != source.name.lower()
+                ]
+                for name in targets:
+                    refs.append((source, line_no, match.group(1), name))
+    return refs
+
+
+def _resolve_named(name: str) -> Path | None:
+    """Resolve a bare filename mentioned in prose to a file in the repo."""
+    direct = REPO_ROOT / name
+    if direct.is_file():
+        return direct
+    for candidate in REPO_ROOT.rglob(Path(name).name):
+        if not SKIP_DIRS.intersection(candidate.parts):
+            return candidate
+    return None
+
+
+def test_quoted_section_references_resolve() -> None:
+    """Every `Read <file> and locate the "## X" section` must name a real heading."""
+    broken = []
+    for source, line_no, heading, target_name in _section_references():
+        target = _resolve_named(target_name)
+        if target is None:
+            broken.append(f"{source.relative_to(REPO_ROOT)}:{line_no} -> {target_name} not found")
+            continue
+        headings = _headings(target)
+        if headings is not None and heading not in headings:
+            broken.append(
+                f"{source.relative_to(REPO_ROOT)}:{line_no} -> {heading!r} not in {target_name}"
+            )
+
+    assert not broken, "instruction pointers that resolve to nothing:\n  " + "\n  ".join(broken)
+
+
+def test_markdown_anchors_resolve() -> None:
+    """`[text](file.md#anchor)` must name a heading that exists in that file.
+
+    Complements `tests/test_markdown_links.py`, which strips the fragment.
+    """
+    broken = []
+    for source in _markdown_files():
+        for match in MD_LINK.finditer(source.read_text(encoding="utf-8")):
+            target = match.group(1)
+            if target.startswith(("http", "mailto:", "#")) or "#" not in target:
+                continue
+            path_part, _, fragment = target.partition("#")
+            resolved = (source.parent / path_part).resolve()
+            anchors = _anchors(resolved)
+            if anchors is None:
+                broken.append(f"{source.relative_to(REPO_ROOT)}: {target} (file missing)")
+            elif fragment.lower() not in anchors:
+                broken.append(f"{source.relative_to(REPO_ROOT)}: {target}")
+
+    assert not broken, "markdown links with anchors that resolve to nothing:\n  " + "\n  ".join(
+        broken
+    )
+
+
+def test_referenced_commands_exist() -> None:
+    """A `/command` or `$skill` named in an instruction file must be installed.
+
+    `/commit-commands:commit` was named in a MANDATORY block for months without
+    ever existing (#738).
+    """
+    known: set[str] = set()
+    for path in REPO_ROOT.glob(".claude/commands/**/*.md"):
+        rel = path.relative_to(REPO_ROOT / ".claude" / "commands").with_suffix("")
+        known.add(rel.as_posix().replace("/", ":"))
+    for pattern in (".github/skills/*/SKILL.md", ".agents/skills/*/SKILL.md"):
+        known |= {p.parent.name for p in REPO_ROOT.glob(pattern)}
+    for path in REPO_ROOT.glob(".copilot/commands/*.md"):
+        known.add(path.stem)
+
+    claude_md = REPO_ROOT / ".claude" / "CLAUDE.md"
+    broken = [
+        name
+        # Not preceded by a word char, backtick, slash, dot or @ — so the
+        # `@./rules/*.md` import reads as a path, not a command — and not
+        # followed by a path separator.
+        for name in re.findall(
+            r"(?<![\w`/.@])/([a-z][\w-]*(?::[\w-]+)?)(?![\w/-])",
+            claude_md.read_text("utf-8"),
+        )
+        if name not in known and name.split(":")[0] not in known
+    ]
+
+    assert not broken, (
+        f"CLAUDE.md names commands that are not installed: {sorted(set(broken))}. "
+        "Available: " + ", ".join(sorted(known)[:12]) + " ..."
+    )
+
+
+def test_the_scanner_actually_finds_references() -> None:
+    """Guard against the pointer regexes silently matching nothing."""
+    assert _section_references(), "no quoted section references found; the regex has gone stale"
+
+    anchored = [
+        m.group(1)
+        for source in _markdown_files()
+        for m in MD_LINK.finditer(source.read_text(encoding="utf-8"))
+        if "#" in m.group(1) and not m.group(1).startswith(("http", "mailto:", "#"))
+    ]
+    assert len(anchored) >= 10, f"only {len(anchored)} anchored links found; expected the docs set"
+
+
+def test_shell_payloads_are_not_treated_as_pointers() -> None:
+    """`--body="## Problem\\nDescribe..."` is a payload, not a section reference.
+
+    AGENTS.md's issue-creation examples embed heading text in shell strings. Left
+    unfiltered they read as seven dangling pointers and would drown the real ones.
+    """
+    payload = '--body="## Problem\\nDescribe the problem\\n\\n## Proposed Solution\\nDo it"'
+    assert not QUOTED_HEADING.findall(payload), (
+        "the quoted-heading regex matched a shell payload; it must exclude escapes"
+    )
+
+
+def test_anchor_checker_detects_a_broken_anchor(tmp_path: Path) -> None:
+    """The anchor check must fail on a fragment that names no heading.
+
+    Every anchor in the repo resolves today, so without this the check could pass
+    because it found nothing rather than because everything is sound.
+    """
+    target = tmp_path / "target.md"
+    target.write_text("# Real Heading\n", encoding="utf-8")
+
+    assert _anchors(target) == {"real-heading"}
+    assert "no-such-heading" not in (_anchors(target) or set())
+
+
+@pytest.mark.parametrize(
+    ("heading", "expected"),
+    [
+        ("## Commit Guidelines", "commit-guidelines"),
+        ("### 5. Pre-Action Checks (Dynamic Context)", "5-pre-action-checks-dynamic-context"),
+        ("# Overview", "overview"),
+    ],
+)
+def test_slug_matches_github_anchor_rules(heading: str, expected: str) -> None:
+    """Anchor slugs must match what GitHub generates, or the check is nonsense."""
+    assert _slug(heading) == expected


### PR DESCRIPTION
## Description

`.claude/CLAUDE.md` auto-loads into every Claude session. Its two blocks marked
**MANDATORY**, ending "NO EXCEPTIONS", contained three instructions that resolved to
nothing:

| Line | Instruction | Reality |
| ---: | :--- | :--- |
| 50 | locate `## Development Workflow` in `AGENTS.md` | not there — it is `.github/CONTRIBUTING.md:712` |
| 60 | locate `## Commit Guidelines` in `AGENTS.md` | not there — it is `.github/CONTRIBUTING.md:234` |
| 63 | use `/commit-commands:commit` | no such command; `.claude/commands/` has no `commit-commands/` |

`AGENTS.md` was already correct — its **Sources of Truth** table points Workflow & Git and
Commit Guidelines at `.github/CONTRIBUTING.md`. `CLAUDE.md` was the file that was wrong.

An instruction with authoritative framing and no destination is the documentation form of
the pattern this backlog keeps finding: a control that reports success while doing
nothing.

## Related Issue

Addresses #738

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Changes Made

**The three pointers are corrected**, and the closing line ("If AGENTS.md has fallen out of
context, READ IT FIRST") now names `.github/CONTRIBUTING.md` so it agrees with the steps
above it.

**`tests/test_instruction_pointers.py`** checks three pointer shapes across the instruction
surface:

1. **Quoted section references** — `Read <file> and locate the "## Section" section`, over
   78 instruction, command and skill files.
2. **Markdown link anchors** — `[text](file.md#anchor)`, over all 150 markdown files. This
   closes a real gap: `tests/test_markdown_links.py` does `target.split("#")[0]` before
   resolving, so it validates the file and never the section. All 32 anchors resolve
   today, so this half is preventive.
3. **Commands named in `CLAUDE.md`** — a `/command` in an instruction file must be
   installed under `.claude/commands/`, `.github/skills/`, `.agents/skills/` or
   `.copilot/commands/`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**The guard was verified against the real defect, not against the fix.** Restoring the
pre-fix `CLAUDE.md` from `HEAD` and running the new tests names all three problems:

```
.claude/CLAUDE.md:50 -> '## Development Workflow' not in AGENTS.md
.claude/CLAUDE.md:60 -> '## Commit Guidelines' not in AGENTS.md
CLAUDE.md names commands that are not installed: ['commit-commands:commit']
```

| break simulated | guard that fired |
| :--- | :--- |
| pre-fix `CLAUDE.md` restored from HEAD | `test_quoted_section_references_resolve`, `test_referenced_commands_exist` |
| broken `#anchor` injected into a docs page | `test_markdown_anchors_resolve` |

Because the anchor half is preventive — nothing is broken there now — proving it fires
mattered more than usual. `test_anchor_checker_detects_a_broken_anchor` and
`test_slug_matches_github_anchor_rules` pin the slug logic so the check cannot pass by
generating anchors nobody uses.

`test_the_scanner_actually_finds_references` guards the regexes from silently matching
nothing, and `test_shell_payloads_are_not_treated_as_pointers` pins the opposite risk:
`AGENTS.md`'s `doit issue --body="## Problem\nDescribe the problem"` examples embed heading
text in shell strings, and an unfiltered regex reads them as seven dangling pointers that
would drown the two real ones.

`doit check`: all passed. `mkdocs build --strict`: clean.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### One judgment call beyond correcting links

Line 63 needed *some* replacement. Naming only `doit commit` would have left agents an
instruction they cannot follow in a headless or delegated run — commitizen is interactive
and its prompts cannot be answered — which recreates the same failure in a new form. The
step now covers both cases and stays consistent with `AGENTS.md`'s Tool Reference, which
forbids "`git commit` **without format**" rather than `git commit` as such.

Flagging it because it is content, not just a corrected pointer.

### A false positive caught during development

The first version of the command regex read `@./rules/*.md` — `CLAUDE.md`'s glob import —
as a command named `/rules`. It is now anchored to exclude path contexts. Worth recording:
a guard that cries wolf gets switched off, which leaves the codebase worse than an absent
guard rather than better.

### Relationship to #693

#693 proposes moving reference material out of `AGENTS.md` and reaching it through the
Pre-Action Checks index — replacing always-on prose with pointers. Pointers into that index
could dangle undetected, and three did. This lands first so that the reduction work in #693
is verifiable rather than hopeful.
