### PR TITLE
refactor: reject unmocked gh subprocess calls outright

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest configuration and Hypothesis profiles."""
 
 import os
+import subprocess  # nosec B404 - guarding subprocess use, not invoking it
 import sys
 from collections.abc import Callable, Iterator
 from typing import Any
@@ -127,6 +128,37 @@ print(
 )
 sys.exit(127)
 """
+
+
+# Commands no test may reach through Python's subprocess. The PATH stub above
+# covers shell scripts under test, but it cannot help on Windows: CreateProcess
+# searches only `gh` and `gh.exe` and never consults PATHEXT for `.CMD`, so a
+# Python-level `subprocess.run(["gh", ...])` would still find the real binary
+# there. Failing the call outright makes hermeticity hold on every platform
+# rather than on POSIX only (#710).
+#
+# Only `gh` is covered. `git` is invoked against tmp_path repositories where
+# running the real binary is the point of the test, not a leak.
+_UNMOCKED_COMMANDS = frozenset({"gh"})
+
+
+@pytest.fixture(autouse=True)
+def _no_unmocked_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail loudly if a test shells out to `gh` without mocking it."""
+    real_run = subprocess.run
+
+    def guarded(cmd: object, *args: object, **kwargs: object) -> object:
+        if isinstance(cmd, (list, tuple)) and cmd and str(cmd[0]) in _UNMOCKED_COMMANDS:
+            raise AssertionError(
+                f"unmocked subprocess call to {list(cmd)!r}. Patch subprocess.run in "
+                "the module under test — a real call makes the result depend on the "
+                "developer's machine (#710)."
+            )
+        # Deliberately signature-agnostic: this forwards arbitrary calls, so it
+        # cannot match subprocess.run's overload set.
+        return real_run(cmd, *args, **kwargs)  # type: ignore[call-overload]
+
+    monkeypatch.setattr(subprocess, "run", guarded)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/template/test_setup_repo.py
+++ b/tests/template/test_setup_repo.py
@@ -75,6 +75,12 @@ class TestRepositorySetup:
 
         with (
             patch("tools.pyproject_template.setup_repo.command_exists", return_value=True),
+            # `gh --version` runs before the auth check, so it must be mocked or
+            # the test shells out to the real binary (#710).
+            patch(
+                "tools.pyproject_template.setup_repo.subprocess.run",
+                return_value=MagicMock(stdout="gh version 0.0.0\n"),
+            ),
             patch(
                 "tools.pyproject_template.setup_repo.GitHubCLI.is_authenticated",
                 return_value=False,
@@ -89,16 +95,32 @@ class TestRepositorySetup:
 
         setup = RepositorySetup()
 
+        versions = {
+            "gh": "gh version 2.0.0\n",
+            "git": "git version 2.40.0\n",
+            "uv": "uv 0.5.0\n",
+        }
+
+        def _fake_run(cmd: list[str], *_a: object, **_kw: object) -> MagicMock:
+            return MagicMock(stdout=versions[cmd[0]])
+
         with (
             patch("tools.pyproject_template.setup_repo.command_exists", return_value=True),
+            # gh, git and uv are each invoked for their version string. Without
+            # this the test shells out to all three real binaries (#710).
+            patch(
+                "tools.pyproject_template.setup_repo.subprocess.run", side_effect=_fake_run
+            ) as mock_run,
             patch(
                 "tools.pyproject_template.setup_repo.GitHubCLI.is_authenticated",
                 return_value=True,
             ),
             patch.object(setup, "_check_token_permissions"),
         ):
-            # Should not raise
             setup.check_requirements()
+
+        # Assert what it actually did, rather than only that it did not raise.
+        assert [call.args[0][0] for call in mock_run.call_args_list] == ["gh", "git", "uv"]
 
     def test_gather_inputs_with_git_config(self) -> None:
         """Test that gather_inputs uses git config values as defaults."""


### PR DESCRIPTION
## Description

Follow-up to PR #745, closing the one platform gap it left open.

That PR put a stub `gh` on PATH, which covers shell scripts everywhere and Python calls on
POSIX. It cannot help on Windows: `CreateProcess` searches only `gh` and `gh.exe` and never
consults `PATHEXT` for `.CMD`, so `subprocess.run(["gh", ...])` still found the real binary
there. Four calls remained, one of them the `gh auth status` that #710 names explicitly.

Guarding at the Python level is platform-independent, so hermeticity now holds everywhere
rather than on POSIX only.

## Related Issue

Addresses #710

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

**`tests/conftest.py`** — an autouse fixture raises on `subprocess.run(["gh", ...])`, with a
message naming the module that should be patched instead.

Scoped to `gh` deliberately. `git` is invoked against `tmp_path` repositories where running
the real binary is the point of the test rather than a leak; poisoning it would be a much
larger change with a real risk of weakening those tests. That is noted in the code so the
narrow scope reads as a decision.

**`tests/template/test_setup_repo.py`** — two tests reached `check_requirements()`, which
shells out three times (`gh`, `git`, `uv`), without patching `subprocess.run`:

| test | what leaked |
| :--- | :--- |
| `test_check_requirements_fails_without_gh_auth` | `gh --version` runs *before* the auth check it was exercising |
| `test_check_requirements_passes_with_all_requirements` | all three real binaries |

Both now mock it. The passing case additionally asserts the call order —
`["gh", "git", "uv"]` — instead of only that it did not raise, which is a stronger test than
before.

The other two `check_requirements` tests exit before reaching any subprocess and were left
alone.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**Verified by poisoning, not by inspection.** Running the whole suite with `subprocess.run`
made to raise for `gh`: **1,446 pass**, so no Python code shells out to `gh` anywhere.

**The guard was confirmed to fire** with a throwaway test that calls it:

```
AssertionError: unmocked subprocess call to ['gh', 'auth', 'status']. Patch
subprocess.run in the module under test — a real call makes the result depend on
the developer's machine (#710).
```

`doit check`: all passed.

### #710's criteria, now on every platform

| criterion | status |
| :--- | :--- |
| No unit test invokes the real `gh auth status` | ✅ — POSIX **and** Windows |
| Bootstrap tests assert which token branch they exercise | ✅ — #689 pinned both branches; the incidental path is now mocked rather than deterministic-by-luck |
| Coverage identical with and without local `gh` authentication | ✅ — `64.67%` both ways |
| `doit check` passes | ✅ |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — `docs/development/ci-cd-testing.md` already carries the "Keep coverage hermetic" write-up from #689
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### Why both mechanisms, rather than one

They cover different things and neither is redundant:

- The **PATH stub** (PR #745) is the only way to intercept the *shell scripts* under test —
  the statusline tests run `bash script`, which cannot be mocked at the Python level. It
  accounted for 14 of the original 18 calls.
- The **subprocess guard** (this PR) is the only thing that works for Python callers on
  Windows, and it turns hermeticity from a property that happens to hold into one that is
  enforced.

### One typing concession

mypy rejects the wrapper because a deliberately signature-agnostic forwarder cannot match
`subprocess.run`'s overload set. Rather than widening types, the single forwarding line
carries `# type: ignore[call-overload]` with the reason inline.
