### PR TITLE
fix: stop the temp-file cleanup tests reading a shared directory

### DIFF
--- a/tests/template/test_doit_install_tools.py
+++ b/tests/template/test_doit_install_tools.py
@@ -980,12 +980,34 @@ class TestDownloadAndExtractArchive:
                 "https://github.com/o/r/releases/download/v1/foo.7z", ["foo"], tmp_path
             )
 
-    def test_temp_file_cleanup_on_success(self, tmp_path: Path) -> None:
+    @pytest.fixture
+    def private_tempdir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Point `tempfile` at a directory only the calling test writes to.
+
+        The cleanup tests below assert on what is left behind in the temp
+        directory. Reading the process-global one means reading a directory
+        every other xdist worker is also writing to: ten tests in this file call
+        `download_and_extract_archive`, and one of them mid-download drops a
+        `tmpXXXX.tar.gz` inside the measurement window, which the diff then
+        attributes to the test doing the measuring (#756).
+
+        `download_and_extract_archive` creates its scratch archive with
+        `tempfile.NamedTemporaryFile`, which resolves `tempfile.tempdir` at call
+        time, so redirecting it here covers the implementation and the
+        assertion together. The scope is this process, and xdist workers are
+        separate processes, so nothing leaks between them.
+        """
+        private = tmp_path / "systemp"
+        private.mkdir()
+        monkeypatch.setattr(tempfile, "tempdir", str(private))
+        return private
+
+    def test_temp_file_cleanup_on_success(self, tmp_path: Path, private_tempdir: Path) -> None:
         fixture = tmp_path / "fixture.tar.gz"
         _make_targz(fixture, {"mytool": b"binary"})
         dest = tmp_path / "out"
 
-        before = set(Path(tempfile.gettempdir()).iterdir())
+        before = set(private_tempdir.iterdir())
         with patch(
             "tools.doit.install_tools.urllib.request.urlretrieve",
             side_effect=lambda url, d: shutil.copy(fixture, d),
@@ -993,17 +1015,17 @@ class TestDownloadAndExtractArchive:
             download_and_extract_archive(
                 "https://github.com/o/r/releases/download/v1/x.tar.gz", ["mytool"], dest
             )
-        after = set(Path(tempfile.gettempdir()).iterdir())
+        after = set(private_tempdir.iterdir())
 
         new_files = after - before
-        assert not any(f.suffix in (".gz", ".zip") for f in new_files)
+        assert not new_files, f"download_and_extract_archive left {sorted(new_files)} behind"
 
-    def test_temp_file_cleanup_on_failure(self, tmp_path: Path) -> None:
+    def test_temp_file_cleanup_on_failure(self, tmp_path: Path, private_tempdir: Path) -> None:
         fixture = tmp_path / "fixture.tar.gz"
         _make_targz(fixture, {"other": b"binary"})
         dest = tmp_path / "out"
 
-        before = set(Path(tempfile.gettempdir()).iterdir())
+        before = set(private_tempdir.iterdir())
         with (
             patch(
                 "tools.doit.install_tools.urllib.request.urlretrieve",
@@ -1014,10 +1036,10 @@ class TestDownloadAndExtractArchive:
             download_and_extract_archive(
                 "https://github.com/o/r/releases/download/v1/x.tar.gz", ["missing"], dest
             )
-        after = set(Path(tempfile.gettempdir()).iterdir())
+        after = set(private_tempdir.iterdir())
 
         new_files = after - before
-        assert not any(f.suffix in (".gz", ".zip") for f in new_files)
+        assert not new_files, f"download_and_extract_archive left {sorted(new_files)} behind"
 
     def test_missing_binary_raises_runtime_error(self, tmp_path: Path) -> None:
         fixture = tmp_path / "fixture.tar.gz"


### PR DESCRIPTION
## Description

`TestDownloadAndExtractArchive::test_temp_file_cleanup_on_success` and `..._on_failure` snapshotted
the **process-global** temp directory before and after their call and asserted that no archive
appeared:

```python
before = set(Path(tempfile.gettempdir()).iterdir())
...
after = set(Path(tempfile.gettempdir()).iterdir())
assert not any(f.suffix in (".gz", ".zip") for f in after - before)
```

`download_and_extract_archive` creates its scratch file there
(`install_tools.py:253`, `NamedTemporaryFile(delete=False, suffix=suffix)`), and ten tests in that
file call it. Under `pytest -n auto` another worker mid-download drops a `tmpXXXX.tar.gz` inside the
measurement window, and the diff attributes it to whichever test is doing the measuring.

The assertion was right about what it wanted to check — that the implementation deletes its own
temp file. It was reading a resource it does not own.

## Related Issue

Addresses #756

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

**A `private_tempdir` fixture** points `tempfile.tempdir` at a per-test directory.
`NamedTemporaryFile` resolves `tempfile.tempdir` at call time, so a single redirect covers the
implementation's scratch file and the test's snapshot together. The scope is the process, and xdist
workers are separate processes, so nothing leaks between them.

**The assertion is now exact rather than approximate:**

```diff
-  assert not any(f.suffix in (".gz", ".zip") for f in new_files)
+  assert not new_files, f"download_and_extract_archive left {sorted(new_files)} behind"
```

The suffix filter existed because a shared directory could not be read cleanly — it was
approximating "nothing left behind" while tolerating other workers' non-archive files. A private
directory can assert the real thing. **This is a deliberate strengthening, not a side effect**; say
the word if you would rather keep the original predicate, which the fix also supports.

No production code was touched. The diff is one test file.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` passes. Verified in **both** directions, because a fix that stops the flake without
still catching a real leak would be worse than the flake:

| check | result |
| :--- | :--- |
| race gone | 10 consecutive runs of `pytest ... -n 4`, all clean — the same command failed ~50% of runs before |
| guarantee intact | replacing `finally: temp_path.unlink()` in `install_tools.py` with `pass` fails **both** tests |

The issue's open question is also answered: **no other test** reads a process-global directory.
`gettempdir`, `tempfile.tempdir` and `TMPDIR` appear nowhere else under `tests/`.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A, no behavior change
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**Why this was worth doing before the feature backlog.** It failed `test (macos-latest, 3.12)` on
PR #755 while the other five matrix jobs — including macOS on 3.14 — passed, which is the signature
of a race rather than a platform difference. Until fixed, every PR paid a re-run tax and every red
CI run had to be diagnosed before it could be dismissed. That is the expensive part of a flaky
test: not the failure, but that it trains you to ignore failures.

**Scope.** `tools/doit/install_tools.py` and `tests/template/test_doit_install_tools.py` are both
downstream-owned (ADR-9017), so spawned projects inherited the flake and now inherit the fix.
