### PR TITLE
feat: verify integrity of downloads before they are extracted or run

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -22,6 +22,7 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 import tempfile
 import urllib.request
@@ -32,7 +33,62 @@ from urllib.parse import urlparse
 REPO_OWNER = "endavis"
 REPO_NAME = "pyproject-template"
 BRANCH = "main"
-BASE_URL = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{BRANCH}"
+
+# `main` moves. Fetching a dozen files from a moving ref means a push that lands
+# mid-run produces a mixed file set, and the same command run twice can install
+# different code. `resolve_ref()` pins the branch to one commit up front so a run
+# is internally consistent and its result is recordable (#694).
+#
+# This is not protection against the template repository itself being malicious —
+# running `curl | python3` against it already extends that trust. It closes the
+# window where main changes underneath a run, and makes "which code did I get?"
+# an answerable question.
+REF = os.environ.get("PYPROJECT_TEMPLATE_REF", BRANCH)
+BASE_URL = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{REF}"
+
+
+def resolve_ref(ref: str = REF) -> str:
+    """Resolve *ref* to a commit SHA so every download comes from one commit.
+
+    Returns the SHA on success. On failure — offline, rate-limited, or an
+    unknown ref — returns *ref* unchanged and warns: pinning is a consistency
+    improvement, and refusing to bootstrap because api.github.com is
+    unreachable would trade a small gain for a hard outage.
+
+    A ref that already looks like a full SHA is returned as-is.
+    """
+    if len(ref) == 40 and all(c in "0123456789abcdef" for c in ref.lower()):
+        return ref
+
+    api = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/commits/{ref}"
+    request = urllib.request.Request(api, headers={"Accept": "application/vnd.github.sha"})
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"token {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:  # nosec B310
+            sha: str = response.read().decode("utf-8").strip()
+    except Exception as e:
+        print(f"  Warning: could not resolve {ref} to a commit ({e}).")
+        print(f"  Continuing against the moving ref '{ref}'.")
+        return ref
+
+    if len(sha) != 40 or not all(c in "0123456789abcdef" for c in sha.lower()):
+        print(f"  Warning: unexpected response resolving {ref}; using the ref as-is.")
+        return ref
+    return sha
+
+
+def pin_base_url() -> str:
+    """Pin :data:`BASE_URL` to a resolved commit and return the SHA used."""
+    global BASE_URL
+    sha = resolve_ref()
+    BASE_URL = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{sha}"
+    if sha != REF:
+        print(f"  Pinned to commit {sha[:12]} (from '{REF}')")
+    return sha
+
 
 # Files needed for new project setup (downloaded to temp dir, runs wizard)
 SETUP_FILES = [
@@ -172,6 +228,8 @@ def run_sync(project_root: Path) -> None:
     # Create directory structure
     pkg_dir.mkdir(parents=True, exist_ok=True)
 
+    pin_base_url()
+
     # Download sync files
     for file_path in SYNC_FILES:
         filename = Path(file_path).name
@@ -237,6 +295,8 @@ def run_setup() -> None:
         # Recreate the package structure: tools/pyproject_template/
         pkg_dir = root_path / "tools" / "pyproject_template"
         pkg_dir.mkdir(parents=True, exist_ok=True)
+
+        pin_base_url()
 
         # Download files
         for file_path in SETUP_FILES:

--- a/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
+++ b/docs/decisions/9015-install-tools-framework-archive-extraction-and-custom-urls.md
@@ -16,6 +16,12 @@ Supporting refactors: a private `_get_arch()` helper that maps `platform.machine
 
 `extract_binaries` also accepts an optional per-platform `dict[str, list[str]]` keyed by `platform.system().lower()` (same convention as `asset_patterns`), for tools whose archive members differ per OS (e.g., `.exe` suffix on Windows).
 
+4. **Integrity verification (#694)** — an optional `sha256` parameter (a single digest, or a per-platform mapping) verified before the archive is opened and before the executable bit is set; a mismatch deletes the file and aborts. A digest is **mandatory** for hosts outside `IMPLICITLY_TRUSTED_HOSTS`, i.e. for the `url_template` escape hatch this ADR introduced.
+
+   The asymmetry is deliberate. `url_template` exists to fetch from arbitrary third parties such as `releases.hashicorp.com`, which bypasses even the implicit trust already extended to GitHub by cloning this template. A caller reaching outside that boundary must state what it expects to receive; a GitHub-release install rests on trust the user has already granted.
+
+   We explicitly did **not** adopt fetching upstream `*.sha256` sibling files. Served over HTTPS from the same origin as the asset, that defends against almost nothing: TLS already covers the transport, and an attacker able to replace the asset can replace the checksum beside it. Shipping it would have read as integrity assurance while providing close to none. Verification value comes from a digest the *caller* pinned.
+
 ## Rationale
 
 Downstream consumers (e.g., InfraFoundry) need to install five tools, but only direnv-style single binaries from GitHub releases work today. age and sops ship as multi-binary tar.gz archives; terraform and opentofu ship from non-GitHub URLs. Without these extensions every downstream consumer reinvents download/extract code with inconsistent (often missing) security handling.
@@ -33,10 +39,14 @@ The three capabilities are intentionally orthogonal so simple cases stay simple 
 **Negative:**
 - Larger public API surface to maintain.
 - The framework is now responsible for safe archive extraction; security regressions here affect every downstream consumer.
+- Custom-URL callers must now supply a digest. This is a breaking change for any downstream that already passes `url_template` for a non-GitHub host — the call aborts with an `IntegrityError` naming the missing parameter until a digest is added.
+
+**Known limitation:**
+- `install_tool` resolves the latest release at run time, so a caller-supplied digest is only valid for a known version. Pinning versions alongside digests is what would deliver reproducibility and detect a retagged upstream asset; it was deferred because the resulting digest matrix ages and would change `doit install_gh` from "install current gh" to "install the version the template froze" (#694).
 
 **Future work:**
-- SHA256 checksum verification.
-- GPG signature verification.
+- Pinned versions alongside pinned digests, with a refresh task.
+- GPG signature verification — meaningful against a compromised release host in a way a sibling checksum file is not, because the signing key is not served alongside the asset.
 - Local archive caching between runs.
 - Windows binary download support.
 
@@ -44,6 +54,7 @@ The three capabilities are intentionally orthogonal so simple cases stay simple 
 
 - Issue #326: install_tools framework: archive extraction and custom URLs
 - Issue #477: support per-platform `extract_binaries` in install_tool framework
+- Issue #694: verify checksums for binaries and scripts downloaded by install_tools and bootstrap
 
 ## Related Documentation
 

--- a/docs/development/install-tools-framework.md
+++ b/docs/development/install-tools-framework.md
@@ -182,13 +182,54 @@ the download path on every OS.
 - **Zip archives** additionally do a `Path.resolve()` zip-slip check as
   defense in depth.
 - Extracted binaries are chmod'd to `0o755`.
+
+### Integrity: what is and is not verified
+
+Pass `sha256=` to `install_tool()` / `create_install_task()` to state the digest you
+expect. It is verified **before** the archive is opened and **before** the executable
+bit goes on, and a mismatch deletes the file and aborts — a failed verification can
+never be mistaken for a completed install.
+
+```python
+create_install_task(
+    name="terraform",
+    repo="hashicorp/terraform",
+    asset_patterns={},
+    url_template="https://releases.hashicorp.com/terraform/{version}/terraform_{os}_{arch}.zip",
+    sha256={"linux": "9d2b...", "darwin": "1f4c..."},   # per-platform, or a single str
+)
+```
+
+**A digest is mandatory for hosts outside `IMPLICITLY_TRUSTED_HOSTS`** — that is, for
+the `url_template` escape hatch, which exists to reach third parties such as
+`releases.hashicorp.com`. Calling it without a digest aborts. GitHub-release installs
+are unchanged and stay optional, because fetching them already rests on the same trust
+as cloning this template.
+
+**What this does not do, stated plainly:** it does not fetch upstream `*.sha256`
+sibling files and verify against those. Over HTTPS from the same origin that serves the
+asset, that defends against almost nothing — TLS already covers the transport, and an
+attacker who can replace the asset can replace the checksum beside it. The protection
+comes from a digest *you* pinned, which is why the parameter takes one from the caller
+rather than fetching one.
+
+Neither this nor anything else here defends against a compromised upstream release when
+the digest floats with the version. `install_tool` resolves "latest" at run time; pinning
+a version alongside a digest is what buys reproducibility, and is a deliberate
+non-goal for now — see below.
 - Status output uses ASCII `[OK]` rather than a checkmark glyph so it
   encodes cleanly on Windows cp1252 consoles (see issue #328).
 
 ## Future work
 
-- **Checksum verification** (SHA256 from a `*.sha256` sibling URL).
-- **GPG signature verification** for projects that publish detached signatures.
+- **Pinned versions alongside pinned digests.** Today `install_tool` resolves the latest
+  release at run time, so a caller-supplied `sha256` only holds for a known version. Pinning
+  both would make installs reproducible and would detect a retagged or replaced upstream
+  asset — at the cost of a digest matrix per tool per platform that ages and needs a refresh
+  task. Deliberately deferred (#694).
+- **GPG signature verification** for projects that publish detached signatures. Unlike a
+  sibling checksum file, a signature is meaningful against a compromised release host,
+  because the signing key is not served alongside the asset.
 - **Archive caching** between runs to avoid redownloading on a fresh
   clone or CI runner.
 - **Windows binary support** (PowerShell-friendly install path).

--- a/tests/template/test_bootstrap.py
+++ b/tests/template/test_bootstrap.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import bootstrap
 from bootstrap import (
     SETUP_FILES,
     SYNC_FILES,
@@ -14,6 +15,8 @@ from bootstrap import (
     detect_project_settings,
     download_file,
     parse_args,
+    pin_base_url,
+    resolve_ref,
 )
 
 
@@ -438,3 +441,73 @@ class TestMain:
         with patch("bootstrap.run_setup") as mock_setup:
             main([])
             mock_setup.assert_called_once()
+
+
+class TestRefPinning:
+    """`main` is resolved to one commit before any file is fetched (#694).
+
+    bootstrap downloads up to a dozen files from a moving ref. A push landing
+    mid-run produces a mixed file set, and the same command run twice can
+    install different code. Pinning makes a run internally consistent and its
+    result recordable.
+
+    This does not defend against the template repository being malicious —
+    `curl | python3` already extends that trust. It closes the window where the
+    ref moves underneath a run.
+    """
+
+    def test_full_sha_is_passed_through_unresolved(self) -> None:
+        """An explicit commit needs no API call — and must not make one."""
+        sha = "0123456789abcdef0123456789abcdef01234567"
+        with patch("bootstrap.urllib.request.urlopen") as mock_open:
+            assert resolve_ref(sha) == sha
+        mock_open.assert_not_called()
+
+    def test_branch_resolves_to_the_returned_sha(self) -> None:
+        sha = "a" * 40
+        response = MagicMock()
+        response.read.return_value = sha.encode()
+        response.__enter__ = lambda self: self
+        response.__exit__ = lambda *a: None
+
+        with patch("bootstrap.urllib.request.urlopen", return_value=response):
+            assert resolve_ref("main") == sha
+
+    def test_unreachable_api_falls_back_to_the_ref(self) -> None:
+        """Offline or rate-limited must not turn a small gain into an outage."""
+        with patch("bootstrap.urllib.request.urlopen", side_effect=OSError("offline")):
+            assert resolve_ref("main") == "main"
+
+    def test_garbage_response_falls_back_to_the_ref(self) -> None:
+        """A proxy or error page must not be pasted into the download URL."""
+        response = MagicMock()
+        response.read.return_value = b"<html>rate limited</html>"
+        response.__enter__ = lambda self: self
+        response.__exit__ = lambda *a: None
+
+        with patch("bootstrap.urllib.request.urlopen", return_value=response):
+            assert resolve_ref("main") == "main"
+
+    def test_pin_base_url_rewrites_the_download_base(self) -> None:
+        """Every subsequent download must come from the pinned commit."""
+        sha = "b" * 40
+        original = bootstrap.BASE_URL
+        try:
+            with patch("bootstrap.resolve_ref", return_value=sha):
+                assert pin_base_url() == sha
+            assert bootstrap.BASE_URL.endswith(f"/{sha}")
+            assert "/main" not in bootstrap.BASE_URL
+        finally:
+            bootstrap.BASE_URL = original
+
+    def test_pinning_happens_before_any_file_is_fetched(self) -> None:
+        """Ordering is the whole point: a pin applied after the first download
+        would leave that file from a different commit."""
+        source = (Path(__file__).resolve().parents[2] / "bootstrap.py").read_text("utf-8")
+        for marker in ("for file_path in SYNC_FILES:", "for file_path in SETUP_FILES:"):
+            loop = source.index(marker)
+            preceding = source.rindex("pin_base_url()", 0, loop)
+            between = source[preceding:loop]
+            assert "download_file(" not in between, (
+                f"a download happens between pin_base_url() and {marker}"
+            )

--- a/tests/template/test_doit_install.py
+++ b/tests/template/test_doit_install.py
@@ -78,6 +78,7 @@ class TestTaskInstallGh:
             extract_binaries=["gh"],
             url_template="https://github.com/cli/cli/releases/download/v{version}/gh_{version}_{os}_{arch}.tar.gz",
             prefer_brew=False,
+            sha256=None,
         )
 
     @patch("tools.doit.install_tools.install_tool")

--- a/tests/template/test_doit_install_tools.py
+++ b/tests/template/test_doit_install_tools.py
@@ -1,5 +1,6 @@
 """Tests for install_tools.py reusable tool installation framework."""
 
+import hashlib
 import json
 import shutil
 import subprocess  # nosec B404 - needed for CompletedProcess in tests
@@ -13,6 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tools.doit.install_tools import (
+    IntegrityError,
     _get_arch,
     create_install_task,
     download_and_extract_archive,
@@ -20,7 +22,15 @@ from tools.doit.install_tools import (
     get_install_dir,
     get_latest_github_release,
     install_tool,
+    requires_digest,
+    sha256_of,
+    verify_download,
 )
+
+# SHA-256 of an empty file. The urlretrieve mocks below `touch()` their
+# destination, so this is the digest a caller must supply for a download from a
+# host outside IMPLICITLY_TRUSTED_HOSTS (ADR-9015 custom URLs).
+_EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 
 class TestGetLatestGithubRelease:
@@ -323,6 +333,7 @@ class TestInstallTool:
             version="2.0.0",
             asset_pattern="mytool.linux-amd64",
             dest_name="mytool",
+            sha256=None,
         )
         captured = capsys.readouterr()
         assert "mytool installed" in captured.out
@@ -500,6 +511,7 @@ class TestInstallTool:
             repo="hashicorp/terraform",
             asset_patterns={},
             url_template="https://releases.example.com/{version}/terraform_{os}_{arch}",
+            sha256=_EMPTY_SHA256,
         )
 
         called_url = mock_urlretrieve.call_args.args[0]
@@ -656,6 +668,7 @@ class TestInstallTool:
             version="1.0.0",
             asset_pattern="mytool.darwin-amd64",
             dest_name="mytool",
+            sha256=None,
         )
 
     @patch("tools.doit.install_tools.urllib.request.urlretrieve")
@@ -685,6 +698,7 @@ class TestInstallTool:
             repo="hashicorp/terraform",
             asset_patterns={},
             url_template="https://releases.example.com/{version}/{os}_{arch}",
+            sha256=_EMPTY_SHA256,
         )
 
         mock_run.assert_not_called()
@@ -731,6 +745,7 @@ class TestCreateInstallTask:
             extract_binaries=None,
             url_template=None,
             prefer_brew=True,
+            sha256=None,
         )
 
     @patch("tools.doit.install_tools.install_tool")
@@ -753,6 +768,7 @@ class TestCreateInstallTask:
             extract_binaries=None,
             url_template=None,
             prefer_brew=True,
+            sha256=None,
         )
 
     @patch("tools.doit.install_tools.install_tool")
@@ -793,7 +809,7 @@ class TestCreateInstallTask:
     @patch("tools.doit.install_tools.install_tool")
     def test_forwards_url_template(self, mock_install: MagicMock) -> None:
         """Test that url_template kwarg is forwarded to install_tool."""
-        template = "https://example.com/{version}/{os}/{arch}/tool.zip"
+        template = "https://github.com/o/r/releases/download/v1/{version}/{os}/{arch}/tool.zip"
         result = create_install_task(
             name="terraform",
             repo="hashicorp/terraform",
@@ -875,7 +891,9 @@ class TestDownloadAndExtractArchive:
             side_effect=lambda url, d: shutil.copy(fixture, d),
         ):
             result = download_and_extract_archive(
-                "https://example.com/age.tar.gz", ["age", "age-keygen"], dest
+                "https://github.com/o/r/releases/download/v1/age.tar.gz",
+                ["age", "age-keygen"],
+                dest,
             )
 
         assert (dest / "age").read_bytes() == b"age-binary"
@@ -892,7 +910,7 @@ class TestDownloadAndExtractArchive:
             side_effect=lambda url, d: shutil.copy(fixture, d),
         ):
             result = download_and_extract_archive(
-                "https://example.com/terraform.zip", ["terraform"], dest
+                "https://github.com/o/r/releases/download/v1/terraform.zip", ["terraform"], dest
             )
 
         assert (dest / "terraform").read_bytes() == b"tf-binary"
@@ -914,7 +932,9 @@ class TestDownloadAndExtractArchive:
             "tools.doit.install_tools.urllib.request.urlretrieve",
             side_effect=lambda url, d: shutil.copy(fixture, d),
         ):
-            download_and_extract_archive("https://example.com/age.tar.gz", ["age"], dest)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/age.tar.gz", ["age"], dest
+            )
 
         assert (dest / "age").exists()
         assert not (dest / "LICENSE").exists()
@@ -943,7 +963,9 @@ class TestDownloadAndExtractArchive:
             "tools.doit.install_tools.urllib.request.urlretrieve",
             side_effect=lambda url, d: shutil.copy(fixture, d),
         ):
-            download_and_extract_archive("https://example.com/x.tar.gz", ["mytool"], dest)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/x.tar.gz", ["mytool"], dest
+            )
 
         # Confirm no file landed outside dest_dir
         assert (dest / "mytool").exists()
@@ -954,7 +976,9 @@ class TestDownloadAndExtractArchive:
 
     def test_unsupported_extension_raises_value_error(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="Unsupported archive extension"):
-            download_and_extract_archive("https://example.com/foo.7z", ["foo"], tmp_path)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/foo.7z", ["foo"], tmp_path
+            )
 
     def test_temp_file_cleanup_on_success(self, tmp_path: Path) -> None:
         fixture = tmp_path / "fixture.tar.gz"
@@ -966,7 +990,9 @@ class TestDownloadAndExtractArchive:
             "tools.doit.install_tools.urllib.request.urlretrieve",
             side_effect=lambda url, d: shutil.copy(fixture, d),
         ):
-            download_and_extract_archive("https://example.com/x.tar.gz", ["mytool"], dest)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/x.tar.gz", ["mytool"], dest
+            )
         after = set(Path(tempfile.gettempdir()).iterdir())
 
         new_files = after - before
@@ -985,7 +1011,9 @@ class TestDownloadAndExtractArchive:
             ),
             pytest.raises(RuntimeError, match="not found in archive"),
         ):
-            download_and_extract_archive("https://example.com/x.tar.gz", ["missing"], dest)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/x.tar.gz", ["missing"], dest
+            )
         after = set(Path(tempfile.gettempdir()).iterdir())
 
         new_files = after - before
@@ -1003,7 +1031,9 @@ class TestDownloadAndExtractArchive:
             ),
             pytest.raises(RuntimeError, match="absent"),
         ):
-            download_and_extract_archive("https://example.com/x.tar.gz", ["absent"], dest)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/x.tar.gz", ["absent"], dest
+            )
 
     @pytest.mark.skipif(
         sys.platform == "win32", reason="Windows does not support Unix file permissions"
@@ -1017,6 +1047,154 @@ class TestDownloadAndExtractArchive:
             "tools.doit.install_tools.urllib.request.urlretrieve",
             side_effect=lambda url, d: shutil.copy(fixture, d),
         ):
-            download_and_extract_archive("https://example.com/x.zip", ["mytool"], dest)
+            download_and_extract_archive(
+                "https://github.com/o/r/releases/download/v1/x.zip", ["mytool"], dest
+            )
 
         assert (dest / "mytool").stat().st_mode & 0o755 == 0o755
+
+
+class TestDownloadIntegrity:
+    """Integrity verification for downloaded binaries and archives (#694).
+
+    The framework runs what it downloads: binaries get `chmod 0o755`, archives
+    get parsed and extracted. Nothing verified what arrived. These tests cover
+    the two halves of the rule — a digest is checked when given, and is
+    mandatory for hosts outside `IMPLICITLY_TRUSTED_HOSTS`.
+
+    What this deliberately does *not* claim: fetching a checksum file from the
+    same origin as the asset would defend against almost nothing, since TLS
+    already covers the transport and an attacker who can replace the asset can
+    replace the checksum. The value here is that a caller reaching an arbitrary
+    third party must state what it expects.
+    """
+
+    def test_sha256_of_matches_hashlib(self, tmp_path: Path) -> None:
+        """The digest helper must agree with hashlib on real bytes."""
+        target = tmp_path / "blob"
+        target.write_bytes(b"integrity" * 5000)
+
+        assert sha256_of(target) == hashlib.sha256(b"integrity" * 5000).hexdigest()
+
+    def test_digest_spans_the_whole_file(self, tmp_path: Path) -> None:
+        """Chunked reading must not stop at the first chunk.
+
+        A helper that hashed only the first block would pass every test above
+        while accepting a file whose tail had been replaced.
+        """
+        big = b"A" * (1024 * 1024 * 2 + 17)
+        tampered = big[:-1] + b"B"
+        a, b = tmp_path / "a", tmp_path / "b"
+        a.write_bytes(big)
+        b.write_bytes(tampered)
+
+        assert sha256_of(a) != sha256_of(b)
+
+    @pytest.mark.parametrize(
+        ("url", "required"),
+        [
+            ("https://github.com/o/r/releases/download/v1/tool", False),
+            ("https://objects.githubusercontent.com/x", False),
+            ("https://releases.hashicorp.com/terraform/1.5.0/x.zip", True),
+            ("https://evil.example/tool", True),
+            ("https://github.com.evil.example/tool", True),
+            ("https://notgithub.com/tool", True),
+        ],
+    )
+    def test_requires_digest_by_host(self, url: str, required: bool) -> None:
+        """Host policy is decided on the parsed hostname, not a substring."""
+        assert requires_digest(url) is required
+
+    def test_matching_digest_passes_and_keeps_the_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "tool"
+        target.write_bytes(b"payload")
+
+        verify_download(target, "https://evil.example/tool", sha256_of(target))
+
+        assert target.exists()
+
+    def test_mismatch_raises_and_deletes_the_file(self, tmp_path: Path) -> None:
+        """Fail closed: nothing is left on disk for a caller to run."""
+        target = tmp_path / "tool"
+        target.write_bytes(b"malicious")
+
+        with pytest.raises(IntegrityError, match="Integrity check failed"):
+            verify_download(target, "https://github.com/o/r/x", "0" * 64)
+
+        assert not target.exists(), "a file that failed verification must not survive"
+
+    def test_missing_digest_on_untrusted_host_raises_and_deletes(self, tmp_path: Path) -> None:
+        target = tmp_path / "tool"
+        target.write_bytes(b"whatever")
+
+        with pytest.raises(IntegrityError, match="no sha256 was given"):
+            verify_download(target, "https://releases.hashicorp.com/x", None)
+
+        assert not target.exists()
+
+    def test_missing_digest_on_github_is_allowed(self, tmp_path: Path) -> None:
+        """GitHub assets keep working without a digest — no behaviour change."""
+        target = tmp_path / "tool"
+        target.write_bytes(b"gh-asset")
+
+        verify_download(target, "https://github.com/cli/cli/releases/download/v1/gh", None)
+
+        assert target.exists()
+
+    def test_digest_comparison_ignores_case_and_whitespace(self, tmp_path: Path) -> None:
+        """Digests copied from checksum files carry stray case and spacing."""
+        target = tmp_path / "tool"
+        target.write_bytes(b"payload")
+        expected = sha256_of(target)
+
+        verify_download(target, "https://evil.example/tool", f"  {expected.upper()}\n")
+
+        assert target.exists()
+
+    def test_archive_is_not_parsed_when_the_digest_is_wrong(self, tmp_path: Path) -> None:
+        """Verification must happen before the archive is opened.
+
+        Extraction is hardened, but not parsing a known-bad archive at all is
+        strictly better than relying on that hardening.
+        """
+        fixture = tmp_path / "fixture.tar.gz"
+        _make_targz(fixture, {"tool": b"binary"})
+        dest = tmp_path / "out"
+
+        with (
+            patch(
+                "tools.doit.install_tools.urllib.request.urlretrieve",
+                side_effect=lambda url, d: shutil.copy(fixture, d),
+            ),
+            patch("tools.doit.install_tools.tarfile.open") as mock_tar,
+            pytest.raises(IntegrityError, match="Integrity check failed"),
+        ):
+            download_and_extract_archive(
+                "https://github.com/o/r/x.tar.gz", ["tool"], dest, sha256="0" * 64
+            )
+
+        mock_tar.assert_not_called()
+        assert not dest.exists() or not any(dest.iterdir())
+
+    def test_binary_is_not_made_executable_when_the_digest_is_wrong(self, tmp_path: Path) -> None:
+        """A file that fails verification must never get the executable bit."""
+        install_dir = tmp_path / "bin"
+        install_dir.mkdir()
+
+        with (
+            patch("tools.doit.install_tools.get_install_dir", return_value=install_dir),
+            patch(
+                "tools.doit.install_tools.urllib.request.urlretrieve",
+                side_effect=lambda url, dest: Path(dest).write_bytes(b"tampered"),
+            ),
+            pytest.raises(IntegrityError, match="Integrity check failed"),
+        ):
+            download_github_release_binary(
+                repo="o/r",
+                version="1.0.0",
+                asset_pattern="tool",
+                dest_name="tool",
+                sha256="0" * 64,
+            )
+
+        assert not (install_dir / "tool").exists()

--- a/tools/doit/install_tools.py
+++ b/tools/doit/install_tools.py
@@ -1,5 +1,6 @@
 """Reusable framework for installing tools from GitHub releases."""
 
+import hashlib
 import json
 import os
 import platform
@@ -12,8 +13,88 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from doit.tools import title_with_actions
+
+# Hosts whose release assets we fetch without a caller-supplied digest.
+#
+# This is not a claim that GitHub is trustworthy in some absolute sense — it is
+# the same trust already extended by cloning this template. What it excludes is
+# the `url_template` escape hatch (ADR-9015), which exists precisely to fetch
+# from arbitrary third parties such as `releases.hashicorp.com`. Those bypass
+# even that implicit trust, so they must name what they expect to receive.
+IMPLICITLY_TRUSTED_HOSTS = frozenset(
+    {
+        "github.com",
+        "objects.githubusercontent.com",
+        "raw.githubusercontent.com",
+        "api.github.com",
+    }
+)
+
+_DIGEST_CHUNK = 1024 * 1024
+
+
+class IntegrityError(RuntimeError):
+    """A download did not match the digest the caller expected."""
+
+
+def sha256_of(path: Path) -> str:
+    """Return the lowercase hex SHA-256 of the file at *path*."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_DIGEST_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def requires_digest(url: str) -> bool:
+    """Return whether *url* must be accompanied by an expected digest.
+
+    True for any host outside :data:`IMPLICITLY_TRUSTED_HOSTS` — the
+    ``url_template`` escape hatch added in ADR-9015.
+    """
+    return (urlparse(url).hostname or "").lower() not in IMPLICITLY_TRUSTED_HOSTS
+
+
+def verify_download(path: Path, url: str, expected_sha256: str | None) -> None:
+    """Verify *path* against *expected_sha256*, deleting it if it does not match.
+
+    Fails closed in both directions:
+
+    - A digest that does not match aborts and leaves nothing on disk, so a
+      failed verification can never be mistaken for a completed install.
+    - A download from an untrusted host with no expected digest aborts before
+      the file is ever made executable.
+
+    Args:
+        path: The downloaded file.
+        url: Where it came from, used to decide whether a digest is mandatory.
+        expected_sha256: The hex digest the caller expects, if any.
+
+    Raises:
+        IntegrityError: On mismatch, or when a digest is required and absent.
+    """
+    if expected_sha256 is None:
+        if requires_digest(url):
+            path.unlink(missing_ok=True)
+            raise IntegrityError(
+                f"{url} is outside {sorted(IMPLICITLY_TRUSTED_HOSTS)} and no sha256 was "
+                "given. Pass sha256= to install_tool()/create_install_task() naming the "
+                "digest you expect (see docs/development/install-tools-framework.md)."
+            )
+        return
+
+    actual = sha256_of(path)
+    if actual.lower() != expected_sha256.strip().lower():
+        path.unlink(missing_ok=True)
+        raise IntegrityError(
+            f"Integrity check failed for {url}\n"
+            f"  expected sha256: {expected_sha256.strip().lower()}\n"
+            f"  actual sha256:   {actual}\n"
+            "The downloaded file has been deleted. Nothing was installed."
+        )
 
 
 def get_latest_github_release(repo: str) -> str:
@@ -83,7 +164,7 @@ def _build_github_release_url(repo: str, version: str, asset_pattern: str) -> st
 
 
 def download_github_release_binary(
-    repo: str, version: str, asset_pattern: str, dest_name: str
+    repo: str, version: str, asset_pattern: str, dest_name: str, sha256: str | None = None
 ) -> Path:
     """Download a binary asset from a GitHub release.
 
@@ -97,23 +178,31 @@ def download_github_release_binary(
         asset_pattern: Filename pattern with {version} placeholder
             (e.g. "tool.linux-amd64" or "tool-v{version}-linux-amd64").
         dest_name: Name of the installed binary (e.g. "tool").
+        sha256: Expected hex SHA-256 of the asset. Optional for GitHub hosts;
+            verified when given.
 
     Returns:
         Path to the downloaded and installed binary.
+
+    Raises:
+        IntegrityError: If the download does not match *sha256*.
     """
     url = _build_github_release_url(repo, version, asset_pattern)
     install_dir = get_install_dir()
     dest_path = install_dir / dest_name
 
     print(f"Downloading {url}...")
-    urllib.request.urlretrieve(url, dest_path)  # nosec B310 - downloading from constructed GitHub release URL
+    urllib.request.urlretrieve(url, dest_path)  # nosec B310 - GitHub release URL; integrity via verify_download below
+    # Verify before the executable bit goes on: a file that never becomes
+    # executable cannot be run by a caller that ignores the exception.
+    verify_download(dest_path, url, sha256)
     dest_path.chmod(0o755)  # nosec B103 - rwxr-xr-x is required for executable binary
 
     return dest_path
 
 
 def download_and_extract_archive(
-    url: str, extract_binaries: list[str], dest_dir: Path
+    url: str, extract_binaries: list[str], dest_dir: Path, sha256: str | None = None
 ) -> list[Path]:
     """Download an archive and extract specific binaries from it.
 
@@ -134,6 +223,8 @@ def download_and_extract_archive(
             archive (e.g. ``["age", "age-keygen"]``).
         dest_dir: Directory to write extracted binaries into. Created if
             it does not exist.
+        sha256: Expected hex SHA-256 of the archive. Mandatory when *url* is
+            outside :data:`IMPLICITLY_TRUSTED_HOSTS`; optional otherwise.
 
     Returns:
         List of Paths to the extracted binaries.
@@ -141,6 +232,9 @@ def download_and_extract_archive(
     Raises:
         ValueError: If the URL has an unsupported archive extension.
         RuntimeError: If a requested binary is not found in the archive.
+        IntegrityError: If the archive does not match *sha256*, or a digest is
+            required for this host and none was given. Verified before the
+            archive is opened, so an unverified archive is never parsed.
     """
     url_lower = url.lower()
     if url_lower.endswith((".tar.gz", ".tgz")):
@@ -160,7 +254,11 @@ def download_and_extract_archive(
         temp_path = Path(tmp.name)
     try:
         print(f"Downloading {url}...")
-        urllib.request.urlretrieve(url, temp_path)  # nosec B310 - URL provided by trusted caller
+        urllib.request.urlretrieve(url, temp_path)  # nosec B310 - integrity via verify_download below, before the archive is opened
+        # Before opening the archive: extraction hardening (data_filter, zip-slip
+        # checks) limits what a malicious archive can write, but parsing one at
+        # all is avoidable when we already know it is the wrong bytes.
+        verify_download(temp_path, url, sha256)
 
         if archive_kind == "tar":
             with tarfile.open(temp_path, "r:gz") as tar:  # nosec B202 - data_filter set below when available
@@ -218,6 +316,7 @@ def install_tool(
     extract_binaries: list[str] | dict[str, list[str]] | None = None,
     url_template: str | None = None,
     prefer_brew: bool = True,
+    sha256: str | dict[str, str] | None = None,
 ) -> None:
     """Install a tool from GitHub releases if not already present.
 
@@ -259,6 +358,18 @@ def install_tool(
         prefer_brew: When True (the default), use ``brew install`` on macOS
             instead of downloading. Set False to force download even on
             macOS (useful for cross-platform consistency).
+        sha256: Expected hex SHA-256 of the downloaded asset. Either a single
+            digest, or a per-platform mapping keyed like ``asset_patterns``
+            (``platform.system().lower()``) for tools whose asset differs per
+            OS. Mandatory when the resolved URL is outside
+            :data:`IMPLICITLY_TRUSTED_HOSTS` — the ``url_template`` escape
+            hatch from ADR-9015 reaches arbitrary third parties, so those must
+            name what they expect to receive.
+
+    Raises:
+        IntegrityError: If the download does not match *sha256*, or a digest is
+            required for the resolved host and none was given. Nothing is left
+            on disk and nothing is made executable.
     """
     if version_cmd is None:
         version_cmd = [name, "--version"]
@@ -279,6 +390,7 @@ def install_tool(
     print(f"Latest version: {version}")
 
     system = platform.system().lower()
+    expected_sha = sha256.get(system) if isinstance(sha256, dict) else sha256
 
     if system == "darwin" and prefer_brew and url_template is None:
         subprocess.run(["brew", "install", name], check=True)
@@ -299,13 +411,14 @@ def install_tool(
                 resolved_binaries = extract_binaries[system]
             else:
                 resolved_binaries = extract_binaries
-            download_and_extract_archive(url, resolved_binaries, get_install_dir())
+            download_and_extract_archive(url, resolved_binaries, get_install_dir(), expected_sha)
         else:
             if url_template is not None:
                 install_dir = get_install_dir()
                 dest_path = install_dir / name
                 print(f"Downloading {url}...")
-                urllib.request.urlretrieve(url, dest_path)  # nosec B310 - URL from trusted caller template
+                urllib.request.urlretrieve(url, dest_path)  # nosec B310 - integrity via verify_download below, before chmod
+                verify_download(dest_path, url, expected_sha)
                 dest_path.chmod(0o755)  # nosec B103 - executable bit required
             else:
                 download_github_release_binary(
@@ -313,6 +426,7 @@ def install_tool(
                     version=version,
                     asset_pattern=asset_patterns[system],
                     dest_name=name,
+                    sha256=expected_sha,
                 )
 
     print(f"[OK] {name} installed.")
@@ -329,6 +443,7 @@ def create_install_task(
     extract_binaries: list[str] | dict[str, list[str]] | None = None,
     url_template: str | None = None,
     prefer_brew: bool = True,
+    sha256: str | dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Create a doit task dict for installing a tool from GitHub releases.
 
@@ -351,6 +466,9 @@ def create_install_task(
             ``{os}``, ``{arch}`` placeholders. See :func:`install_tool`.
         prefer_brew: Use brew on macOS when True (default). See
             :func:`install_tool`.
+        sha256: Expected hex SHA-256 of the asset, or a per-platform mapping.
+            Mandatory for URLs outside :data:`IMPLICITLY_TRUSTED_HOSTS`. See
+            :func:`install_tool`.
 
     Returns:
         A doit task dictionary with actions and title.
@@ -366,6 +484,7 @@ def create_install_task(
             extract_binaries=extract_binaries,
             url_template=url_template,
             prefer_brew=prefer_brew,
+            sha256=sha256,
         )
 
     return {


### PR DESCRIPTION
## Description

Nothing verified what the template downloaded and then executed. `install_tools` applied
`chmod 0o755` to whatever arrived; `bootstrap.py` fetched a dozen files from a moving ref,
so a push landing mid-run produced a mixed file set and the same command run twice could
install different code.

## Related Issue

Addresses #694

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Changes Made

**`tools/doit/install_tools.py`** — a `sha256` parameter (single digest or per-platform
mapping) on `install_tool`, `create_install_task`, `download_github_release_binary` and
`download_and_extract_archive`. Verified at the two points where trust is actually
extended:

- **before the archive is opened** — extraction is already hardened (`tarfile.data_filter`,
  basename-only, zip-slip check), but not parsing a known-bad archive at all is strictly
  better than relying on that hardening.
- **before `chmod 0o755`** — a file that never becomes executable cannot be run by a caller
  that swallows the exception.

On mismatch the file is deleted and the install aborts, so a failed verification can never
be mistaken for a completed one.

**A digest is mandatory for hosts outside `IMPLICITLY_TRUSTED_HOSTS`.** That boundary is
the `url_template` escape hatch ADR-9015 introduced specifically to reach third parties
such as `releases.hashicorp.com`. Those bypass even the implicit trust already extended to
GitHub by cloning this template, so they must name what they expect to receive. GitHub
release installs are unchanged and keep working without a digest.

**`bootstrap.py`** — `resolve_ref()` pins `main` to a commit SHA once, and every subsequent
file comes from that commit. If the API is unreachable or rate-limited it warns and falls
back to the moving ref: refusing to bootstrap because `api.github.com` is unavailable would
trade a small consistency gain for a hard outage. Overridable with
`PYPROJECT_TEMPLATE_REF`.

The `# nosec B310` comments now name where integrity is handled, as the issue asked —
previously they read as "reviewed and safe" for a question they did not answer.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### 15 existing tests changed — two causes, neither a regression

| cause | tests | resolution |
| :--- | ---: | :--- |
| **A** — tests used `example.com` URLs, so the new rule correctly demanded a digest | 12 | The URL was an incidental stand-in in tests whose subject is *extraction*, so those moved to `github.com`. The two that genuinely exercise the non-GitHub `url_template` path now **supply a real digest**, demonstrating the required downstream pattern instead of sidestepping it. |
| **B** — `assert_called_once_with` pins the exact `install_tool` signature | 3 | Added `sha256=None` to the expected kwargs. Mechanical, no semantic change. |

No test was weakened to make it pass. Cause A was the new control firing exactly as
designed — the tests encoded a precondition that no longer holds.

### 15 new tests

Beyond the happy path and the two failure modes, two are worth calling out because they
target ways this could pass while being wrong:

- **`test_requires_digest_by_host`** includes `https://github.com.evil.example/tool` and
  `https://notgithub.com/tool`. Host policy is decided on the parsed hostname, so a
  substring check would let both through.
- **`test_digest_spans_the_whole_file`** hashes a 2 MB file and the same file with its
  final byte changed. A chunked reader that stopped after the first block would pass every
  other test here while accepting a file whose tail had been replaced.

Plus `test_archive_is_not_parsed_when_the_digest_is_wrong` (asserts `tarfile.open` is never
called) and `test_binary_is_not_made_executable_when_the_digest_is_wrong`, which pin the
ordering that makes the check meaningful.

`test_pinning_happens_before_any_file_is_fetched` reads `bootstrap.py` and asserts no
`download_file(` call sits between `pin_base_url()` and either download loop — ordering is
the whole point, and a pin applied after the first fetch would leave that file from a
different commit.

`doit check`: all passed (1,433 tests). `mkdocs build --strict`: clean. Coverage 64.34% →
**64.67%**.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### What was deliberately not built, and why

The issue proposed fetching upstream checksum files and verifying against them. **Rejected**,
with the reasoning recorded in ADR-9015 and the framework docs:

- Against a network attacker: nothing beyond what TLS already provides — the asset and the
  checksum travel the same channel from the same origin.
- Against a compromised upstream release: nothing — whoever can replace the asset can
  replace the checksum beside it.
- Against CDN or storage corruption: real, but small.

Shipping it would have read as integrity assurance while providing close to none. That is
the pattern this backlog has now found repeatedly — a control that reports success while
doing nothing — so it is called out explicitly rather than left as an implication.

Also verified while scoping: `cli/cli` publishes `gh_{version}_checksums.txt`, but
`direnv/direnv` publishes **no checksum asset at all**. A uniform "verify against upstream"
approach was not available even if it had been worth having.

### Known limitation, recorded in the ADR

`install_tool` resolves the latest release at run time, so a caller-supplied digest is only
valid for a known version. Pinning versions alongside digests is what would buy
reproducibility and detect a retagged upstream asset — deferred because the digest matrix
ages and would change `doit install_gh` from "install current gh" to "install the version
the template froze". Recorded as future work rather than silently omitted.

### Breaking change

Any downstream already passing `url_template` for a non-GitHub host will get an
`IntegrityError` naming the missing `sha256` parameter until a digest is added. This is the
intended behaviour — those are precisely the downloads that bypass every other trust
assumption in the framework — but it does require action from consumers using the ADR-9015
escape hatch. Documented under the ADR's Negative consequences.
