### PR TITLE
refactor: index AGENTS.md's just-in-time reference from Pre-Action Checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 | **Generating new code** | `docs/development/ai/architectural-conventions.md` | Layering rules and anti-patterns to avoid before writing code. |
 | **Architectural Decision** | `docs/decisions/README.md` | Check for related ADRs to update. |
 | **Editing AI agent config** (commands, skills, hooks, instruction files) | `docs/development/AI_SETUP.md` | Per-agent config roots, discovery rules and hook wiring. |
+| **Creating an issue, PR or ADR** | `.github/CONTRIBUTING.md` (Development Workflow) | The commands, their flags, and the required fields. |
+| **Merging a dependabot PR** | `docs/development/dependabot-automerge.md` | Rebase procedure; never `update-branch` — it strips signatures. |
 
 ### 6. Decision Framework
 
@@ -234,46 +236,16 @@ gh pr list --state open
 
 ### Dependabot PRs
 
-Dependabot PRs that pass CI are now auto-merged by `.github/workflows/dependabot-automerge.yml`. The manual workflow below applies only to PRs the bot skips (major bumps, sensitive deps, or PRs labeled `automerge-blocked`). See [docs/development/dependabot-automerge.md](docs/development/dependabot-automerge.md) for details.
+Dependabot PRs that pass CI are auto-merged by `.github/workflows/dependabot-automerge.yml`. A PR
+the bot skips (major bumps, sensitive deps, `automerge-blocked`) is merged by hand.
 
-When merging dependabot PRs that are behind `main`, **never** use the GitHub API `update-branch` endpoint or local rebase to update the branch. This strips the verified commit signatures from dependabot commits, which are required by branch protection rules.
+**Never** use the GitHub `update-branch` API or a local rebase to update a dependabot branch — both
+strip the verified commit signatures that branch protection requires. Use `@dependabot rebase`
+instead, posted from a real user account.
 
-Instead, use dependabot's own rebase command:
-
-```bash
-gh pr comment <number> --body "@dependabot rebase"
-```
-
-Dependabot will rebase the branch and re-sign the commits, preserving verified signatures.
-
-#### Dependabot PR merge workflow
-
-When merging dependabot PRs that are behind `main`, use this procedure:
-
-1. **Request rebase** via dependabot's own action (preserves signed commits):
-   ```bash
-   gh pr comment <number> --body "@dependabot rebase"
-   ```
-
-2. **Wait for force-push** — poll until the PR's commit parent matches current `main` HEAD:
-   ```bash
-   # Get current main HEAD
-   main_sha=$(gh api repos/{owner}/{repo}/git/ref/heads/main --jq '.object.sha[0:7]')
-
-   # Poll PR commit parent until it matches
-   gh api repos/{owner}/{repo}/pulls/<number>/commits --jq '.[0].parents[0].sha[0:7]'
-   ```
-   This takes 1–3 minutes. **Do not** request a second rebase until the first one lands.
-
-3. **Wait for CI** to pass (`gh pr checks <number> --watch`).
-
-4. **Merge** with `doit pr_merge --pr=<number>`.
-
-#### What NOT to do
-
-- **Never** use `gh api .../update-branch` to rebase — this strips verified commit signatures.
-- **Never** rebase locally — same problem.
-- **Never** request a second `@dependabot rebase` before confirming the first force-push landed.
+The full procedure — requesting the rebase, confirming the force-push landed, merging — is in
+[Dependabot Auto-merge](docs/development/dependabot-automerge.md#stale-prs). Read it before
+merging a dependabot PR.
 
 ### AI Agent File Operations
 
@@ -353,65 +325,9 @@ Where `<agent-type>` is one of: `claude`, `copilot`, `codex`, `antigravity`, or 
 - **Issues:** Use `doit issue --type=<type>` to create issues (types: feature, bug, refactor, docs, chore). Labels are auto-applied. Manually close after PR merge with comment "Addressed in PR #XXX". Issues are not closed automatically when PRs are merged.
 - **ADRs:** When implementing architectural decisions (typically `feat` or `refactor`, rarely `fix`), update related ADRs in `docs/decisions/` to add the issue link. Create new ADRs for significant decisions using `doit adr`. Every ADR must link to the documentation in `docs/` that describes the implementation. Doc and chore issues do not need ADRs. Issues with the `needs-adr` label require an ADR before the PR can be merged.
 
-## Workflow Commands (for AI agents)
-
-### Issue Creation
-Each issue type requires specific sections. Use `--body-file` for complex bodies.
-
-```bash
-# Feature request (requires: Problem, Proposed Solution)
-doit issue --type=feature --title="feat: add caching" \
-  --body="## Problem\nDescribe the problem\n\n## Proposed Solution\nDescribe the solution"
-
-# Bug report (requires: Bug Description, Steps to Reproduce, Expected vs Actual Behavior)
-doit issue --type=bug --title="bug: crash on empty config" \
-  --body="## Bug Description\nWhat happened\n\n## Steps to Reproduce\n1. Step one\n\n## Expected vs Actual Behavior\nExpected X, got Y"
-
-# Refactor (requires: Current Code Issue, Proposed Improvement)
-doit issue --type=refactor --title="refactor: extract validation" \
-  --body="## Current Code Issue\nDuplicated logic\n\n## Proposed Improvement\nExtract to mixin"
-
-# Documentation (requires: Description)
-doit issue --type=docs --title="docs: add provider guide" \
-  --body="## Description\nAdd guide for creating custom providers"
-
-# Chore (requires: Description)
-doit issue --type=chore --title="chore: update dependencies" \
-  --body="## Description\nUpdate all dependencies to latest versions"
-```
-
-### PR Creation
-```bash
-doit pr --title="feat: add caching" --body="## Summary\nAdded caching support\n\nAddresses #123"
-doit pr --title="fix: handle null" --body-file=pr.md
-```
-
-`doit pr` auto-pushes the current branch to `origin` if it has no upstream. Pass `--no-push` to skip the auto-push (the task aborts instead).
-
-### PR Merge
-```bash
-doit pr_merge                        # Merge PR for current branch
-doit pr_merge --pr=123               # Merge specific PR
-doit pr_merge --pr=123 --auto-close  # Also close linked issues after merge
-```
-
-### ADR Creation
-```bash
-doit adr --title="Use Redis for caching" \
-  --body="## Status\nAccepted\n\n## Context\nNeed caching\n\n## Decision\nUse Redis"
-doit adr --title="Use Redis" --body-file=adr.md
-```
-
 ## PR Checklist (for AI agents)
 
-Before creating a PR, verify:
-
-- [ ] `doit check` passes (tests, lint, type-check, security)
-- [ ] Branch name follows convention: `<type>/<issue>-<description>`
-- [ ] Commits follow conventional format: `<type>: <subject>`
-- [ ] PR title follows conventional format: `<type>: <subject>`
-- [ ] PR description references the issue: "Addresses #XX" (at start of line)
-- [ ] If issue has `needs-adr` label: ADR created and included in PR
-- [ ] If implementing architectural decision: Related ADR updated with issue link
-- [ ] If ADR created/updated: Links to documentation in `docs/` included
-- [ ] Documentation updated if behavior changed
+Before creating a PR, read [CONTRIBUTING.md — Pull Request Process](.github/CONTRIBUTING.md#pull-request-process)
+and work through the checklist in [`.github/pull_request_template.md`](.github/pull_request_template.md).
+Between them they carry every check this section used to restate — `doit check`, branch and commit
+format, the `Addresses #XX` reference, the `needs-adr` label, and ADR and documentation updates.

--- a/docs/development/dependabot-automerge.md
+++ b/docs/development/dependabot-automerge.md
@@ -225,6 +225,22 @@ This also follows the signed-commit rule documented in the
 **never** call the GitHub `update-branch` API or rebase locally, because
 both strip dependabot's verified commit signatures.
 
+### Confirming the rebase landed
+
+The force-push takes one to three minutes. **Do not request a second
+`@dependabot rebase` until the first one lands** — the second request is
+processed against the pre-rebase branch and the two can race.
+
+Poll until the PR's first commit has current `main` as its parent:
+
+```bash
+main_sha=$(gh api repos/{owner}/{repo}/git/ref/heads/main --jq '.object.sha[0:7]')
+gh api repos/{owner}/{repo}/pulls/<number>/commits --jq '.[0].parents[0].sha[0:7]'
+```
+
+When those match, wait for CI (`gh pr checks <number> --watch`) and merge
+with `doit pr_merge --pr=<number>`.
+
 ## Related
 
 - `AGENTS.md` section [Dependabot PRs](../../AGENTS.md#dependabot-prs)

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -649,6 +649,10 @@ doit pr --draft
 - `--body`: PR body content (non-interactive)
 - `--body-file`: File containing PR body (non-interactive)
 - `--draft`: Create as draft PR
+- `--no-push`: Skip the automatic push of a branch that has no upstream. The
+  task pushes by default; with this flag it aborts instead.
+- `--no-update-check`: Skip the check that aborts when the branch is behind
+  `origin/main`. Use only when you know the branch is deliberately behind.
 
 ### `pr_merge`
 

--- a/tests/test_agents_md_allocation.py
+++ b/tests/test_agents_md_allocation.py
@@ -22,6 +22,7 @@ always-on rule, which is the opposite, so it cannot fail for the right reason.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -177,3 +178,72 @@ def test_the_row_parser_finds_the_shipped_rows() -> None:
     assert len(rows) == len(present_agents()), (
         f"parsed {len(rows)} config rows for {len(present_agents())} wired agents"
     )
+
+
+# --- Relocated procedure must stay reachable (#751) ------------------------
+#
+# `### 5. Pre-Action Checks` is the index for content AGENTS.md delegates rather
+# than carries. `test_instruction_pointers.py` (#739) checks that a pointer
+# *resolves*; nothing checked that relocated content *has* one. A section moved
+# out of the always-on file and not indexed is unreachable in practice — the
+# agent has no moment at which it learns to go and read it.
+
+PRE_ACTION_HEADING = "### 5. Pre-Action Checks (Dynamic Context)"
+
+# Docs that AGENTS.md delegates procedure to instead of restating it. Adding a
+# row here is the second half of moving something out of AGENTS.md.
+RELOCATION_TARGETS = (
+    "docs/development/AI_SETUP.md",  # per-agent config (#750)
+    ".github/CONTRIBUTING.md",  # issue / PR / ADR commands (#751)
+    "docs/development/dependabot-automerge.md",  # rebase procedure (#751)
+)
+
+_BACKTICKED_PATH = re.compile(r"`([\w./-]+\.(?:md|yml|yaml))`")
+
+
+def _pre_action_rows() -> list[str]:
+    """Return the body rows of the Pre-Action Checks table."""
+    lines = _agents_md().splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.startswith(PRE_ACTION_HEADING))
+    except StopIteration:  # pragma: no cover - guarded by its own test
+        return []
+
+    rows: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("#"):
+            break
+        stripped = line.strip()
+        if not stripped.startswith("|") or set(stripped) <= set("|: -"):
+            continue
+        if stripped.startswith("| Intent"):
+            continue
+        rows.append(stripped)
+    return rows
+
+
+def _indexed_paths() -> set[str]:
+    return {path for row in _pre_action_rows() for path in _BACKTICKED_PATH.findall(row)}
+
+
+@pytest.mark.parametrize("target", RELOCATION_TARGETS)
+def test_relocation_targets_are_indexed(target: str) -> None:
+    """Content moved out of AGENTS.md must be reachable from Pre-Action Checks."""
+    assert target in _indexed_paths(), (
+        f"{target} carries procedure moved out of AGENTS.md but has no row in "
+        f"{PRE_ACTION_HEADING}. Without one, nothing tells an agent when to read it — "
+        "the content is out of the always-on file and out of reach (#751)."
+    )
+
+
+def test_indexed_files_exist() -> None:
+    """A row naming a file that is not there is the #738 failure in a new place."""
+    missing = sorted(p for p in _indexed_paths() if not (REPO_ROOT / p).is_file())
+    assert not missing, f"{PRE_ACTION_HEADING} names files that do not exist: {missing}"
+
+
+def test_the_pre_action_parser_finds_the_shipped_rows() -> None:
+    """Guard against the two assertions above passing on an empty parse."""
+    rows = _pre_action_rows()
+    assert len(rows) >= len(RELOCATION_TARGETS), f"parsed only {len(rows)} Pre-Action rows"
+    assert _indexed_paths(), "parsed no file paths out of the Pre-Action Checks table"


### PR DESCRIPTION
## Description

Three blocks in `AGENTS.md` were procedure an agent needs only at a nameable moment, carried in the
file every agent reads at all times — the dependabot merge workflow (1,891 bytes), the
`doit issue`/`pr`/`pr_merge`/`adr` catalogue (1,962), and the PR checklist (671).

`AGENTS.md`: **23,313 → 20,188 bytes (−13.4%)**. With #750, **27,575 → 20,188 (−27%)**.

**The audit changed the risk calculus the issue was written on.** #751 expected a *relocation* and
judged itself risky on that basis: moving content behind a pointer costs a read at the moment of
need, and #738 showed that a pointer an agent skips is no better than a paragraph it never reads.
Two of the three blocks turned out to be duplicates of docs `### 5. Pre-Action Checks` **already**
points at — CONTRIBUTING appears there twice — so the trade barely applies. Deleting a duplicate
costs no resolution step; the agent was going to open CONTRIBUTING anyway.

## Related Issue

Addresses #751

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

### Moved first, deleted second

Three things were genuinely not carried anywhere else. Each went to its destination **before**
anything was removed from `AGENTS.md`:

| unique content | destination |
| :--- | :--- |
| force-push polling procedure + "don't request a second rebase" | `dependabot-automerge.md` § *Confirming the rebase landed* (new) |
| `doit pr --no-push` | `doit-tasks-reference.md` § `pr` |
| `doit pr --no-update-check` | same — it was **referenced from Critical Reminders and defined nowhere in the repo** |

### `### Dependabot PRs` — reduced, heading kept

`docs/development/dependabot-automerge.md` links this anchor twice, once as the documented home of
the signed-commit rule. Deleting the heading would have created exactly the dangling pointer #738
was about, so the heading stays and the body becomes the auto-merge fact, the never-`update-branch`
rule, and a pointer. The rest — the rebase command, the force-push behavior, the real-user caveat —
was already in that doc's § Stale PRs.

### `## Workflow Commands` — deleted

Every command and flag in it is in `CONTRIBUTING.md` § Development Workflow (all five
`doit issue --type=*` forms, `--body-file`/`--body`, label auto-application, `doit pr`,
`doit pr_merge`, ADRs) or the doit task reference, except the two flags moved above.

### `## PR Checklist` — trimmed to a pointer

Trimmed rather than kept whole or deleted outright, per the maintainer's call. The premise did not
survive the audit: **no item was unique.** All nine are stated elsewhere, most more fully — branch
naming carries allowed types and examples in CONTRIBUTING's Branch step, and the `Addresses #XX`
start-of-line precision (which `--auto-close` actually parses) is in `doit-tasks-reference.md:677`.
So the trim left a pointer to CONTRIBUTING § Pull Request Process and the PR template's own
checklist.

### Two new Pre-Action Checks rows

- **Creating an issue, PR or ADR** → `.github/CONTRIBUTING.md` (Development Workflow)
- **Merging a dependabot PR** → `docs/development/dependabot-automerge.md`

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

`tests/test_agents_md_allocation.py` gains the converse guard #751 asks for.
`test_instruction_pointers.py` (#739) checks that a pointer **resolves**; nothing checked that
relocated content **has** one — and content moved out of the always-on file without an index row is
unreachable in practice, because nothing tells an agent when to go read it.

- `test_relocation_targets_are_indexed` — each delegated doc has a Pre-Action Checks row
- `test_indexed_files_exist` — every file named in that table exists (#738's failure mode, in the
  table that now carries more weight)
- `test_the_pre_action_parser_finds_the_shipped_rows` — so the two above cannot pass on an empty
  parse

Proved by mutation: deleting the dependabot row fails
`test_relocation_targets_are_indexed[docs/development/dependabot-automerge.md]`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**On ADR-9018.** This is the second application of the allocation rule and needed no amendment to
it: all three blocks failed the always-on half of the test, and the anti-duplication constraint is
what turned an expected relocation into mostly deletion.

**Remaining from #693:** #752 (audit the reasoning examples against `enforcement-principles.md`),
which may legitimately close as a no-op — the measured overlap is one bullet against thirteen
concrete rationalizations. #693 itself is then down to a tracker for that one issue.
