### PR TITLE
chore: pin actions to commit SHAs and scope benchmark write permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,18 +7,30 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least privilege at workflow scope. The write grant lives on the `store` job
+# alone, which only runs for pushes to main (#695).
+#
+# Previously `contents: write` and `pull-requests: write` were declared here, so
+# they applied to the `pull_request` trigger as well. On a same-repo branch that
+# means PR code runs with a write-capable GITHUB_TOKEN, which was then handed to
+# a third-party action. benchmark-action's own README says as much:
+# "Do not run this workflow on pull request since this workflow has permission
+# to modify contents."
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
+    outputs:
+      has-benchmarks: ${{ steps.check-benchmarks.outputs.exists }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check for benchmark tests
         id: check-benchmarks
@@ -34,19 +46,19 @@ jobs:
         if: steps.check-benchmarks.outputs.exists == 'true'
         uses: ./.github/actions/python-versions
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           python-version: ${{ steps.pv.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         if: steps.check-benchmarks.outputs.exists == 'true'
         with:
           version: "latest"
 
       - name: Cache uv dependencies
         if: steps.check-benchmarks.outputs.exists == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
@@ -65,8 +77,36 @@ jobs:
             --benchmark-enable --benchmark-only \
             --benchmark-json=tmp/benchmark-results.json -v
 
+      - name: Upload benchmark results
+        if: always() && steps.check-benchmarks.outputs.exists == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-results
+          path: tmp/benchmark-results.json
+          retention-days: 90
+
+  # Storing results rewrites the gh-benchmarks branch, so this is the only job
+  # that needs write access — and it never runs for a pull request.
+  store:
+    needs: benchmark
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.benchmark.outputs.has-benchmarks == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download benchmark results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-results
+          path: tmp
+
       - name: Check for benchmark data branch
-        if: steps.check-benchmarks.outputs.exists == 'true'
         id: check-bench-branch
         run: |
           if git ls-remote --exit-code origin gh-benchmarks >/dev/null 2>&1; then
@@ -76,7 +116,7 @@ jobs:
           fi
 
       - name: Create benchmark data branch
-        if: steps.check-benchmarks.outputs.exists == 'true' && steps.check-bench-branch.outputs.exists != 'true' && github.event_name == 'push'
+        if: steps.check-bench-branch.outputs.exists != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -86,23 +126,13 @@ jobs:
           git checkout ${{ github.sha }}
 
       - name: Store benchmark results
-        if: steps.check-benchmarks.outputs.exists == 'true' && (github.event_name == 'push' || steps.check-bench-branch.outputs.exists == 'true')
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: 'pytest'
           output-file-path: tmp/benchmark-results.json
           gh-pages-branch: gh-benchmarks
           benchmark-data-dir-path: dev/bench
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          auto-push: true
           comment-on-alert: true
-          comment-always: ${{ github.event_name == 'pull_request' }}
           alert-threshold: '110%'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload benchmark results
-        if: always() && steps.check-benchmarks.outputs.exists == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmark-results
-          path: tmp/benchmark-results.json
-          retention-days: 90

--- a/.github/workflows/breaking-change-detection.yml
+++ b/.github/workflows/breaking-change-detection.yml
@@ -14,7 +14,7 @@ jobs:
     name: Detect API Breaking Changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Need full history for comparison
 
@@ -24,7 +24,7 @@ jobs:
       - id: pv
         uses: ./.github/actions/python-versions
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ steps.pv.outputs.newest }}
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Report breaking changes
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HAS_BREAKING: ${{ steps.griffe.outputs.has_breaking }}
           GRIFFE_OUTPUT: ${{ steps.griffe.outputs.details }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       oldest: ${{ steps.pv.outputs.oldest }}
       newest: ${{ steps.pv.outputs.newest }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             .github/python-versions.json
@@ -89,18 +89,18 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == needs.setup.outputs.newest && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./tmp/coverage.xml
           flags: unittests
@@ -137,18 +137,18 @@ jobs:
       UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ needs.setup.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
@@ -169,18 +169,18 @@ jobs:
       UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ needs.setup.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,15 +37,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -20,21 +20,21 @@ jobs:
       UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - id: pv
         uses: ./.github/actions/python-versions
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ steps.pv.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,17 +28,17 @@ jobs:
       reason: ${{ steps.decide.outputs.reason }}
       pr_number: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Fetch dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Decide eligibility
         id: decide
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
           DEPENDENCY_NAMES: ${{ steps.meta.outputs.dependency-names }}
@@ -120,7 +120,7 @@ jobs:
       - name: Generate App token
         id: app-token
         if: ${{ vars.RELEASE_APP_ID != '' }}
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Post sticky status comment
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AUTOMERGE_OUTCOME: ${{ steps.automerge.outcome }}
           APP_TOKEN_CONFIGURED: ${{ steps.app-token.outputs.token != '' }}
@@ -190,7 +190,7 @@ jobs:
     if: needs.evaluate.outputs.qualifies == 'false'
     steps:
       - name: Post sticky skip comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
           REASON: ${{ needs.evaluate.outputs.reason }}

--- a/.github/workflows/dependabot-blocked-label.yml
+++ b/.github/workflows/dependabot-blocked-label.yml
@@ -29,7 +29,7 @@ jobs:
         run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label ready-to-merge || true
 
       - name: Post sticky blocked comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -15,21 +15,21 @@ jobs:
       UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - id: pv
         uses: ./.github/actions/python-versions
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ steps.pv.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload mutation results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-results
           path: tmp/mutmut-results.txt

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows conventional commits
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -42,12 +42,12 @@ jobs:
     name: Validate Issue Link
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Check for linked issue
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR description completeness
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,18 +19,18 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - id: pv
         uses: ./.github/actions/python-versions
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ steps.pv.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
@@ -57,7 +57,7 @@ jobs:
       # and ``sbom`` for the GitHub release. Mixing SBOM files into the
       # publish artifact makes twine abort with InvalidDistribution. See
       # issue #665.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: |
@@ -65,7 +65,7 @@ jobs:
             dist/*.tar.gz
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: |
@@ -82,7 +82,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
@@ -103,7 +103,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create GitHub release with auto-generated notes
         env:
@@ -131,7 +131,7 @@ jobs:
           tag="${GITHUB_REF_NAME}"
           gh release create "$tag" --generate-notes --title "$tag"
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom
           path: dist

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -24,18 +24,18 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - id: pv
         uses: ./.github/actions/python-versions
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ steps.pv.outputs.newest }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "latest"
 
@@ -49,7 +49,7 @@ jobs:
       - name: Build artifacts
         run: uv build
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist
@@ -63,7 +63,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -256,6 +256,42 @@ The same principle does **not** license shedding these tests. They cover
 runs in the project, and that the gate below measures. Shedding them was measured
 at 40.73% total and 8.27% on `tools/hooks/`, well under `fail_under` (#731).
 
+### Action pinning and workflow permissions
+
+**Every external action is pinned to a commit SHA**, with a `# vX.Y.Z` comment so the
+file stays readable:
+
+```yaml
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+```
+
+A major tag such as `@v7` is a moving pointer the publisher can re-aim at any commit, so
+`uses: some/action@v7` is a standing instruction to run whatever they decide to put
+there. A 40-character SHA is not re-pointable. Dependabot is configured for the
+`github-actions` ecosystem, so pins are bumped through a reviewable PR rather than
+changing silently — that trade is the point, and it is why pinning does not mean falling
+behind.
+
+First-party `actions/*` are pinned too. "GitHub publishes it" is not a security boundary,
+and exempting them would leave most of the surface unpinned for no gain.
+
+**One deliberate exemption:** `pypa/gh-action-pypi-publish@release/v1`. PyPA documents
+that branch as the supported reference for trusted publishing and ships security fixes to
+it, and the workflows using it hold `id-token: write`. The exemption and its reason live
+in `PINNING_EXEMPT` in `tests/test_workflow_action_pinning.py`, which fails if it is ever
+added to without a reason or left in place after the action stops being used.
+
+**Permissions are least-privilege, and write is never reachable from a pull request.** A
+same-repo PR branch runs its own code; if a write-capable `GITHUB_TOKEN` is in scope,
+that code can use it — and workflow-scope `permissions:` apply to every trigger,
+including `pull_request`. So a job needing write declares it at *job* scope and gates
+itself on `github.event_name == 'push'`. `benchmark.yml` is the worked example: a
+read-only `benchmark` job that runs everywhere, and a `store` job holding the only write
+grant, gated on pushes to main.
+
+`tests/test_benchmark_workflow.py` and `tests/test_workflow_action_pinning.py` enforce
+both properties.
+
 ### Coverage Requirements
 
 - **Enforced threshold**: `fail_under = 54` in `pyproject.toml`

--- a/tests/test_benchmark_workflow.py
+++ b/tests/test_benchmark_workflow.py
@@ -1,12 +1,32 @@
-"""Tests for the benchmark GitHub Actions workflow configuration."""
+"""Tests for the benchmark GitHub Actions workflow configuration.
+
+Rewritten for #695. The previous version asserted the design this issue set out
+to remove: `contents: write` and `pull-requests: write` at *workflow* scope, so
+they applied to the `pull_request` trigger, plus a store step that ran on PRs and
+handed a write-capable `GITHUB_TOKEN` to a third-party action.
+
+The workflow is now split. `benchmark` runs everywhere read-only; `store` holds
+the only write grant and runs for pushes to main alone. benchmark-action's own
+README makes the same point: "Do not run this workflow on pull request since this
+workflow has permission to modify contents."
+
+These tests assert the *property* — no write permission is reachable from a pull
+request — rather than the shape of any particular step, so a future restructure
+that preserves the property does not have to rewrite them again.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+import pytest
 import yaml
 
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "benchmark.yml"
+
+# Permissions that let a job change the repository or its pull requests.
+WRITE_SCOPES = {"write", "write-all"}
 
 
 def _load_workflow() -> dict:
@@ -19,6 +39,24 @@ def _load_workflow() -> dict:
     return data
 
 
+def _jobs() -> dict[str, Any]:
+    jobs: dict[str, Any] = _load_workflow()["jobs"]
+    return jobs
+
+
+def _write_permissions(perms: str | dict[str, str] | None) -> set[str]:
+    """Return the permission names granted at write level in *perms*.
+
+    Accepts the three shapes GitHub allows: absent, a blanket string such as
+    ``write-all``, or a per-scope mapping.
+    """
+    if perms is None:
+        return set()
+    if isinstance(perms, str):
+        return {"<all>"} if perms in WRITE_SCOPES else set()
+    return {name for name, level in perms.items() if level in WRITE_SCOPES}
+
+
 class TestBenchmarkWorkflowExists:
     """Test that the benchmark workflow file exists."""
 
@@ -28,193 +66,169 @@ class TestBenchmarkWorkflowExists:
 
 
 class TestBenchmarkWorkflowTriggers:
-    """Test that the benchmark workflow has correct triggers."""
+    """Triggers are unchanged by #695 — only what each one may do changed."""
 
     def test_has_push_trigger(self) -> None:
-        """Workflow should trigger on push to main."""
-        workflow = _load_workflow()
-        triggers = workflow[True]  # YAML 'on' is parsed as boolean True
+        triggers = _load_workflow()[True]  # YAML 'on' parses as boolean True
         assert "push" in triggers
         assert "main" in triggers["push"]["branches"]
 
     def test_has_pull_request_trigger(self) -> None:
-        """Workflow should trigger on pull requests to main."""
-        workflow = _load_workflow()
-        triggers = workflow[True]
+        triggers = _load_workflow()[True]
         assert "pull_request" in triggers
         assert "main" in triggers["pull_request"]["branches"]
 
     def test_has_workflow_dispatch_trigger(self) -> None:
-        """Workflow should support manual dispatch."""
-        workflow = _load_workflow()
-        triggers = workflow[True]
-        assert "workflow_dispatch" in triggers
+        assert "workflow_dispatch" in _load_workflow()[True]
 
 
-class TestBenchmarkWorkflowPermissions:
-    """Test that the benchmark workflow has correct permissions."""
+class TestLeastPrivilege:
+    """The security property #695 exists to establish."""
 
-    def test_has_contents_write_permission(self) -> None:
-        """Workflow needs contents:write to push to gh-benchmarks branch."""
-        workflow = _load_workflow()
-        assert workflow["permissions"]["contents"] == "write"
+    def test_workflow_scope_grants_no_write(self) -> None:
+        """Workflow-level permissions apply to every trigger, including PRs."""
+        granted = _write_permissions(_load_workflow().get("permissions"))
+        assert not granted, (
+            f"benchmark.yml grants {sorted(granted)} at workflow scope, so the "
+            "pull_request trigger gets it too. Move it to the job that needs it."
+        )
 
-    def test_has_pull_requests_write_permission(self) -> None:
-        """Workflow needs pull-requests:write to post PR comments."""
-        workflow = _load_workflow()
-        assert workflow["permissions"]["pull-requests"] == "write"
+    def test_no_write_permission_is_reachable_from_a_pull_request(self) -> None:
+        """Any job with write access must be gated off the pull_request path.
+
+        This is the assertion that matters. A same-repo PR branch runs its own
+        code; if a write-capable token is in scope, that code can use it.
+        """
+        offenders = []
+        for name, job in _jobs().items():
+            granted = _write_permissions(job.get("permissions"))
+            if not granted:
+                continue
+            condition = str(job.get("if", ""))
+            if "github.event_name == 'push'" not in condition:
+                offenders.append(f"{name} grants {sorted(granted)} but is not gated on push")
+
+        assert not offenders, "write permission reachable from a pull request:\n  " + "\n  ".join(
+            offenders
+        )
+
+    def test_benchmark_job_is_explicitly_read_only(self) -> None:
+        """The job that runs on PRs states its permissions rather than inheriting."""
+        benchmark = _jobs()["benchmark"]
+        assert benchmark.get("permissions") == {"contents": "read"}
+
+    def test_store_job_is_gated_on_push_to_main(self) -> None:
+        condition = str(_jobs()["store"].get("if", ""))
+        assert "github.event_name == 'push'" in condition
+        assert "github.ref == 'refs/heads/main'" in condition
+
+    def test_only_the_store_job_holds_the_write_grant(self) -> None:
+        writers = {
+            name for name, job in _jobs().items() if _write_permissions(job.get("permissions"))
+        }
+        assert writers == {"store"}, f"unexpected write-capable jobs: {sorted(writers - {'store'})}"
+
+    def test_pull_requests_write_is_not_granted_anywhere(self) -> None:
+        """It was never needed: benchmark-action posts *commit* comments."""
+        scopes = _write_permissions(_load_workflow().get("permissions"))
+        for job in _jobs().values():
+            scopes |= _write_permissions(job.get("permissions"))
+        assert "pull-requests" not in scopes
 
 
-class TestBenchmarkWorkflowSteps:
-    """Test that the benchmark workflow has the expected steps."""
+class TestBenchmarkJob:
+    """The read-only half: run the benchmarks, publish the numbers as an artifact."""
 
-    def _get_steps(self) -> list[dict]:
-        """Get the steps from the benchmark job."""
-        workflow = _load_workflow()
-        # Indexing an untyped mapping yields Any; bind to an annotated local so
-        # warn_return_any does not fire on the return.
-        steps: list[dict] = workflow["jobs"]["benchmark"]["steps"]
+    @staticmethod
+    def _steps() -> list[dict]:
+        steps: list[dict] = _jobs()["benchmark"]["steps"]
         return steps
 
-    def _find_step(self, name: str) -> dict | None:
-        """Find a step by name."""
-        for step in self._get_steps():
-            if step.get("name") == name:
-                return step
-        return None
+    def test_runs_benchmarks(self) -> None:
+        assert any("--benchmark-only" in str(s.get("run", "")) for s in self._steps())
 
-    def test_has_check_bench_branch_step(self) -> None:
-        """Workflow should check if the gh-benchmarks branch exists."""
-        step = self._find_step("Check for benchmark data branch")
-        assert step is not None, "Missing 'Check for benchmark data branch' step"
-        assert step.get("id") == "check-bench-branch"
-        assert "gh-benchmarks" in step["run"]
+    def test_uploads_results_artifact(self) -> None:
+        uploads = [s for s in self._steps() if "upload-artifact" in str(s.get("uses", ""))]
+        assert uploads, "benchmark results must still be published as an artifact"
+        assert uploads[0]["with"]["name"] == "benchmark-results"
 
-    def test_store_step_conditional_on_branch_existence(self) -> None:
-        """Store step should only run on push or when gh-benchmarks branch exists."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        condition = step.get("if", "")
-        assert "push" in condition
-        assert "check-bench-branch" in condition
+    def test_exposes_whether_benchmarks_exist(self) -> None:
+        """`store` skips when there is nothing to store, so it needs the output."""
+        assert "has-benchmarks" in _jobs()["benchmark"]["outputs"]
 
-    def test_check_bench_branch_before_store_step(self) -> None:
-        """Check branch step should come before store step."""
-        steps = self._get_steps()
-        step_names = [s.get("name") for s in steps]
-        check_idx = step_names.index("Check for benchmark data branch")
-        store_idx = step_names.index("Store benchmark results")
-        assert check_idx < store_idx, "Check branch step must come before Store step"
+    def test_does_not_run_the_third_party_benchmark_action(self) -> None:
+        """The action takes a token and writes; it belongs in the gated job.
 
-    def test_has_create_bench_branch_step(self) -> None:
-        """Workflow should create the gh-benchmarks branch if it doesn't exist."""
-        step = self._find_step("Create benchmark data branch")
-        assert step is not None, "Missing 'Create benchmark data branch' step"
-        condition = step.get("if", "")
-        assert "check-bench-branch" in condition
-        assert "push" in condition
-        assert "gh-benchmarks" in step["run"]
-        assert "git config user.name" in step["run"]
-        assert "git config user.email" in step["run"]
+        Trade-off recorded deliberately: PRs no longer get an automated
+        regression comment. The benchmark still runs and its JSON is uploaded,
+        and `fail-on-alert` was rejected as a replacement because a wall-clock
+        threshold on a shared runner is a flake source — the same lesson as the
+        Hypothesis deadline in #736.
+        """
+        assert not any("github-action-benchmark" in str(s.get("uses", "")) for s in self._steps())
 
-    def test_create_branch_before_store_step(self) -> None:
-        """Create branch step should come before store step."""
-        steps = self._get_steps()
-        step_names = [s.get("name") for s in steps]
-        create_idx = step_names.index("Create benchmark data branch")
-        store_idx = step_names.index("Store benchmark results")
-        assert create_idx < store_idx
 
-    def test_has_store_benchmark_results_step(self) -> None:
-        """Workflow should have a step to store benchmark results."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None, "Missing 'Store benchmark results' step"
+class TestStoreJob:
+    """The write half: rewrite the gh-benchmarks branch, on main only."""
 
-    def test_store_step_uses_benchmark_action(self) -> None:
-        """The store step should use benchmark-action/github-action-benchmark."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["uses"] == "benchmark-action/github-action-benchmark@v1"
+    @staticmethod
+    def _steps() -> list[dict]:
+        steps: list[dict] = _jobs()["store"]["steps"]
+        return steps
 
-    def test_store_step_uses_pytest_tool(self) -> None:
-        """The store step should be configured for pytest output."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["tool"] == "pytest"
+    def test_depends_on_the_benchmark_job(self) -> None:
+        assert _jobs()["store"]["needs"] == "benchmark"
 
-    def test_store_step_reads_correct_output_file(self) -> None:
-        """The store step should read from the benchmark results JSON."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["output-file-path"] == "tmp/benchmark-results.json"
+    def test_skips_when_there_are_no_benchmarks(self) -> None:
+        assert "needs.benchmark.outputs.has-benchmarks" in str(_jobs()["store"].get("if", ""))
 
-    def test_store_step_uses_gh_benchmarks_branch(self) -> None:
-        """Results should be stored on the gh-benchmarks branch."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["gh-pages-branch"] == "gh-benchmarks"
+    def test_downloads_the_results_artifact(self) -> None:
+        downloads = [s for s in self._steps() if "download-artifact" in str(s.get("uses", ""))]
+        assert downloads, "store must consume the artifact rather than re-running benchmarks"
+        assert downloads[0]["with"]["name"] == "benchmark-results"
 
-    def test_store_step_uses_dev_bench_data_dir(self) -> None:
-        """Results should be stored in the dev/bench directory."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["benchmark-data-dir-path"] == "dev/bench"
+    def test_creates_the_data_branch_when_missing(self) -> None:
+        creates = [s for s in self._steps() if s.get("name") == "Create benchmark data branch"]
+        assert creates
+        assert "gh-benchmarks" in creates[0]["run"]
 
-    def test_store_step_auto_push_conditional(self) -> None:
-        """Auto-push should only happen on push to main."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        auto_push = step["with"]["auto-push"]
-        assert "github.event_name == 'push'" in auto_push
-        assert "refs/heads/main" in auto_push
+    def test_branch_check_precedes_branch_creation(self) -> None:
+        names = [s.get("name") for s in self._steps()]
+        assert names.index("Check for benchmark data branch") < names.index(
+            "Create benchmark data branch"
+        )
 
-    def test_store_step_comment_on_alert_enabled(self) -> None:
-        """Comment-on-alert should be enabled."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["comment-on-alert"] is True
-
-    def test_store_step_comment_always_on_pr(self) -> None:
-        """Comment-always should be conditional on pull_request events."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        comment_always = step["with"]["comment-always"]
-        assert "pull_request" in comment_always
-
-    def test_store_step_alert_threshold(self) -> None:
-        """Alert threshold should be set to 110% (10% regression tolerance)."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["alert-threshold"] == "110%"
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("tool", "pytest"),
+            ("output-file-path", "tmp/benchmark-results.json"),
+            ("gh-pages-branch", "gh-benchmarks"),
+            ("benchmark-data-dir-path", "dev/bench"),
+            ("alert-threshold", "110%"),
+            ("auto-push", True),
+            ("comment-on-alert", True),
+        ],
+    )
+    def test_store_step_configuration(self, key: str, expected: object) -> None:
+        store = next(
+            s for s in self._steps() if "github-action-benchmark" in str(s.get("uses", ""))
+        )
+        assert store["with"][key] == expected
 
     def test_store_step_uses_github_token(self) -> None:
-        """The store step should use GITHUB_TOKEN for authentication."""
-        step = self._find_step("Store benchmark results")
-        assert step is not None
-        assert step["with"]["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
+        store = next(
+            s for s in self._steps() if "github-action-benchmark" in str(s.get("uses", ""))
+        )
+        assert "secrets.GITHUB_TOKEN" in str(store["with"]["github-token"])
 
-    def test_upload_artifact_step_still_exists(self) -> None:
-        """The existing artifact upload step should still be present."""
-        step = self._find_step("Upload benchmark results")
-        assert step is not None, "Missing 'Upload benchmark results' artifact step"
+    def test_auto_push_is_unconditional_here(self) -> None:
+        """The job only runs on push to main, so the step needs no second guard.
 
-    def test_run_benchmarks_step_exists(self) -> None:
-        """The run benchmarks step should still be present."""
-        step = self._find_step("Run benchmarks")
-        assert step is not None, "Missing 'Run benchmarks' step"
-
-    def test_store_step_comes_after_run_step(self) -> None:
-        """Store step should come after the run benchmarks step."""
-        steps = self._get_steps()
-        step_names = [s.get("name") for s in steps]
-        run_idx = step_names.index("Run benchmarks")
-        store_idx = step_names.index("Store benchmark results")
-        assert store_idx > run_idx, "Store step must come after Run benchmarks step"
-
-    def test_upload_step_comes_after_store_step(self) -> None:
-        """Upload artifact step should come after the store step."""
-        steps = self._get_steps()
-        step_names = [s.get("name") for s in steps]
-        store_idx = step_names.index("Store benchmark results")
-        upload_idx = step_names.index("Upload benchmark results")
-        assert upload_idx > store_idx, "Upload step must come after Store step"
+        A leftover `${{ github.event_name == 'push' }}` expression would imply
+        this job can run otherwise, which is exactly the confusion #695 fixed.
+        """
+        store = next(
+            s for s in self._steps() if "github-action-benchmark" in str(s.get("uses", ""))
+        )
+        assert store["with"]["auto-push"] is True

--- a/tests/test_codeql_workflow.py
+++ b/tests/test_codeql_workflow.py
@@ -166,8 +166,8 @@ class TestAnalyzeJob:
         job = workflow["jobs"]["analyze"]
         assert job["strategy"]["fail-fast"] is False
 
-    def test_analyze_pins_checkout_major_version(self) -> None:
-        """``actions/checkout`` must be pinned to a major-version tag (``@vN``).
+    def test_analyze_pins_checkout_to_a_sha(self) -> None:
+        """``actions/checkout`` must be pinned to a commit SHA.
 
         The exact major version is intentionally not asserted. Dependabot bumps
         ``actions/checkout`` routinely; pinning this test to a specific number
@@ -179,18 +179,19 @@ class TestAnalyzeJob:
         checkout_steps = [s for s in steps if s.get("uses", "").startswith("actions/checkout@")]
         assert checkout_steps, "expected an actions/checkout step"
         uses = checkout_steps[0]["uses"]
-        assert re.fullmatch(r"actions/checkout@v\d+", uses), (
-            f"expected actions/checkout pinned to a major-version tag, got {uses!r}"
+        assert re.fullmatch(r"actions/checkout@[0-9a-f]{40}", uses), (
+            f"expected actions/checkout pinned to a commit SHA, got {uses!r}"
         )
 
-    def test_analyze_pins_codeql_init_major_version(self) -> None:
-        """``github/codeql-action/init`` must be pinned to a major-version tag (``@vN``).
+    def test_analyze_pins_codeql_init_to_a_sha(self) -> None:
+        """``github/codeql-action/init`` must be pinned to a commit SHA.
 
         The exact major version is intentionally not asserted. Dependabot bumps
         ``github/codeql-action`` routinely; pinning this test to a specific
         number turns every such bump into a false CI failure (see #626). The
-        repo convention this guards is that the action is pinned to a version
-        tag, not a floating ref/branch.
+        SHA-pinning superseded major-tag pinning in #695. The general rule is
+        enforced by tests/test_workflow_action_pinning.py; this asserts only
+        that the right action is the one pinned.
         """
         steps = _analyze_steps()
         init_steps = [
@@ -198,14 +199,14 @@ class TestAnalyzeJob:
         ]
         assert init_steps, "expected a github/codeql-action/init step"
         uses = init_steps[0]["uses"]
-        assert re.fullmatch(r"github/codeql-action/init@v\d+", uses), (
-            f"expected github/codeql-action/init pinned to a major-version tag, got {uses!r}"
+        assert re.fullmatch(r"github/codeql-action/init@[0-9a-f]{40}", uses), (
+            f"expected github/codeql-action/init pinned to a commit SHA, got {uses!r}"
         )
 
-    def test_analyze_pins_codeql_analyze_major_version(self) -> None:
-        """``github/codeql-action/analyze`` must be pinned to a major-version tag (``@vN``).
+    def test_analyze_pins_codeql_analyze_to_a_sha(self) -> None:
+        """``github/codeql-action/analyze`` must be pinned to a commit SHA.
 
-        See ``test_analyze_pins_codeql_init_major_version`` for the rationale
+        See ``test_analyze_pins_codeql_init_to_a_sha`` for the rationale
         (#626): the exact major version is intentionally not asserted so routine
         dependabot bumps don't turn into false CI failures.
         """
@@ -215,8 +216,8 @@ class TestAnalyzeJob:
         ]
         assert analyze_steps, "expected a github/codeql-action/analyze step"
         uses = analyze_steps[0]["uses"]
-        assert re.fullmatch(r"github/codeql-action/analyze@v\d+", uses), (
-            f"expected github/codeql-action/analyze pinned to a major-version tag, got {uses!r}"
+        assert re.fullmatch(r"github/codeql-action/analyze@[0-9a-f]{40}", uses), (
+            f"expected github/codeql-action/analyze pinned to a commit SHA, got {uses!r}"
         )
 
     def test_analyze_init_passes_matrix_language(self) -> None:

--- a/tests/test_dependabot_automerge_workflow.py
+++ b/tests/test_dependabot_automerge_workflow.py
@@ -135,7 +135,7 @@ class TestAppTokenStep:
         time.
         """
         steps = _enable_automerge_steps()
-        assert steps[0]["uses"] == "actions/create-github-app-token@v3"
+        assert steps[0]["uses"].startswith("actions/create-github-app-token@")
 
     def test_app_token_conditional_on_release_app_id(self) -> None:
         """The App-token step must be guarded by ``if: ${{ vars.RELEASE_APP_ID != '' }}``.
@@ -261,7 +261,7 @@ class TestStickyCommentStep:
     def test_sticky_comment_uses_github_script(self) -> None:
         """The sticky comment step should use ``actions/github-script``."""
         steps = _enable_automerge_steps()
-        assert steps[3]["uses"] == "actions/github-script@v9"
+        assert steps[3]["uses"].startswith("actions/github-script@")
 
     def test_sticky_comment_exposes_automerge_outcome(self) -> None:
         """The sticky comment step must expose ``AUTOMERGE_OUTCOME`` via ``env``."""

--- a/tests/test_dependabot_blocked_label_workflow.py
+++ b/tests/test_dependabot_blocked_label_workflow.py
@@ -194,7 +194,7 @@ class TestHandleBlockedLabelSteps:
         """Step 3 posts the sticky blocked comment via ``actions/github-script``."""
         steps = _handle_blocked_label_steps()
         assert steps[2]["name"] == "Post sticky blocked comment"
-        assert steps[2]["uses"] == "actions/github-script@v9"
+        assert steps[2]["uses"].startswith("actions/github-script@")
 
     def test_sticky_comment_retains_dedupe_marker(self) -> None:
         """The sticky-comment dedupe marker must match the parent workflow's marker

--- a/tests/test_workflow_action_pinning.py
+++ b/tests/test_workflow_action_pinning.py
@@ -1,0 +1,136 @@
+"""Third-party actions must be pinned to commit SHAs, not mutable tags (#695).
+
+A major tag like `@v7` is a moving pointer the publisher can re-aim at any
+commit, so `uses: some/action@v7` is a standing instruction to run whatever that
+publisher decides to put there. A 40-character SHA is not re-pointable.
+
+Dependabot is configured for the `github-actions` ecosystem, so pins get bumped
+rather than rotting — pinning trades "silently changes" for "changes via a
+reviewable PR", which is the whole point.
+
+Each pin carries a `# vX.Y.Z` comment so a human can read the file without
+resolving SHAs, and that comment is asserted too: a pin whose comment has drifted
+from the version it names is worse than no comment.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIRS = (REPO_ROOT / ".github" / "workflows", REPO_ROOT / ".github" / "actions")
+
+# `uses: owner/repo@ref` — captures the ref and any trailing comment.
+USES = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<action>[^@\s]+)@(?P<ref>\S+)(?:\s*#\s*(?P<comment>.*))?$"
+)
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+SEMVER_COMMENT = re.compile(r"^v?\d+\.\d+")
+
+# Actions deliberately left on a mutable ref, each with the reason.
+#
+# PyPA publishes trusted-publishing fixes on this branch and documents it as the
+# reference to use; the workflows holding `id-token: write` follow that guidance
+# rather than pinning past it. Recorded here so the exemption is a decision
+# rather than an oversight (#695).
+PINNING_EXEMPT: dict[str, str] = {
+    "pypa/gh-action-pypi-publish": (
+        "PyPA documents `release/v1` as the supported reference for trusted "
+        "publishing and ships security fixes to it"
+    ),
+}
+
+
+def _workflow_files() -> list[Path]:
+    files: list[Path] = []
+    for directory in WORKFLOW_DIRS:
+        if directory.is_dir():
+            files += sorted(directory.rglob("*.yml"))
+    return files
+
+
+def _uses_entries() -> list[tuple[Path, int, str, str, str | None]]:
+    """Return (file, line_no, action, ref, comment) for every `uses:` line."""
+    entries = []
+    for path in _workflow_files():
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            match = USES.match(line)
+            if not match:
+                continue
+            action = match.group("action").strip("'\"")
+            if action.startswith("./"):
+                continue  # local composite action or reusable workflow
+            entries.append((path, line_no, action, match.group("ref"), match.group("comment")))
+    return entries
+
+
+def _base_repo(action: str) -> str:
+    """`github/codeql-action/init` -> `github/codeql-action`."""
+    return "/".join(action.split("/")[:2])
+
+
+def test_every_external_action_is_sha_pinned() -> None:
+    """No `uses:` may name a mutable tag or branch, exemptions aside."""
+    unpinned = [
+        f"{path.relative_to(REPO_ROOT)}:{line_no} {action}@{ref}"
+        for path, line_no, action, ref, _ in _uses_entries()
+        if not SHA.match(ref) and _base_repo(action) not in PINNING_EXEMPT
+    ]
+    assert not unpinned, (
+        "actions on mutable refs — a publisher can re-point these at any commit:\n  "
+        + "\n  ".join(unpinned)
+        + "\n\nPin to a 40-character commit SHA with a `# vX.Y.Z` comment, or add an "
+        "entry to PINNING_EXEMPT with a reason."
+    )
+
+
+def test_every_pin_names_the_version_it_points_at() -> None:
+    """A SHA with no version comment is unreadable; a wrong one is misleading."""
+    missing = [
+        f"{path.relative_to(REPO_ROOT)}:{line_no} {action}"
+        for path, line_no, action, ref, comment in _uses_entries()
+        if SHA.match(ref) and not (comment and SEMVER_COMMENT.match(comment.strip()))
+    ]
+    assert not missing, "SHA pins without a `# vX.Y.Z` version comment:\n  " + "\n  ".join(missing)
+
+
+def test_the_same_action_is_pinned_consistently() -> None:
+    """One action at two SHAs in one repo means a bump was applied by hand."""
+    seen: dict[str, set[tuple[str, str]]] = {}
+    for _path, _line, action, ref, comment in _uses_entries():
+        if SHA.match(ref):
+            seen.setdefault(action, set()).add((ref, (comment or "").strip()))
+
+    divergent = {a: sorted(v) for a, v in seen.items() if len(v) > 1}
+    assert not divergent, f"the same action is pinned to different commits: {divergent}"
+
+
+@pytest.mark.parametrize("action", sorted(PINNING_EXEMPT))
+def test_exemptions_are_real_and_still_used(action: str) -> None:
+    """An exemption must name a reason and an action the repo still uses.
+
+    Stops the list becoming a place things are quietly added to and never
+    removed.
+    """
+    assert PINNING_EXEMPT[action].strip(), f"{action} needs a reason"
+    in_use = {_base_repo(a) for _p, _l, a, _r, _c in _uses_entries()}
+    assert action in in_use, f"{action} is exempt but no longer used; drop the exemption"
+
+
+def test_the_scanner_finds_the_uses_lines() -> None:
+    """Guard the regex: a pattern matching nothing would pass every test above."""
+    entries = _uses_entries()
+    assert len(entries) >= 40, f"only {len(entries)} `uses:` entries found; regex has gone stale"
+    assert sum(1 for e in entries if SHA.match(e[3])) >= 40
+
+
+def test_the_pin_check_rejects_a_mutable_ref() -> None:
+    """The matcher must actually distinguish a tag from a SHA."""
+    assert not SHA.match("v7")
+    assert not SHA.match("release/v1")
+    assert not SHA.match("3d3c42e5aac5ba805825da76410c181273ba90b")  # 39 chars
+    assert SHA.match("3d3c42e5aac5ba805825da76410c181273ba90b1")


### PR DESCRIPTION
## Description

Two workflow hardening gaps: a write-capable token reachable from the `pull_request`
trigger, and every action pinned to a mutable tag.

## Related Issue

Addresses #695

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement
- [x] CI/CD configuration

## Changes Made

### 1. `benchmark.yml` — write is no longer reachable from a pull request

`contents: write` and `pull-requests: write` were declared at **workflow** scope, so they
applied to the `pull_request` trigger too. On a same-repo branch that means PR code runs
with a write-capable `GITHUB_TOKEN`, which was then handed to a third-party action.

The action's own README settles the design:

> `# Do not run this workflow on pull request since this workflow has permission to modify contents.`

The workflow is now two jobs:

| job | permissions | runs |
| :--- | :--- | :--- |
| `benchmark` | `contents: read` | every trigger — runs benchmarks, uploads the results artifact |
| `store` | `contents: write` | pushes to main only — writes the `gh-benchmarks` branch |

**`pull-requests: write` is dropped entirely.** It was never needed: benchmark-action posts
*commit* comments, not PR comments. That grant widened the blast radius and bought nothing.

### 2. All 60 external action references pinned to commit SHAs

Each with a `# vX.Y.Z` comment so the file stays readable:

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

A major tag is a moving pointer the publisher can re-aim at any commit. Dependabot is
configured for the `github-actions` ecosystem, so pins are bumped through a reviewable PR
instead of changing silently — that trade is the point.

First-party `actions/*` are pinned too: "GitHub publishes it" is not a security boundary,
and exempting them would leave most of the surface unpinned for no gain.

**One documented exemption:** `pypa/gh-action-pypi-publish@release/v1`. PyPA documents that
branch as the supported reference for trusted publishing and ships security fixes to it,
and the workflows using it hold `id-token: write`. The reason lives in `PINNING_EXEMPT`
alongside a test that fails if an exemption is added without a reason or outlives its use.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Guards verified by reintroducing each regression:**

| break simulated | guard that fired |
| :--- | :--- |
| an action reverted to `@v7` | `test_every_external_action_is_sha_pinned` |
| write restored at workflow scope | `test_workflow_scope_grants_no_write`, `test_pull_requests_write_is_not_granted_anywhere` |
| `store`'s push gate removed | `test_no_write_permission_is_reachable_from_a_pull_request` |

### 26 tests changed — and why that is the right call

**`test_benchmark_workflow.py` was rewritten (20 tests).** Its previous assertions pinned
the design this PR removes — `test_has_contents_write_permission`,
`test_has_pull_requests_write_permission`, `test_store_step_comment_always_on_pr`. A test
named for a security control was pinning the absence of one.

The replacement asserts the **property** — no write permission is reachable from a pull
request — rather than the shape of any particular step, so a future restructure that
preserves the property will not force another rewrite.

**Six tests in three other files** asserted the older convention, "pinned to a
major-version tag". SHA-pinning supersedes it and is strictly stronger, so those now assert
the action's identity and defer the pinning rule to the new generic guard.

`doit check`: all passed. `actionlint`: passed. `mkdocs build --strict`: clean.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### A deliberate trade-off: PRs lose the benchmark regression comment

That comment required `contents: write` on the PR path, which is precisely what this issue
asks to remove. The benchmark still runs on PRs and its JSON is still uploaded as an
artifact.

`fail-on-alert` was considered as a read-only replacement and **rejected**: a 110%
wall-clock threshold on a shared runner is a flake source, which is the same lesson #736
established for the Hypothesis deadline. Trading a comment for a flaky red check would be a
bad deal. The reasoning is recorded in a test docstring so it survives.

### Not done: `zizmor`

The issue says "consider" adding it alongside `actionlint`. Adding a dependency is an
"Ask First" item under `AGENTS.md`, so it is left for a separate decision rather than
slipped in here.

### Version comments were re-resolved after a wrong first pass

Resolving the pins initially via `releases/latest` produced `# v7.0.0` for
`actions/setup-python@v6` — the repo's newest release, not the version the `v6` tag points
at. Wrong version comments are worse than none, so every pin was re-resolved with
`git ls-remote` to find the exact tag at each SHA. Noting it because the comments are the
only human-readable part of a SHA pin, and their accuracy is the whole reason they exist.
