### PR TITLE
fix: scan heredoc bodies that a shell will execute

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -99,6 +99,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9016: Unify ADR directories under docs/decisions](decisions/9016-unify-adr-directories.md)
 - [ADR-9017: Template tooling and its tests are template-owned](decisions/9017-template-tooling-and-its-tests-are-template-owned.md)
 - [ADR-9018: AGENTS.md carries only shared, always-on instructions](decisions/9018-agentsmd-carries-only-shared-always-on-instructions.md)
+- [ADR-9019: The dangerous-command hook is a guardrail, not a security boundary](decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
 - [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Copilot, Codex, and Antigravity for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template

--- a/docs/decisions/9005-ai-agent-command-restrictions.md
+++ b/docs/decisions/9005-ai-agent-command-restrictions.md
@@ -25,6 +25,7 @@ Documentation alone is insufficient - AI agents may violate rules after context 
 
 ## Related Documentation
 
+- [ADR-9019](9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md) — what the hook should block, and how far to go to do it
 - [AI Command Blocking](../development/ai/command-blocking.md)
 - [AI Enforcement Principles](../development/ai/enforcement-principles.md)
 - [AI Setup Guide](../development/AI_SETUP.md)

--- a/docs/decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md
+++ b/docs/decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md
@@ -1,0 +1,113 @@
+# ADR-9019: The dangerous-command hook is a guardrail, not a security boundary
+
+## Status
+Accepted
+
+## Decision
+The dangerous-command hook is a **guardrail against a non-adversarial agent, not a boundary
+against a determined one.** ADR-9005 decided to block commands at the tool level; this decides
+*what* it should block and *how far* it should go to do it.
+
+**Three categories, deliberately different in value:**
+
+| category | examples | what it is doing | tolerance |
+| :--- | :--- | :--- | :--- |
+| **1. Workflow redirect** | `gh pr create` → `doit pr`, `gh issue create`, `uv add`, `doit release`, `ready-to-merge` | process compliance; the *message* is the product | false positives cheap; false negatives cost a template |
+| **2. Damage guardrail** | `rm -rf ~`, `git reset --hard`, force-push or delete a protected branch, `--no-verify`, `--admin` | irreversible harm from a careless agent | highest value per line; both error kinds matter |
+| **3. Accidental exposure** | `env`, `printenv SECRET`, `~/.netrc`, `~/.aws/credentials` | tripwire against a secret reaching a transcript | trivially avoided by design; precision here buys little |
+
+All three assume the agent is **not trying to evade the hook**. An agent that types `rm -rf ~` meant
+it as a shortcut. This assumption is what makes pattern matching a reasonable instrument at all, and
+it is the reason none of the categories justify unbounded effort.
+
+**Two layers of scanning, and each stays in its lane:**
+
+- **Precise layer** — the command line proper, plus payloads that are *provably shell*:
+  `bash/sh/zsh/dash -c <payload>`, `eval`, and a heredoc fed to a shell's stdin (`bash <<EOF`).
+  These are re-scanned by `check_command` with every check, including the position-sensitive ones
+  (`check_env_dump`, `check_credential_file_read`).
+- **Crude layer** — a flat `shlex` token scan over the whole command string, matching a pattern in
+  any position. A catch-all tripwire.
+
+**Rules that follow, and are the operative part of this decision:**
+
+1. **Never trade crude-layer coverage for precision.** The over-matching is the feature: it needs no
+   allowlist, so it covers interpreters nobody has thought about.
+2. **Add a payload to the precise layer only when the payload is shell.** Not Python, Perl, Ruby or
+   JavaScript: shell patterns inside those are string literals, and the real risk in them
+   (`os.system("cat ~/.netrc")`) is not shell-shaped, so scanning buys false positives and no
+   coverage.
+3. **Crude-layer false positives are fixed by convention, not by making the crude layer smarter.**
+   A heredoc that names a blocked pattern in prose is blocked; the answer is to pass the text by
+   file (#759), not to teach the scanner to recognise prose.
+4. **Do not spend complexity on category 3.** It is already documented as not-a-boundary. Precision
+   there is false assurance.
+
+## Rationale
+The principle already existed in `command-blocking.md`, stated for one case:
+
+> `$VAR` interpolation is deliberately **not** blocked: legitimate uses are common, and blocking it
+> would give false assurance while being trivially avoided.
+
+That is the correct test. It had never been generalised, so each new question — *should the hook see
+inside a heredoc?* — was re-argued from scratch and answered inconsistently. The immediate cause of
+this ADR is two issues that pointed in opposite directions (#759, over-blocking prose; #762,
+under-blocking executed bodies) and turned out to be the same design question.
+
+**Both plausible "fix the false positive" routes were measured, and both cost real coverage:**
+
+| candidate | what it un-blocks |
+| :--- | :--- |
+| strip heredoc bodies whose receiver consumes them as data | `perl <<EOF` / `rm -rf ~`, `ruby <<EOF` / `--admin`, `node <<EOF` / `git push --force origin main`, `ssh host <<EOF` / `rm -rf ~` |
+| make wrapper detection position-aware | `xargs bash -c`, `find -exec bash -c`, `timeout 5 bash -c` |
+
+Every one of those is blocked today **only** because the crude layer over-matches. Trading four
+category-2 blocks for one cosmetic false positive is the wrong direction, and a *more correct* shell
+parser makes it worse, not better: a parser that understood heredoc ownership would stop flagging
+`perl <<EOF` / `rm -rf ~` unless it also modelled Perl, and that regress is unbounded.
+
+Rule 2 was learned the same way. An earlier draft of #762 included `python3 - <<EOF` as an
+interpreter whose body should be scanned. It is not:
+
+```console
+$ python3 - <<'PY'
+printenv PATH
+PY
+SyntaxError: invalid syntax
+```
+
+The body is Python. `printenv PYPI_TOKEN` there does not dump anything, it crashes — so the
+pre-existing test case marking it `ALLOW` and labelling it "heredoc *mentioning* a dump" was right,
+and the draft that flipped it to `BLOCK` was wrong.
+
+## Consequences
+- **Known false positives are accepted and recorded** rather than engineered away: prose naming a
+  blocked pattern inside `cat > file <<EOF`, `gh ... --body-file - <<EOF`, or a `bash -c` payload
+  quoted inside a data heredoc. Conventions the repo already has — the Write tool over
+  `cat <<EOF`, `--body-file=<path>` over `-` — avoid all of them.
+- **#762 is the last precision addition of its kind.** It closes a real inconsistency and makes the
+  enforced-processes table true, but everything it newly blocks is category 3; every category-2
+  pattern in a shell heredoc was already caught by the crude layer. Under rule 4 it would not be
+  proposed today, and this ADR exists partly so the next one is not.
+- **Future "should the hook catch X" is answered by category and rule**, not re-argued. If X is
+  category 3 and needs new parsing, the answer is no.
+- **The hook stays small enough to audit.** It is a single file every agent depends on; the cost of
+  a subtle mistake in it is higher than the cost of the false positives it produces.
+- This constrains contributors who will reasonably want to close a demonstrated gap. The constraint
+  is deliberate: a demonstrated gap in category 3 is not sufficient reason to add parsing.
+
+## Related Issues
+- Issue #762: interpreter heredoc bodies escaped the position-sensitive checks — the precise-layer
+  addition this ADR bounds
+- Issue #759: the hook scans heredoc bodies, so commit messages naming a blocked pattern are
+  refused — the crude-layer false positive this ADR declines to fix in the matcher
+- Issue #678: git global options, refspecs and shell wrappers — an earlier round of the same
+  precise-versus-crude question
+- ADR-9005: the decision to block at the tool level, which this scopes
+
+## Related Documentation
+- [AI Command Blocking](../development/ai/command-blocking.md) — the pattern tables, the deny
+  contracts, and the category-3 threat model this generalises
+- [AI Enforcement Principles](../development/ai/enforcement-principles.md) — why enforcement lives
+  in code rather than instructions, and the Block and Redirect pattern category 1 depends on
+- [ADR-9005](9005-ai-agent-command-restrictions.md) — the mechanism decision this builds on

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -98,6 +98,7 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [9016](9016-unify-adr-directories.md) | Unify ADR directories under docs/decisions | Accepted |
 | [9017](9017-template-tooling-and-its-tests-are-template-owned.md) | Template tooling and its tests are template-owned | Accepted |
 | [9018](9018-agentsmd-carries-only-shared-always-on-instructions.md) | AGENTS.md carries only shared, always-on instructions | Accepted |
+| [9019](9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md) | The dangerous-command hook is a guardrail, not a security boundary | Accepted |
 
 ### Project-level ADRs (0001+)
 

--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -360,7 +360,10 @@ everyone:
 
 **What this is and is not.** It reduces *accidental* exposure — a secret dumped into a transcript
 that is then pasted into an issue, or read by a later summarisation step. It is not a boundary
-against a determined agent, which has many other routes to the same value. `$VAR` interpolation is
+against a determined agent, which has many other routes to the same value. That is true of the
+hook as a whole, not only of this section — see
+[ADR-9019](../../decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md) for the categories, the non-adversarial
+assumption, and the rules governing what may be added. `$VAR` interpolation is
 deliberately **not** blocked: legitimate uses are common, and blocking it would give false
 assurance while being trivially avoided.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
       - ADR-9016 Unify ADRs: decisions/9016-unify-adr-directories.md
       - ADR-9017 Template ownership: decisions/9017-template-tooling-and-its-tests-are-template-owned.md
       - ADR-9018 Instruction allocation: decisions/9018-agentsmd-carries-only-shared-always-on-instructions.md
+      - ADR-9019 Hook scope: decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md
   - Reference:
       - API Reference: reference/api.md
   - Examples:

--- a/tests/test_hook_dangerous_command_matrix.py
+++ b/tests/test_hook_dangerous_command_matrix.py
@@ -1123,8 +1123,39 @@ SECRET_EXPOSURE_CASES: list[tuple[str, str, str]] = [
     ("cat credentials", "ALLOW", "a bare 'credentials' file outside .aws"),
     ("grep -rn pypirc docs/", "ALLOW", "searching for the name is not reading the file"),
     ("cat README.md", "ALLOW", "an ordinary file read"),
-    ("python3 - <<EOF\nprintenv PYPI_TOKEN\nEOF", "ALLOW", "heredoc mentioning a dump"),
-    ("cat >> notes.md <<EOF\ncat ~/.netrc\nEOF", "ALLOW", "heredoc mentioning a credential path"),
+    # Who receives the body, and in what language. `bash <<EOF` runs it as shell,
+    # so shell patterns in it are real commands. `cat >> notes.md` writes it to a
+    # file, and `python3 -` runs it as Python -- where `printenv PYPI_TOKEN` is a
+    # SyntaxError, not a dump. Only the shell case is scanned (#762).
+    (
+        "cat >> notes.md <<EOF\ncat ~/.netrc\nEOF",
+        "ALLOW",
+        "a data heredoc: the body is written, not run",
+    ),
+    (
+        "python3 - <<EOF\nprintenv PYPI_TOKEN\nEOF",
+        "ALLOW",
+        "python3 - runs Python: that body is a SyntaxError, not a dump",
+    ),
+    ("bash <<EOF\ncat ~/.netrc\nEOF", "BLOCK", "bash executes the credential read in its body"),
+    ("sh <<EOF\ncat ~/.pypirc\nEOF", "BLOCK", "sh executes the credential read in its body"),
+    ("zsh <<EOF\nprintenv MY_API_KEY\nEOF", "BLOCK", "zsh executes the dump in its body"),
+    ("dash <<EOF\nenv\nEOF", "BLOCK", "dash executes the bare env dump in its body"),
+    (
+        "python - <<EOF\ncat ~/.aws/credentials\nEOF",
+        "ALLOW",
+        "same: a shell line in a Python heredoc does not run",
+    ),
+    (
+        "python3 script.py <<EOF\nprintenv PYPI_TOKEN\nEOF",
+        "ALLOW",
+        "a script reading stdin data, not code",
+    ),
+    (
+        'bash -c "cat ~/.netrc"',
+        "BLOCK",
+        "the -c form was already covered; the heredoc must match it",
+    ),
     # Deliberately NOT blocked -- see docs/development/ai/command-blocking.md.
     # Blocking $VAR interpolation gives false assurance while being trivially
     # avoided, and legitimate uses are common.
@@ -1145,5 +1176,74 @@ def test_secret_exposure(
     description: str,
 ) -> None:
     """Environment dumps and credential reads are blocked for every agent."""
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+    assert _outcome_exit_code(hook, monkeypatch, payload) == expected, description
+
+
+# --- Heredoc bodies: data or code (#762) -----------------------------------
+#
+# `check_command` recurses into `bash -c <payload>`, but a heredoc on stdin is
+# not `-c`, so its body was never re-scanned. Checks matching a token in any
+# position caught it anyway; checks needing a command position did not, so
+# `bash <<EOF cat ~/.netrc EOF` ran while `bash -c "cat ~/.netrc"` was blocked.
+#
+# The distinction the parser has to get right is who receives the body: an
+# interpreter reading stdin executes it, everything else consumes it as text.
+# These cases pin that boundary and the parsing around it.
+
+HEREDOC_BODY_CASES: list[tuple[str, str, str]] = [
+    # Interpreters: the body runs, so it is scanned.
+    ("bash <<-EOF\n\tcat ~/.netrc\n\tEOF", "BLOCK", "<<- with a tab-indented terminator"),
+    ("bash <<'END'\ncat ~/.pypirc\nEND", "BLOCK", "quoted delimiter"),
+    ("/bin/bash <<EOF\ncat ~/.netrc\nEOF", "BLOCK", "interpreter named by absolute path"),
+    ("cd /tmp && bash <<EOF\ncat ~/.netrc\nEOF", "BLOCK", "interpreter after a shell separator"),
+    (
+        "bash <<EOF\necho one\necho two\ncat ~/.aws/credentials\nEOF",
+        "BLOCK",
+        "danger on the third line of the body",
+    ),
+    (
+        "cat > a.md <<A\nhello\nA\nbash <<B\ncat ~/.netrc\nB",
+        "BLOCK",
+        "a data heredoc first, then an interpreter one",
+    ),
+    # Data consumers: the body is text, so it is not scanned.
+    (
+        "cat >> notes.md <<EOF\nprintenv PYPI_TOKEN\nEOF",
+        "ALLOW",
+        "written to a file, not run",
+    ),
+    # Known limitation, and #759's territory rather than this one's: a data
+    # heredoc naming a pattern that any check matches positionally -- `--admin`,
+    # `gh issue create`, or a `bash -c` payload the outer tokenization reaches --
+    # is still blocked. That predates this change and is untouched by it; the
+    # case is pinned here so the gap is recorded rather than rediscovered.
+    (
+        "cat >> notes.md <<EOF\nbash -c 'cat ~/.netrc'\nEOF",
+        "BLOCK",
+        "known limitation: outer tokenization reaches a -c payload in a data heredoc",
+    ),
+    ("python3 script.py <<EOF\nprintenv PYPI_TOKEN\nEOF", "ALLOW", "stdin for a named script"),
+    ("bash script.sh <<EOF\ncat ~/.netrc\nEOF", "ALLOW", "stdin for a named shell script"),
+    # Parsing edges.
+    ("bash <<EOF\necho hello", "ALLOW", "unterminated heredoc, benign body"),
+    ("cat > n.md <<EOF\nEOF is the delimiter\nEOF", "ALLOW", "delimiter word inside the body"),
+    ('python3 -c "print(1)"', "ALLOW", "the -c path is untouched by heredoc handling"),
+]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected", "description"),
+    HEREDOC_BODY_CASES,
+    ids=_ids(HEREDOC_BODY_CASES, 2),
+)
+def test_heredoc_body(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    expected: str,
+    description: str,
+) -> None:
+    """A heredoc an interpreter will execute is scanned; one consumed as text is not."""
     payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
     assert _outcome_exit_code(hook, monkeypatch, payload) == expected, description

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -346,6 +346,82 @@ def _wrapped_payloads(tokens: list[str]) -> list[str]:
     return payloads
 
 
+# POSIX shells that run their stdin as a *shell* program. A heredoc feeding one
+# of these is shell code and must be scanned the way `bash -c <payload>` already
+# is.
+#
+# Deliberately shells only. `python3 - <<EOF`, `perl`, `ruby` and `node` also run
+# their stdin, but as Python/Perl/Ruby/JS -- `printenv PYPI_TOKEN` in a Python
+# heredoc is a SyntaxError, not a dump. Scanning those bodies for shell patterns
+# would block string literals while still missing the real risk
+# (`os.system("cat ~/.netrc")`), so it buys false positives and no coverage.
+# Their bodies stay in the outer token scan, which is unchanged.
+_STDIN_INTERPRETERS = frozenset({"bash", "sh", "zsh", "dash"})
+
+# `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`.
+_HEREDOC_START = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def _reads_stdin_as_code(words: list[str]) -> bool:
+    """Whether the command in *words* will execute a heredoc body as a program.
+
+    `bash <<EOF` and `sh -s <<EOF` run their body as shell; `bash script.sh
+    <<EOF` and `cat >> notes.md <<EOF` feed it to something as input. The
+    difference is whether a script argument appears before the heredoc operator.
+    """
+    if not words:
+        return False
+    if words[0].rsplit("/", 1)[-1].lower() not in _STDIN_INTERPRETERS:
+        return False
+    for word in words[1:]:
+        if word.startswith("<<"):
+            break
+        if word == "-":
+            return True  # explicit "read the program from stdin"
+        if word.startswith("-"):
+            continue  # some other flag; keep looking
+        return False  # a script path: the heredoc is that script's input
+    return True  # bare `bash <<EOF` reads the program from stdin
+
+
+def _heredoc_payloads(command: str) -> list[str]:
+    """Return the lines of every heredoc body that its receiver will execute.
+
+    `check_command` recurses into `bash -c <payload>` through
+    :func:`_wrapped_payloads`, but a heredoc on stdin is not `-c`, so the body
+    was never re-scanned. The checks that match a token in any position caught
+    it anyway; the ones needing a command position did not, so
+    `bash <<EOF cat ~/.netrc EOF` ran while `bash -c "cat ~/.netrc"` was blocked
+    (#762).
+
+    Each line is yielded separately because each is its own command to the
+    shell, and a command position is what the missing checks require.
+    """
+    payloads: list[str] = []
+    lines = command.splitlines()
+    index = 0
+    while index < len(lines):
+        match = _HEREDOC_START.search(lines[index])
+        if not match:
+            index += 1
+            continue
+
+        delimiter = match.group(2)
+        # The command owning this heredoc is the last segment before it.
+        words = re.split(r"[;&|]", lines[index][: match.start()])[-1].split()
+
+        body: list[str] = []
+        cursor = index + 1
+        while cursor < len(lines) and lines[cursor].strip() != delimiter:
+            body.append(lines[cursor])
+            cursor += 1
+
+        if _reads_stdin_as_code(words):
+            payloads += [line for line in body if line.strip()]
+        index = cursor + 1
+    return payloads
+
+
 def check_dangerous_flags(tokens: list[str]) -> tuple[bool, str]:
     """
     Check if any dangerous flag appears as a standalone token.
@@ -963,8 +1039,11 @@ def check_command(command: str, _depth: int = 0) -> tuple[bool, str]:
     5. Merge commits on protected branches
     6. Blocked workflow commands
     7. Governance labels
-    8. Shell-wrapper payloads (``bash -c``, ``sh -c``, ``eval``) — recursed up
-       to depth 3 so all seven checks above gain wrapper coverage.
+    8. Shell-wrapper payloads (``bash -c``, ``sh -c``, ``eval``) and heredoc
+       bodies fed to a shell's stdin (``bash <<EOF``) — recursed up to depth 3
+       so all seven checks above gain wrapper coverage. A heredoc consumed as
+       *data* (``cat >> file <<EOF``, ``git commit -F - <<EOF``) or run by a
+       non-shell interpreter (``python3 - <<EOF``) is not recursed.
 
     Returns:
         (is_dangerous, reason)
@@ -1023,7 +1102,7 @@ def check_command(command: str, _depth: int = 0) -> tuple[bool, str]:
     # Recurse into shell-wrapper payloads (bash/sh/zsh/dash -c <payload>, eval ...)
     # Depth cap of 3 prevents infinite loops on adversarial inputs.
     if _depth < 3:
-        for payload in _wrapped_payloads(tokens):
+        for payload in _wrapped_payloads(tokens) + _heredoc_payloads(command):
             is_dangerous, reason = check_command(payload, _depth + 1)
             if is_dangerous:
                 return True, reason


### PR DESCRIPTION
## Description

`check_command` recurses into `bash -c <payload>` through `_wrapped_payloads`, but a heredoc on
stdin is not `-c`, so its body was never re-scanned. Checks matching a token in **any** position
caught it anyway; checks needing a **command** position did not:

```console
$ bash -c "cat ~/.netrc"                    # blocked
$ bash <<EOF                                # ran
cat ~/.netrc
EOF
```

The fix yields shell heredoc bodies into the recursion that already exists. The ADR that comes with
it records what the hook is for, which is the reason this is the *last* change of its kind.

## Related Issue

Addresses #762

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

### `4f46fa3` — scan heredoc bodies a shell will execute

`_heredoc_payloads` yields bodies into the same recursion, depth cap and checks as `bash -c`.
A body is yielded only when its receiver executes it as shell — `_reads_stdin_as_code` requires a
POSIX shell with no script argument before the operator, or an explicit `-`. Lines are yielded
individually, because each is its own command and a command position is what the missing checks
require.

**Scoped to shells deliberately, and this corrects the issue as filed.** #762 claims
`python3 - <<EOF` is part of the gap. It is not — that body is Python:

```console
$ python3 - <<'PY'
printenv PATH
PY
SyntaxError: invalid syntax
```

`printenv PYPI_TOKEN` there does not dump anything, it crashes. So the pre-existing case marking it
`ALLOW` and calling it a heredoc *mentioning* a dump was right, and my draft flipping it to `BLOCK`
was wrong; it is restored with a label that explains why. Shell patterns inside Python, Perl, Ruby
or JavaScript are string literals, and the real risk in those (`os.system("cat ~/.netrc")`) is not
shell-shaped, so scanning them buys false positives and no coverage.

The change is **additive** — it scans more, never less — so a mistake in it is a false positive,
not a bypass. That is the property that made this safe to do in the matcher when #759's proposal
was not.

### `bf47519` — ADR-9019: what the hook is for

ADR-9005 decided to block at the tool level. Nothing recorded *what* to block or *how far* to go,
so each new question was re-argued from scratch — #759 (over-blocking prose) and #762
(under-blocking executed bodies) turned out to be the same design question answered inconsistently.

A guardrail against a non-adversarial agent, not a boundary against a determined one. Three
categories — workflow redirect, damage guardrail, accidental exposure — and two scanning layers,
precise and crude. Four rules follow: never trade crude-layer coverage for precision; add to the
precise layer only when the payload is shell; fix crude-layer false positives by convention;
spend no complexity on category 3.

`command-blocking.md` already stated the test for one case — `$VAR` interpolation is not blocked
because it "would give false assurance while being trivially avoided". The ADR generalises that,
and the section now points at it.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass. All 222 hook tests green.

Tests were written **before** the fix and confirmed red — 6 failing, then green. Twelve further
cases pin the parser's contract: `<<-` with a tab-indented terminator, quoted delimiters, an
absolute interpreter path, a shell after `&&`, danger on the third line of a body, a second heredoc
after a data one, and the data-consumer cases that must stay allowed.

| verification | result |
| :--- | :--- |
| gap closed | `bash <<EOF`/`cat ~/.netrc`, `sh`, `zsh`, `dash` now blocked, matching `bash -c` |
| no over-blocking | `cat >> notes.md <<EOF`, `python3 script.py <<EOF`, `bash script.sh <<EOF`, `python3 - <<EOF` allowed |
| no regression | 222 hook tests pass; #759's cases unchanged |
| coverage is real | removing `_heredoc_payloads` from the recursion turns 12 cases red |

One case is pinned as a **known limitation rather than fixed**: a data heredoc quoting a `bash -c`
payload is still blocked, because the outer token scan reaches it. That predates this change, is
#759's territory, and is recorded so it is not rediscovered.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] ADR created (ADR-9019) and linked from ADR-9005 and `command-blocking.md`
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**The ADR says this change would not be proposed under its own rules, and I want that visible in
review rather than buried.** Everything #762 newly blocks is category 3 — accidental exposure,
already documented as not-a-boundary — and every category-2 pattern in a shell heredoc (`rm -rf ~`,
`--admin`, force-push) was **already** caught by the crude layer. It is kept because it is written,
tested, and makes the enforced-processes table honest; the ADR marks it as the last precision
addition of its kind. Dropping it and recording the gap as accepted would also have been defensible.

**Both alternative fixes for the related false positive were measured and rejected**, with what each
would un-block recorded in the ADR: stripping data heredoc bodies un-blocks `perl`, `ruby`, `node`
and `ssh` heredocs; position-aware wrapper detection un-blocks `xargs`, `find -exec` and `timeout`.
Each is blocked today *only* because the crude layer over-matches.

**#762's body overstates the gap** — it names `python3 - <<EOF` as part of it. I will correct that on
the issue when this merges rather than silently shipping a fix narrower than the issue describes.
