### PR TITLE
fix: pass commit messages by file, and redirect when one is not

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -270,6 +270,32 @@ docs: update installation instructions
 test: add tests for edge cases in parser
 ```
 
+### Passing the Message
+
+Short one-liners are fine inline:
+
+```bash
+git commit -m "fix: handle None values in data processor"
+```
+
+**Anything longer goes in a file.** Write the message, then pass it with `-F`:
+
+```bash
+# AI agents: use tmp/agents/<agent-type>/ and delete the file afterwards
+git commit -F tmp/agents/claude/commit-752.md
+```
+
+This matches how every other long-form body in this project is passed —
+`doit issue --body-file=`, `doit pr --body-file=`, `doit adr --body-file=`.
+
+It is also the only reliable way to write a message *about* the enforcement system. A heredoc
+(`git commit -F - <<EOF`) is scanned by the dangerous-command hook as command arguments, so a
+message that merely names `--admin`, `gh issue create` or any other blocked pattern is refused as
+if it invoked it. The hook is not taught to tell prose from commands — doing that means skipping
+heredoc bodies for a list of trusted commands, and a mistake in such a list is a bypass rather than
+an inconvenience (see [ADR-9019](../docs/decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md)).
+Passing the message by file costs nothing and avoids the question entirely.
+
 ### Breaking Changes
 
 For breaking changes, include `BREAKING CHANGE:` in the footer:

--- a/tests/test_hook_block_dangerous_commands.py
+++ b/tests/test_hook_block_dangerous_commands.py
@@ -600,3 +600,76 @@ def test_launcher_resolves_the_hook_independently_of_cwd(tmp_path: Path) -> None
     proc = _run_launcher(_agy_payload(DANGEROUS), cwd=tmp_path)
     assert proc.returncode == 0
     assert json.loads(proc.stdout)["decision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Block-and-redirect: a commit message passed by heredoc (#759)
+# ---------------------------------------------------------------------------
+
+_BLOCKED_FLAG = "--" + "admin"  # assembled so this file is not itself blocked
+
+
+def test_commit_heredoc_block_names_the_file_alternative(
+    hook: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The block must say what to do instead, not just that something is wrong.
+
+    A commit message naming a blocked pattern is refused because the heredoc is
+    scanned as arguments. The generic "contains dangerous pattern" wording sends
+    the author hunting for a dangerous command they never wrote; the redirect
+    sends them to ``-F <file>`` (ADR-9019, category 1).
+    """
+    command = f"git commit -F - <<EOF\ndocs: describe the {_BLOCKED_FLAG} bypass\nEOF"
+    _set_stdin(monkeypatch, _bash_payload(command))
+    with pytest.raises(SystemExit) as exc_info:
+        sys.exit(hook.main())
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "git commit -F <file>" in err
+    assert "tmp/agents/" in err
+
+
+def test_redirect_rewrites_the_reason_not_the_verdict(hook: types.ModuleType) -> None:
+    """Detection only: a command that was allowed stays allowed.
+
+    ``redirect_reason`` runs after ``check_command`` has decided, so it cannot
+    change what is blocked. That is what keeps this free of the bypass risk that
+    stopped the hook being taught to parse heredoc bodies (ADR-9019, rule 3).
+    """
+    safe = "git commit -F - <<EOF\ndocs: a message with nothing blocked in it\nEOF"
+    assert hook.check_command(safe) == (False, "")
+    assert hook.redirect_reason(safe, "") == ""
+
+    flagged = f"git commit -F - <<EOF\ndocs: the {_BLOCKED_FLAG} bypass\nEOF"
+    is_dangerous, original = hook.check_command(flagged)
+    assert is_dangerous
+    assert hook.redirect_reason(flagged, original) != original
+
+
+@pytest.mark.parametrize(
+    ("template", "redirected"),
+    [
+        ("git commit -F - <<EOF\nx {flag}\nEOF", True),
+        ("git commit --amend -F - <<EOF\nx {flag}\nEOF", True),
+        ("cd /repo && git commit -F - <<EOF\nx {flag}\nEOF", True),
+        ("/usr/bin/git commit -F - <<EOF\nx {flag}\nEOF", True),
+        # Owned by another command: a commit quoted inside someone else's body
+        # must not collect a redirect that does not apply to it.
+        ("cat >> tests/t.py <<PY\nx = 'git commit -F - <<EOF {flag}'\nPY", False),
+        ("git tag -F - <<EOF\nx {flag}\nEOF", False),
+        ("cat > notes.md <<EOF\nx {flag}\nEOF", False),
+        # No heredoc: never affected by the scan-as-arguments problem, so it
+        # keeps the reason that actually applies to it.
+        ("gh pr merge 1 {flag}", False),
+        ('git commit -m "x" && gh pr merge 1 {flag}', False),
+    ],
+)
+def test_redirect_fires_only_on_a_commit_heredoc(
+    hook: types.ModuleType, template: str, redirected: bool
+) -> None:
+    """Scoped to the shape that has a better path available."""
+    command = template.format(flag=_BLOCKED_FLAG)
+    assert hook._is_commit_message_heredoc(command) is redirected

--- a/tools/hooks/ai/block-dangerous-commands.py
+++ b/tools/hooks/ai/block-dangerous-commands.py
@@ -422,6 +422,50 @@ def _heredoc_payloads(command: str) -> list[str]:
     return payloads
 
 
+# A commit message is data, but a heredoc carrying one is scanned as arguments,
+# so a message that *names* a blocked pattern is refused as if it invoked it
+# (#759). The scanner is not taught to recognise prose -- that would mean
+# skipping bodies for an allowlist of receivers, where a mistake is a bypass
+# (ADR-9019, rule 3). The message is passed by file instead, and this turns the
+# block into the redirect that says so.
+_COMMIT_HEREDOC_REDIRECT = (
+    "A commit message passed by heredoc is scanned as command arguments, so a "
+    "message naming a blocked pattern is refused. Write the message to "
+    "tmp/agents/<agent-type>/ and pass it with `git commit -F <file>` "
+    "(.github/CONTRIBUTING.md, Commit Guidelines)."
+)
+
+
+def _is_commit_message_heredoc(command: str) -> bool:
+    """Whether *command* is a ``git commit`` whose message arrives by heredoc.
+
+    Detection only -- the body is never inspected, so this adds no parsing to
+    the scan and cannot change what is blocked. It changes what the block says.
+    """
+    for line in command.splitlines():
+        match = _HEREDOC_START.search(line)
+        if not match:
+            continue
+        # Only the command that *owns* the heredoc counts. Scanning every line
+        # would match a `git commit` example quoted inside another command's
+        # body and hand back a redirect that does not apply to it.
+        words = re.split(r"[;&|]", line[: match.start()])[-1].split()
+        if len(words) >= 2 and words[0].rsplit("/", 1)[-1] == "git" and "commit" in words[1:3]:
+            return True
+    return False
+
+
+def redirect_reason(command: str, reason: str) -> str:
+    """Replace *reason* with an actionable one where the repo has a better path.
+
+    Block-and-redirect (`docs/development/ai/enforcement-principles.md`): a block
+    that does not say what to do instead costs a turn and teaches nothing.
+    """
+    if reason and _is_commit_message_heredoc(command):
+        return _COMMIT_HEREDOC_REDIRECT
+    return reason
+
+
 def check_dangerous_flags(tokens: list[str]) -> tuple[bool, str]:
     """
     Check if any dangerous flag appears as a standalone token.
@@ -1310,7 +1354,7 @@ def main() -> int:
             return 0
         is_dangerous, reason = check_command(command)
         if is_dangerous:
-            return _block_response(fmt, reason, command)
+            return _block_response(fmt, redirect_reason(command, reason), command)
         return 0
 
     # --- Codex apply_patch path ---


### PR DESCRIPTION
## Description

A heredoc carrying a commit message is scanned as command arguments, so a message that merely
*names* a blocked pattern is refused as if it invoked one. Two commits in this repo hit it in a
single session — once on a bypass flag, once on `gh issue create` — both appearing only as prose in
a message describing the enforcement system.

**The scanner is not taught to tell prose from commands.** Doing that means skipping heredoc bodies
for a list of trusted receivers, and a mistake in such a list is a bypass rather than an
inconvenience. ADR-9019 records the measurement: stripping data heredoc bodies un-blocks
`perl <<EOF`/`rm -rf ~`, `ruby`, `node` and `ssh` heredocs that are caught today *only* because the
flat token scan over-matches.

So the convention changes instead, and the block learns to say so.

## Related Issue

Addresses #759

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement

## Changes Made

### 1. The convention — `CONTRIBUTING.md` § Commit Guidelines

A new **Passing the Message** section: `-m` for one-liners, `-F <file>` from
`tmp/agents/<agent-type>/` for anything longer.

This closes the last gap in a convention the project already has rather than adding a mechanism —
`doit issue --body-file=`, `doit pr --body-file=` and `doit adr --body-file=` all work this way, and
commit messages were the only long-form text still passed inline. The section explains *why* the
hook is not taught to recognise prose, and links ADR-9019.

**Placement follows ADR-9018's own rule.** This is needed at a nameable moment, not at all times, so
it belongs in CONTRIBUTING — which `### 5. Pre-Action Checks` already indexes for **Committing**.
Nothing was added to `AGENTS.md`.

### 2. The redirect — `redirect_reason`

An instruction alone would not hold. `enforcement-principles.md` argues instructions get ignored,
and the session that found this reached for a heredoc twice while holding all of that context. So
the block now says what to do:

```
Reason: A commit message passed by heredoc is scanned as command arguments, so a
message naming a blocked pattern is refused. Write the message to
tmp/agents/<agent-type>/ and pass it with `git commit -F <file>`
(.github/CONTRIBUTING.md, Commit Guidelines).
```

This is the repo's documented **Block and Redirect Pattern** (category 1 in ADR-9019 — the category
where the *message* is the product).

**It cannot change what is blocked.** `redirect_reason` runs after `check_command` has returned its
verdict, so it replaces the reason string and nothing else. Detection asks only whether the line
*owning* the heredoc is a `git commit` — no body is inspected, so there is no parsing and no new
surface. That is the property that made this safe where teaching the scanner about heredoc bodies
was not.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass. 233 hook tests green.

Three new tests: the block names the file alternative; the redirect rewrites the reason and not the
verdict; and a nine-case parametrization pinning exactly which shapes get redirected
(`git commit --amend`, after `&&`, absolute path) and which must not (`git tag`, `cat > notes.md`,
a commit quoted inside another command's body, and any command with no heredoc at all).

Verified by mutation: dropping `redirect_reason` from the Bash path turns the message test red.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**Two defects in my own work, both caught by the tests rather than by review:**

1. **The hook blocked my first attempt at writing these tests.** A `cat >> tests/... <<PYEOF` whose
   body quoted commit examples was matched, because detection scanned *every* line for a
   `git commit` — so it would have handed a "use `git commit -F`" redirect to someone writing a test
   file. A wrong redirect is worse than a generic block. Detection is now scoped to the line owning
   the heredoc, with a parametrized case pinning it.
2. **`redirect_reason` rewrote unconditionally.** Invisible at its only call site, since `main()`
   calls it only on a block — but wrong as a contract, and the test asserting the contract rather
   than the call site failed. It is now a no-op when there is no reason to replace.

**Known limitations, unchanged and deliberate** (ADR-9019, rule 3): prose naming a blocked pattern
inside `cat > file <<EOF` or `gh ... --body-file - <<EOF` is still blocked, and those keep the
generic reason because there is no better path to redirect them to — the repo's answer is the Write
tool and `--body-file=<path>`, which it already mandates.
