### PR TITLE
docs: cross-link the reasoning examples and the enforcement principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,8 @@ You are a senior coding partner. Your goal is efficient, tested, and compliant c
 
 **Key principle:** If you find yourself thinking "but this case is different because..." or "this is simple enough to...", you are making a judgment call. STOP and follow the documented process or ASK the user.
 
+Some of these are blocked in code as well as forbidden here — committing to `main` and the `--admin` bypasses are stopped by hooks and branch rules, listed in [AI Enforcement Principles — Currently Enforced Processes](docs/development/ai/enforcement-principles.md#currently-enforced-processes). The rest are enforced only by you reading this. A hook matches a command pattern, not the reasoning that reached for it.
+
 ## Sources of Truth
 
 **DO NOT HALLUCINATE RULES.** Read these files to know what to do:

--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -29,6 +29,11 @@ Even when `AGENTS.md` explicitly states "use `doit pr` instead of `gh pr create`
 
 **Solution**: Shift from "tell the agent what to do" to "prevent the agent from doing the wrong thing."
 
+That shift is never complete. Rationalizations like "the user probably wants me to proceed" or "it's just documentation, so tests aren't needed" have no command to intercept, so they stay instruction-side. `AGENTS.md` carries the concrete list —
+[Examples: Prohibited vs. Correct Reasoning](../../../AGENTS.md#examples-prohibited-vs-correct-reasoning)
+— which is this document's complement, not a duplicate of it: this page covers what can be
+enforced, that section covers what cannot.
+
 ## Enforcement Options
 
 Listed in order of preference:
@@ -291,4 +296,6 @@ The following AGENTS.md rules are currently instruction-only and could benefit f
 
 - [AI Command Blocking](command-blocking.md) - Hook implementation details
 - [AGENTS.md](../../../AGENTS.md) - Full AI agent instructions
+- [AGENTS.md — Examples: Prohibited vs. Correct Reasoning](../../../AGENTS.md#examples-prohibited-vs-correct-reasoning)
+  - The instruction-side complement: rationalizations that no hook can intercept
 - [AI Setup Guide](../AI_SETUP.md) - Setting up AI coding assistants


### PR DESCRIPTION
## Description

#693 proposed deduping `AGENTS.md`'s `### Examples: Prohibited vs. Correct Reasoning` against
`docs/development/ai/enforcement-principles.md`. **The audit does not support that framing.**
Measured, the textual overlap is one bullet —

> **Ambiguous interpretation**: Agents may rationalize exceptions ("this is just a quick fix")

— against nine concrete rationalizations. The two documents argue different things: that page
argues instructions are unreliable so processes belong in code; this section is the instruction-side
fallback for what code cannot catch. There is nothing to dedupe.

What was actually wrong is that neither document knew the other existed. This adds two pointers.
Nothing was moved, trimmed, or duplicated.

## Related Issue

Addresses #752

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

### The classification #752 asks for

Every prohibited example, against the enforcement inventory in
`enforcement-principles.md` § Currently Enforced Processes:

| example | status | mechanism |
| :--- | :--- | :--- |
| "just a typo fix, so I can commit directly to main" | **blocked in code** | `no-commit-to-main` pre-commit hook + branch ruleset |
| "the merge is blocked, so I'll use `--admin`" | **blocked in code** | `block-dangerous-commands.py`, all four agents |
| "CI hasn't finished but I'll bypass with `--admin`" | **blocked in code** | same hook |
| "small/trivial, so skip the full workflow" | partially constrained | branch naming, `gh issue create` → `doit issue`, commit-issue-ref (#741) |
| "seems obvious, so skip issue creation" | partially constrained | same three |
| "commit now, create the issue afterward" | partially constrained | same three |
| "GitHub auto-closes with `Addresses #XX`, no need to verify" | **instruction-only** | — factual misconception, not a judgment call |
| "the user probably wants me to proceed without asking" | **instruction-only** | — unenforceable by nature |
| "just documentation, so tests aren't needed" | **instruction-only** | — coverage gate is only a proxy |

The seven "correct" counterparts map onto these and carry no independent rules.

### Why the three enforced examples were kept rather than trimmed

Trimming them was on the table (#752 option 3) and is the wrong call:

- **A hook matches a command pattern, not the reasoning that reached for it.** It stops
  `gh pr merge --admin`; it does not stop the agent that decided the merge should be forced, which
  will look for an unblocked path.
- **`enforcement-principles.md`'s own thesis argues against it.** Its position is that instructions
  get ignored, therefore enforce in code. That is an argument for belt *and* braces, not for
  removing the belt once the braces exist.
- The enforced examples are the most concrete instances of the pattern the list teaches.

### The two pointers

**`AGENTS.md`**, after the Key principle — tells an agent which of these are already impossible
rather than merely forbidden:

> Some of these are blocked in code as well as forbidden here — committing to `main` and the
> `--admin` bypasses are stopped by hooks and branch rules, listed in [AI Enforcement Principles —
> Currently Enforced Processes](…). The rest are enforced only by you reading this. A hook matches
> a command pattern, not the reasoning that reached for it.

**`enforcement-principles.md`**, after its "prevent the agent from doing the wrong thing" thesis —
names the complement, and one Related Documentation entry pointing at the section rather than the
whole file.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

No new test: the issue's criteria do not ask for one, and both new anchors are already covered by
`test_instruction_pointers.py::test_markdown_anchors_resolve` and `test_markdown_links.py`, which
pass — so the anchors demonstrably resolve.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests — N/A, documentation cross-links; anchors covered by existing pointer tests
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**`AGENTS.md` grows by 421 bytes** (20,188 → 20,609) — the first increase in the #693 sequence,
which had taken it from 27,575 to 20,188. Justified under ADR-9018: it is a pointer plus a
distinction that is true for every agent and must be true at all times, namely that some rules are
already impossible and others rest entirely on being read. Flagging it because the direction of
travel changed, not because it is in doubt.

**Committed with `git commit -F <file>`.** The commit message names blocked patterns, and the
dangerous-command hook scans heredoc bodies as if they were arguments, so `git commit -F - <<EOF`
was refused twice — once on `--admin`, once on `gh issue create`, both appearing only as prose.
Filed as #759 with a repro and a fix direction; the message file carries the same text and the hook
is unmodified.

**This closes out #693's three-part split** (#750, #751, #752). `AGENTS.md` went from 27,575 to
20,609 bytes — −25% — with four tests holding the shape: no per-agent config detail, matrix counts
with one owner, relocated procedure reachable from Pre-Action Checks, and the pointer table's rows
bounded.
