### PR TITLE
refactor: make the unit suite hermetic against the real gh binary

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest configuration and Hypothesis profiles."""
 
 import os
+import sys
 from collections.abc import Callable, Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -100,25 +101,31 @@ def mock_subprocess() -> Iterator[MagicMock]:
 # Python code that shells out should mock `subprocess.run` instead; this fixture
 # is the backstop for what slips through, and for shell scripts under test, which
 # cannot be mocked at the Python level.
-_GH_STUB = """#!/bin/sh
-case "$1 $2" in
-  "auth status")
+_GH_STUB_PY = """import sys
+
+args = sys.argv[1:]
+head = " ".join(args[:2])
+
+if head == "auth status":
     # No token markers, so `_check_token_permissions` takes its else branch.
     # Both branches are pinned explicitly in test_setup_repo.py.
-    echo "Logged in to github.com as test-user" >&2
-    exit 0
-    ;;
-  "api user")
+    print("Logged in to github.com as test-user", file=sys.stderr)
+    sys.exit(0)
+
+if head == "api user":
     # Unauthenticated: the statusline must render no user segment.
-    echo "gh: authentication required" >&2
-    exit 1
-    ;;
-esac
-case "$1" in
-  --version) echo "gh version 0.0.0-stub (hermetic test stub)" ; exit 0 ;;
-esac
-echo "HERMETIC-STUB: unmocked 'gh $*' reached the real PATH (#710)" >&2
-exit 127
+    print("gh: authentication required", file=sys.stderr)
+    sys.exit(1)
+
+if args[:1] == ["--version"]:
+    print("gh version 0.0.0-stub (hermetic test stub)")
+    sys.exit(0)
+
+print(
+    "HERMETIC-STUB: unmocked 'gh " + " ".join(args) + "' reached the real PATH (#710)",
+    file=sys.stderr,
+)
+sys.exit(127)
 """
 
 
@@ -126,9 +133,32 @@ exit 127
 def _hermetic_path(
     tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Put a stub `gh` ahead of the real one for every test."""
+    """Put a stub `gh` ahead of the real one for every test.
+
+    The dispatch lives in Python so there is one implementation; only the
+    launcher differs per platform. Windows resolves executables through
+    ``PATHEXT``, so an extensionless shell script named ``gh`` is not executable
+    there — the first version of this fixture silently no-opped on Windows and
+    the suite kept calling the real binary.
+
+    Both launchers are written on Windows: ``gh.CMD`` for ``PATHEXT`` resolution,
+    and an extensionless ``gh`` for the Git Bash used to run the shell scripts
+    under test, which does not consult ``PATHEXT``.
+    """
     bin_dir = tmp_path_factory.mktemp("hermetic-bin")
-    stub = bin_dir / "gh"
-    stub.write_text(_GH_STUB, encoding="utf-8")
-    stub.chmod(0o755)
+    (bin_dir / "_gh_stub.py").write_text(_GH_STUB_PY, encoding="utf-8")
+
+    shim = bin_dir / "gh"
+    shim.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "$(dirname "$0")/_gh_stub.py" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    if os.name == "nt":
+        (bin_dir / "gh.CMD").write_text(
+            f'@echo off\r\n"{sys.executable}" "%~dp0_gh_stub.py" %*\r\n',
+            encoding="utf-8",
+        )
+
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,3 +79,56 @@ def mock_subprocess() -> Iterator[MagicMock]:
         mock_run.side_effect = side_effect
         mock_run.register = dispatch.update
         yield mock_run
+
+
+# ---------------------------------------------------------------------------
+# Hermetic PATH (#710)
+# ---------------------------------------------------------------------------
+
+# Unit tests were reaching the real `gh` binary 18 times per run — 14 of them
+# `gh api user`, which is a *network* call. That makes results depend on whether
+# the developer happens to be authenticated: #689 spent time diagnosing a 0.54pp
+# coverage difference that turned out to be exactly this.
+#
+# Every test now runs with a stub `gh` ahead of the real one. It answers the
+# handful of commands the code under test invokes with fixed output matching an
+# unauthenticated CI runner, and exits 127 with a loud marker for anything else —
+# so a new unmocked call fails visibly rather than depending on the machine.
+#
+# Tests needing specific `gh` behaviour prepend their own stub ahead of this one
+# (see tests/test_statusline_gh_user.py::_stub_gh), which still works. Tests of
+# Python code that shells out should mock `subprocess.run` instead; this fixture
+# is the backstop for what slips through, and for shell scripts under test, which
+# cannot be mocked at the Python level.
+_GH_STUB = """#!/bin/sh
+case "$1 $2" in
+  "auth status")
+    # No token markers, so `_check_token_permissions` takes its else branch.
+    # Both branches are pinned explicitly in test_setup_repo.py.
+    echo "Logged in to github.com as test-user" >&2
+    exit 0
+    ;;
+  "api user")
+    # Unauthenticated: the statusline must render no user segment.
+    echo "gh: authentication required" >&2
+    exit 1
+    ;;
+esac
+case "$1" in
+  --version) echo "gh version 0.0.0-stub (hermetic test stub)" ; exit 0 ;;
+esac
+echo "HERMETIC-STUB: unmocked 'gh $*' reached the real PATH (#710)" >&2
+exit 127
+"""
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_path(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Put a stub `gh` ahead of the real one for every test."""
+    bin_dir = tmp_path_factory.mktemp("hermetic-bin")
+    stub = bin_dir / "gh"
+    stub.write_text(_GH_STUB, encoding="utf-8")
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")

--- a/tests/test_hermetic_suite.py
+++ b/tests/test_hermetic_suite.py
@@ -10,25 +10,45 @@ caused by a branch that ran in one environment and not the other.
 every test. These tests keep that fixture honest — that it is installed, that it
 answers what the code under test calls, and that it is loud rather than silent
 when something unmocked slips through.
+
+Known limitation, stated rather than papered over: on Windows a PATH stub cannot
+intercept ``subprocess.run(["gh", ...])`` from Python at all, because
+``CreateProcess`` searches only ``gh`` and ``gh.exe`` and never consults
+``PATHEXT`` for ``.CMD``. Shell scripts under test *are* covered there, because
+Git Bash resolves the extensionless launcher. Python code that shells out should
+mock ``subprocess.run`` — ``test_setup_repo.py`` already does for both token
+branches — and this fixture is the backstop for everything else.
 """
 
 from __future__ import annotations
 
 import os
 import shutil
-import subprocess  # nosec B404 - the point of this module is to inspect subprocess behaviour
+import subprocess
+import sys  # nosec B404 - the point of this module is to inspect subprocess behaviour
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _stub_dir() -> Path:
+    return Path(os.environ["PATH"].split(os.pathsep)[0])
+
+
 def _run_gh(*args: str) -> subprocess.CompletedProcess[str]:
-    """Invoke whatever `gh` the current PATH resolves to."""
-    return subprocess.run(  # nosec B603 B607 - resolving PATH is the behaviour under test
-        ["gh", *args],
+    """Exercise the stub's dispatch directly.
+
+    Invoking bare ``gh`` would not work on Windows: ``CreateProcess`` searches
+    only for ``gh`` and ``gh.exe``, never ``gh.CMD``, so a Python-level
+    ``subprocess.run(["gh", ...])`` cannot be intercepted by a PATH stub there
+    at all. Running the dispatch module keeps these assertions meaningful on
+    every platform; the launchers are asserted separately.
+    """
+    return subprocess.run(  # nosec B603 - fixed argv, no shell
+        [sys.executable, str(_stub_dir() / "_gh_stub.py"), *args],
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=30,
         check=False,
     )
 

--- a/tests/test_hermetic_suite.py
+++ b/tests/test_hermetic_suite.py
@@ -19,8 +19,6 @@ import shutil
 import subprocess  # nosec B404 - the point of this module is to inspect subprocess behaviour
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -95,9 +93,17 @@ def test_no_test_module_forwards_the_unfiltered_path() -> None:
     )
 
 
-@pytest.mark.parametrize("binary", ["gh"])
-def test_path_prefix_is_a_real_directory(binary: str) -> None:
-    """Guard against the fixture silently no-opping if tmp handling changes."""
-    first = os.environ["PATH"].split(os.pathsep)[0]
-    assert Path(first).is_dir()
-    assert (Path(first) / binary).exists()
+def test_path_prefix_is_a_real_directory() -> None:
+    """Guard against the fixture silently no-opping if tmp handling changes.
+
+    Windows also needs `gh.CMD`: it resolves executables through PATHEXT, so an
+    extensionless shell script is invisible to it. The first version of this
+    fixture no-opped there and the suite kept calling the real binary — caught
+    by `test_the_stub_is_ahead_of_any_real_gh` on the Windows CI cells.
+    """
+    first = Path(os.environ["PATH"].split(os.pathsep)[0])
+    assert first.is_dir()
+    assert (first / "_gh_stub.py").exists(), "the shared dispatch must be present"
+    assert (first / "gh").exists(), "the POSIX/Git-Bash launcher must be present"
+    if os.name == "nt":
+        assert (first / "gh.CMD").exists(), "Windows needs a PATHEXT-resolvable launcher"

--- a/tests/test_hermetic_suite.py
+++ b/tests/test_hermetic_suite.py
@@ -1,0 +1,103 @@
+"""The unit suite must not reach real external binaries (#710).
+
+Before this, a full run invoked the real `gh` 18 times — 14 of them
+`gh api user --jq .login`, a *network* call. Results then depended on whether the
+developer happened to be authenticated, which is exactly the trap #689 spent time
+diagnosing: a 0.54pp coverage difference between a maintainer's machine and CI,
+caused by a branch that ran in one environment and not the other.
+
+`tests/conftest.py::_hermetic_path` puts a stub `gh` ahead of the real one for
+every test. These tests keep that fixture honest — that it is installed, that it
+answers what the code under test calls, and that it is loud rather than silent
+when something unmocked slips through.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - the point of this module is to inspect subprocess behaviour
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_gh(*args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke whatever `gh` the current PATH resolves to."""
+    return subprocess.run(  # nosec B603 B607 - resolving PATH is the behaviour under test
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_the_stub_is_ahead_of_any_real_gh() -> None:
+    """`gh` must resolve into a pytest tmp dir, not to a system install."""
+    resolved = shutil.which("gh")
+    assert resolved is not None, "the stub should always be resolvable"
+    assert "hermetic-bin" in resolved, (
+        f"`gh` resolves to {resolved!r}, not the hermetic stub — the autouse "
+        "fixture in conftest.py is not installed for this test"
+    )
+
+
+def test_the_stub_answers_what_the_code_under_test_calls() -> None:
+    """The three commands the suite actually invokes must be handled."""
+    assert _run_gh("--version").returncode == 0
+    assert "stub" in _run_gh("--version").stdout
+
+    auth = _run_gh("auth", "status")
+    assert auth.returncode == 0
+    # No token markers: `_check_token_permissions` must take its else branch.
+    assert "github_pat_" not in auth.stderr + auth.stdout
+    assert "gho_" not in auth.stderr + auth.stdout
+
+    # Unauthenticated, so the statusline renders no user segment.
+    assert _run_gh("api", "user", "--jq", ".login").returncode != 0
+
+
+def test_an_unmocked_call_fails_loudly() -> None:
+    """Anything the stub does not answer must fail visibly, not return success.
+
+    A stub that silently exits 0 for unknown commands would let a new unmocked
+    call pass while quietly doing nothing — the failure mode this whole backlog
+    keeps finding.
+    """
+    result = _run_gh("pr", "create", "--title", "should never run")
+
+    assert result.returncode == 127
+    assert "HERMETIC-STUB" in result.stderr
+    assert "#710" in result.stderr
+
+
+def test_no_test_module_forwards_the_unfiltered_path() -> None:
+    """A test that rebuilds `env` from `os.environ["PATH"]` inherits the stub.
+
+    The statusline tests construct a minimal environment for the scripts they
+    run. They must copy the *current* PATH — which the fixture has already
+    prefixed — rather than reconstructing one from a hardcoded value.
+    """
+    needles = ('"PATH": "', "'PATH': '")
+    offenders = []
+    for path in sorted(REPO_ROOT.glob("tests/**/test_*.py")):
+        if path.resolve() == Path(__file__).resolve():
+            continue  # this module carries the needles as data, not as usage
+        text = path.read_text(encoding="utf-8")
+        if any(needle in text for needle in needles):
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    assert not offenders, (
+        f"these tests hardcode a PATH instead of inheriting the hermetic one: {offenders}"
+    )
+
+
+@pytest.mark.parametrize("binary", ["gh"])
+def test_path_prefix_is_a_real_directory(binary: str) -> None:
+    """Guard against the fixture silently no-opping if tmp handling changes."""
+    first = os.environ["PATH"].split(os.pathsep)[0]
+    assert Path(first).is_dir()
+    assert (Path(first) / binary).exists()


### PR DESCRIPTION
## Description

A full test run invoked the real `gh` binary **18 times** — 14 of them
`gh api user --jq .login`, which is a network call to api.github.com. Results therefore
depended on whether the developer happened to be authenticated, which is exactly the trap
#689 spent time diagnosing: a 0.54pp coverage difference between a maintainer's machine and
CI, caused by a branch that ran in one environment and not the other.

## Related Issue

Addresses #710

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

**`tests/conftest.py`** — an autouse `_hermetic_path` fixture places a stub `gh` ahead of
the real one for every test. It answers the three commands the suite actually invokes with
fixed output matching an unauthenticated CI runner, and exits **127 with a loud marker**
for anything else, so a future unmocked call fails visibly rather than silently varying by
machine.

**`tests/test_hermetic_suite.py`** — five tests keeping that fixture honest: that the stub
is what `gh` resolves to, that it answers what the code under test calls, that an unmocked
call fails loudly rather than returning success, and that no test module rebuilds `env`
from a hardcoded PATH instead of inheriting the prefixed one.

This generalises a pattern that already existed in the repo rather than inventing one:
`tests/test_statusline_gh_user.py` was the single statusline module making **zero** real
calls, because it already stubs `gh` on a temp PATH.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### The premise held in kind, but covered 1 of 18 calls

The issue named `gh auth status` in `test_bootstrap.py`. A recording shim on PATH found the
rest:

| file | calls | command |
| :--- | ---: | :--- |
| `tests/test_statusline_agy.py` | 12 | `gh api user --jq .login` |
| `tests/test_statusline_claude_usage.py` | 2 | `gh api user --jq .login` |
| `tests/template/test_bootstrap.py` | 2 | `auth status`, `--version` |
| `tests/template/test_setup_repo.py` | 2 | `--version` |

The dominant source — 14 network calls from the statusline tests — is not mentioned in the
issue, and is a worse problem than the local `gh auth status` that is.

**Verified 18 → 0** by re-running the same recording shim after the fix.

### Success criteria

| criterion | evidence |
| :--- | :--- |
| No unit test invokes the real `gh auth status` | zero real invocations of *anything*, not just `auth status` |
| Bootstrap tests assert which token branch they exercise | #689 already pinned both branches in `test_setup_repo.py:651+`; the stub makes the incidental bootstrap path deterministic (no token markers → else branch) |
| Coverage identical with and without local `gh` authentication | ran the issue's own shim reproduction: **`TOTAL 2874 1007 916 82 64.67%` both ways**, byte-identical |
| `doit check` passes | 1,446 tests |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — `docs/development/ci-cd-testing.md` already carries the "Keep coverage hermetic" write-up from #689; this implements it rather than changing what it says
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### Why a PATH stub rather than mocking `subprocess.run`

Both, depending on what is under test. Python code that shells out should mock
`subprocess.run` — and `test_setup_repo.py` already does for the token branches. But the
statusline tests execute **shell scripts**, which cannot be mocked at the Python level; a
stub on PATH is the only way to intercept those. The fixture is therefore the backstop for
what slips through, and the primary mechanism for scripts.

19 subprocess spawns remain, all against the stub. That is inherent for the shell-script
tests and is the correct outcome: deterministic, offline, and fast.

### On the broader sweep the issue suggests

> Consider a broader sweep for the same pattern: any unit test that reaches a
> `subprocess.run` against `gh`, `git`, or `uv` without mocking it.

Only `gh` is stubbed here. `git` is used extensively against `tmp_path` repositories, where
invoking the real binary is the point of the test rather than a leak, and stubbing it would
be a much larger change with a real risk of weakening those tests. `uv` was not observed
being invoked. Worth revisiting as its own issue if `git` isolation becomes a problem;
folding it in here would have mixed a targeted fix with a speculative one.

### A note on the guard

`test_an_unmocked_call_fails_loudly` exists because the obvious mistake would be a stub
that exits 0 for unknown commands. That would let a new unmocked call pass while quietly
doing nothing — the failure mode this backlog keeps finding, in a new place.
