### PR TITLE
feat: reject commits whose issue references disagree with the branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,16 @@
+# Hook types installed by `pre-commit install`.
+#
+# `commit-msg` was missing, so every hook declared with `stages: [commit-msg]`
+# was configured but never ran — including `conventional-pre-commit`, which has
+# been enforcing nothing since it was added. Declaring the types here means a
+# plain `pre-commit install` wires all of them, rather than depending on each
+# caller remembering the right `--hook-type` flags (#741).
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+  - post-merge
+  - post-checkout
+
 repos:
   # Generic file checks (not Python-specific, keep external)
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -124,6 +137,13 @@ repos:
         stages: [pre-commit]
 
       # Prevent direct commits to main branch
+      - id: check-commit-issue-ref
+        name: Check commit issue matches branch
+        entry: python3 tools/hooks/check_commit_issue_ref.py
+        language: system
+        # commit-msg stage: the message is what this compares against the branch.
+        stages: [commit-msg]
+
       - id: no-commit-to-main
         name: Prevent commits to main branch
         entry: |

--- a/tests/test_hook_commit_issue_ref.py
+++ b/tests/test_hook_commit_issue_ref.py
@@ -1,0 +1,199 @@
+"""Tests for the branch/commit issue-reference hook (#741).
+
+Derived from a real failure: during the template review backlog, work for #695
+was committed onto `feat/694-download-integrity-verification` — the branch left
+over from the previous issue. `no-commit-to-main` passed (not `main`), the
+branch-naming hook passed (well-formed), and every quality gate passed (the code
+was fine). Only its location was wrong.
+
+The replay of that exact case is `test_the_incident_that_motivated_this_hook`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.hooks.check_commit_issue_ref import (
+    OVERRIDE_ENV,
+    branch_issue,
+    check,
+    main,
+    message_issues,
+    should_skip,
+    strip_comments,
+)
+
+
+class TestBranchIssue:
+    @pytest.mark.parametrize(
+        ("branch", "expected"),
+        [
+            ("feat/694-download-integrity-verification", 694),
+            ("chore/695-workflow-hardening", 695),
+            ("fix/1-x", 1),
+            ("refactor/12345-long-number", 12345),
+            ("main", None),
+            ("develop", None),
+            ("release/1.2.3", None),
+            ("hotfix/urgent-thing", None),
+            ("", None),
+        ],
+    )
+    def test_extraction(self, branch: str, expected: int | None) -> None:
+        assert branch_issue(branch) == expected
+
+
+class TestMessageIssues:
+    def test_finds_every_reference(self) -> None:
+        assert message_issues("fix: thing (#12)\n\nAlso relates to #34 and #56.") == {12, 34, 56}
+
+    def test_ignores_git_comment_lines(self) -> None:
+        """The commit template and verbose diff must not count as references.
+
+        Without this, `# On branch feat/694-...` or a diff quoting `#695` would
+        be read as the author citing an issue.
+        """
+        message = "chore: something\n\n# Please enter the commit message for #999\n"
+        assert message_issues(message) == set()
+
+    def test_ignores_everything_below_the_scissors_line(self) -> None:
+        message = (
+            "fix: real subject (#12)\n"
+            "\n"
+            "# ------------------------ >8 ------------------------\n"
+            "diff --git a/x b/x\n"
+            "+# fixes #888\n"
+        )
+        assert message_issues(message) == {12}
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "colour #1234ab is fine",  # hex colour, not an issue
+            "channel abc#12 is a mention, not a reference",
+            "no references at all",
+        ],
+    )
+    def test_does_not_match_non_references(self, text: str) -> None:
+        assert message_issues(text) == set()
+
+
+class TestSkipping:
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "Merge branch 'main' into feat/1-x",
+            'Revert "feat: a thing (#12)"',
+            "fixup! feat: a thing (#12)",
+            "squash! feat: a thing (#12)",
+        ],
+    )
+    def test_generated_and_targeted_messages_are_skipped(self, subject: str) -> None:
+        """These reference another commit's issue, not the work being committed."""
+        assert should_skip(subject) is True
+        assert check("feat/999-unrelated", subject) is None
+
+    def test_empty_message_is_skipped(self) -> None:
+        assert should_skip("# just a comment\n") is True
+
+
+class TestCheck:
+    def test_matching_issue_passes(self) -> None:
+        assert check("chore/695-workflow-hardening", "chore: thing\n\nAddresses #695") is None
+
+    def test_branch_issue_among_several_passes(self) -> None:
+        """Citing related issues alongside the branch's own is normal."""
+        message = "fix: thing\n\nAddresses #731. Same lesson as #736."
+        assert check("fix/731-x", message) is None
+
+    def test_message_with_no_references_passes(self) -> None:
+        """Requiring a reference would be a different, more intrusive policy."""
+        assert check("feat/694-x", "chore: tidy up whitespace") is None
+
+    def test_branch_without_an_issue_passes(self) -> None:
+        for branch in ("main", "release/1.0.0", "hotfix/thing"):
+            assert check(branch, "fix: thing (#12)") is None
+
+    def test_mismatch_is_reported(self) -> None:
+        error = check("feat/694-download-integrity", "chore: pin actions\n\nAddresses #695")
+        assert error is not None
+        assert "#695" in error
+        assert "694" in error
+
+    def test_the_incident_that_motivated_this_hook(self) -> None:
+        """Replay of the real commit that prompted #741.
+
+        The #695 work, committed onto the #694 branch. Everything else passed;
+        this must not.
+        """
+        branch = "feat/694-download-integrity-verification"
+        message = (
+            "chore: pin actions to commit SHAs and scope benchmark write permissions\n"
+            "\n"
+            "benchmark.yml declared `contents: write` at workflow scope (#695).\n"
+            "fail-on-alert was rejected as a flake source, per #736.\n"
+        )
+
+        error = check(branch, message)
+
+        assert error is not None, "the hook must reject the commit that motivated it"
+        assert "#695" in error and "#736" in error
+        assert "694" in error
+
+    @pytest.mark.parametrize(
+        ("branch", "message"),
+        [
+            ("fix/731-configure-sheds-coverage-tests", "fix: keep tests (#731)"),
+            ("refactor/691-template-owned", "refactor: rule explicit (#691)"),
+            ("refactor/690-tests-adapt", "refactor: size tests (#690)"),
+            ("fix/736-hypothesis-ci-deadline", "fix: drop deadline (#736)"),
+            ("refactor/710-hermetic-gh", "refactor: hermetic suite (#710)"),
+        ],
+    )
+    def test_real_commits_from_that_session_still_pass(self, branch: str, message: str) -> None:
+        """The rule must not be so strict it would have blocked correct work.
+
+        A guard that fires on legitimate commits gets switched off, which leaves
+        the repository worse than no guard.
+        """
+        assert check(branch, message) is None
+
+
+class TestMain:
+    def test_returns_zero_on_a_matching_commit(self, tmp_path: Path) -> None:
+        msg = tmp_path / "COMMIT_EDITMSG"
+        msg.write_text("chore: thing\n", encoding="utf-8")
+        assert main([str(msg)]) == 0
+
+    def test_usage_error_without_arguments(self) -> None:
+        assert main([]) == 2
+
+    def test_override_env_short_circuits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The documented escape hatch, since AGENTS.md forbids --no-verify."""
+        msg = tmp_path / "COMMIT_EDITMSG"
+        msg.write_text("chore: thing (#999)\n", encoding="utf-8")
+        monkeypatch.setenv(OVERRIDE_ENV, "1")
+        monkeypatch.setattr("tools.hooks.check_commit_issue_ref.current_branch", lambda: "feat/1-x")
+        assert main([str(msg)]) == 0
+
+    def test_rejects_a_mismatch_end_to_end(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        msg = tmp_path / "COMMIT_EDITMSG"
+        msg.write_text("chore: pin actions (#695)\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "tools.hooks.check_commit_issue_ref.current_branch",
+            lambda: "feat/694-download-integrity-verification",
+        )
+
+        assert main([str(msg)]) == 1
+        assert "#695" in capsys.readouterr().err
+
+
+class TestStripComments:
+    def test_keeps_body_text(self) -> None:
+        assert strip_comments("subject\n\nbody\n# comment\n") == "subject\n\nbody"

--- a/tools/hooks/check_commit_issue_ref.py
+++ b/tools/hooks/check_commit_issue_ref.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fail a commit whose issue references disagree with its branch (#741).
+
+The workflow is Issue → Branch → Commit → PR → Merge, and the repo enforces the
+parts it can: `no-commit-to-main` blocks commits on `main`, and the branch-naming
+hook blocks malformed branch names. Nothing checked that a commit lands on the
+branch for *its own* issue.
+
+That gap was hit during the template review backlog: work for #695 was committed
+onto `feat/694-download-integrity-verification`, the branch left over from the
+previous issue. Every existing control passed — the branch was not `main`, its
+name was well-formed, and the code itself was fine. Only its location was wrong.
+
+The rule
+--------
+If the message references any issue, the branch's issue must be among them.
+
+A message that references no issue at all passes: plenty of legitimate commits
+do not cite one, and requiring it would be a different and more intrusive policy
+than this hook is for.
+
+Usage:
+    check_commit_issue_ref.py <path-to-commit-msg-file>
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess  # nosec B404 - reads the current branch name
+import sys
+from pathlib import Path
+
+# `<type>/<issue>-<slug>` — the convention the branch-naming hook already
+# enforces. Branches without an issue number (main, develop, release/*,
+# hotfix/*) yield None and are skipped.
+BRANCH_ISSUE = re.compile(r"^[a-z]+/(\d+)-")
+
+# `#123`, but not `#123` inside a word (`abc#123`) and not a colour like
+# `#1234ab` followed by more hex.
+MESSAGE_ISSUE = re.compile(r"(?<![\w#])#(\d+)\b")
+
+# Messages git generates or that target an existing commit, where the issue
+# reference belongs to something other than the work being committed now.
+SKIP_PREFIXES = ("merge ", "revert ", "fixup!", "squash!", "amend!")
+
+OVERRIDE_ENV = "ALLOW_ISSUE_REF_MISMATCH"
+
+
+def current_branch() -> str:
+    """Return the checked-out branch name, or "" when detached or unavailable."""
+    try:
+        result = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover - defensive
+        return ""
+    return result.stdout.strip()
+
+
+def branch_issue(branch: str) -> int | None:
+    """Return the issue number encoded in *branch*, or None if it has none."""
+    match = BRANCH_ISSUE.match(branch)
+    return int(match.group(1)) if match else None
+
+
+def strip_comments(message: str) -> str:
+    """Drop git's comment lines and everything below a scissors line.
+
+    Without this, the template git puts in `COMMIT_EDITMSG` — and any issue
+    numbers quoted in a verbose diff — would count as references the author
+    never wrote.
+    """
+    lines: list[str] = []
+    for line in message.splitlines():
+        if line.startswith("# ------------------------ >8 ------------------------"):
+            break
+        if line.startswith("#"):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def message_issues(message: str) -> set[int]:
+    """Return every issue number referenced in *message*."""
+    return {int(number) for number in MESSAGE_ISSUE.findall(strip_comments(message))}
+
+
+def should_skip(message: str) -> bool:
+    """Return whether *message* is one this check does not apply to."""
+    first_line = strip_comments(message).strip().splitlines()
+    if not first_line:
+        return True
+    return first_line[0].lower().startswith(SKIP_PREFIXES)
+
+
+def check(branch: str, message: str) -> str | None:
+    """Return an error message when *branch* and *message* disagree, else None."""
+    if should_skip(message):
+        return None
+
+    expected = branch_issue(branch)
+    if expected is None:
+        return None
+
+    referenced = message_issues(message)
+    if not referenced or expected in referenced:
+        return None
+
+    cited = ", ".join(f"#{number}" for number in sorted(referenced))
+    return (
+        f"Commit references {cited} but the branch is '{branch}' (issue #{expected}).\n"
+        "\n"
+        "This is what a commit landing on the previous issue's branch looks like:\n"
+        "the code is fine, the branch name is valid, and only its location is wrong.\n"
+        "\n"
+        "  - If the commit belongs to a different issue, branch for it first:\n"
+        "      git checkout main && git pull\n"
+        f"      git checkout -b <type>/{sorted(referenced)[0]}-<description>\n"
+        f"  - If it does belong to #{expected}, cite that issue in the message.\n"
+        "\n"
+        f"To commit anyway, set {OVERRIDE_ENV}=1 for this command.\n"
+        "Do not use --no-verify; AGENTS.md forbids it."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Takes the path to the commit message file."""
+    args = sys.argv[1:] if argv is None else argv
+    if not args:
+        print("usage: check_commit_issue_ref.py <path-to-commit-msg-file>", file=sys.stderr)
+        return 2
+
+    if os.environ.get(OVERRIDE_ENV) == "1":
+        return 0
+
+    try:
+        message = Path(args[0]).read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive
+        print(f"could not read commit message: {exc}", file=sys.stderr)
+        return 2
+
+    error = check(current_branch(), message)
+    if error is None:
+        return 0
+
+    print(f"\n❌ {error}\n", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Description

The workflow is `Issue → Branch → Commit → PR → Merge`, and the repo enforces the parts it
can. Nothing checked that a commit lands on the branch for **its own** issue.

That gap was hit during the template review backlog: work for #695 was committed onto
`feat/694-download-integrity-verification`, the branch left over from the previous issue.
Every existing control passed —

| control | result | why |
| :--- | :--- | :--- |
| `no-commit-to-main` | pass | the branch was not `main` |
| `Check branch naming convention` | pass | `feat/694-…` is well-formed |
| `ruff`, `mypy`, `bandit`, `actionlint` | pass | the code was fine |

— because only the commit's *location* was wrong. The message said `#695` five times; the
branch said `694`; nothing compared them.

## Related Issue

Addresses #741

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test improvement

## Changes Made

**`tools/hooks/check_commit_issue_ref.py`** — a `commit-msg` hook. The rule:

> If the message references any issue, the branch's issue must be among them.

A message citing no issue **passes**. Plenty of legitimate commits do not cite one, and
requiring it would be a different and more intrusive policy than this hook is for.

Deliberate exclusions, each because the reference belongs to something other than the work
being committed:

- `Merge`, `Revert`, `fixup!`, `squash!`, `amend!` messages skip.
- Git comment lines and everything below the scissors line are stripped, so the commit
  template or a verbose diff quoting `#695` is not read as a citation the author wrote.
- `#1234ab` (a hex colour) and `abc#12` (a mid-word mention) do not count as references.

`ALLOW_ISSUE_REF_MISMATCH=1` is the escape hatch, in the style of
`ALLOW_AI_READY_TO_MERGE`, because `AGENTS.md` forbids `--no-verify`.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

**36 tests, 100% coverage** on the new module.

**Verified with real commits, not only unit tests:**

| case | result |
| :--- | :--- |
| message cites `#695` while on the `741` branch | **blocked**, naming both the citation and the branch's issue |
| correct commit citing `#741` | passes |
| `ALLOW_ISSUE_REF_MISMATCH=1` on a mismatch | passes |

This PR's own commit was validated by the hook it adds.

Two tests deserve specific mention:

- **`test_the_incident_that_motivated_this_hook`** replays the actual bad commit — the real
  branch name and the real message — and requires rejection. The hook is derived from a
  documented failure rather than from intuition about what might go wrong, which is the
  discipline `.claude/rules/README.md` demands.
- **`test_real_commits_from_that_session_still_pass`** runs the rule against five genuine
  commits from the same session (#731, #691, #690, #736, #710). A guard that fires on
  legitimate work gets switched off, which leaves the repository worse than no guard.

`doit check`: all passed.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — the hook documents itself in its failure message and module docstring; no existing doc describes the hook set
- [ ] I have updated the CHANGELOG.md — commitizen generates it at release time; not hand-edited
- [x] My changes generate no new warnings

## Additional Notes

### A dormant control found while wiring this up

Declaring the hook at `stages: [commit-msg]` surfaced that **`.git/hooks/commit-msg` was
never installed**. `doit pre_commit_install` runs:

```
pre-commit install
pre-commit install --hook-type post-merge
pre-commit install --hook-type post-checkout
```

No `commit-msg`. So **`conventional-pre-commit` has been enforcing nothing since it was
added** — configured, visible in the file, running never. That is the same shape as #681,
#687, #689, #702, #704 and #738.

Fixed at the config level with `default_install_hook_types` rather than by adding another
flag to the doit task, so a plain `pre-commit install` wires every type the repo needs and
this cannot drift again by someone forgetting a flag.

### Behaviour change worth flagging before merge

Two things start happening that did not before:

1. **Conventional-commit enforcement (`--strict`) actually runs.** Non-conforming commit
   messages will now be rejected. Every commit in this session already conforms, but anyone
   with a different habit will notice.
2. **Contributors need to re-run `doit pre_commit_install`** once, to install the
   `commit-msg` hook type. Without it, neither this hook nor conventional-commit checking
   runs for them — they simply keep the status quo rather than breaking.

### Scope

Only the branch/message issue comparison. It does not require that a commit cite an issue,
does not check the issue exists on GitHub, and does not look at PR titles — each of those is
a separate policy decision rather than an extension of this one.
