### PR TITLE
docs: measure the .claude/commands/ bleed into Copilot, and close the question

### DIFF
--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -15,7 +15,7 @@ All Copilot-host workflow skills live under `.github/skills/<target>-<action>/SK
 - **To Codex:** `/codex-plan`, `/codex-implement`, `/codex-review`, `/codex-adversarial-review`
 - **To Antigravity:** `/antigravity-plan`, `/antigravity-implement`, `/antigravity-review`, `/antigravity-adversarial-review`
 
-The `multi-*` orchestrators (`/multi-plan`, `/multi-review`, `/multi-adversarial-review`) and `/ghi-finalize` / `/ghi-status` come from `.agents/skills/` (interoperable Codex skill path) and are auto-discovered by Copilot.
+The `multi-*` orchestrators (`/multi-plan`, `/multi-review`, `/multi-adversarial-review`) and `/ghi-finalize` come from `.agents/skills/` (interoperable Codex skill path) and are auto-discovered by Copilot. `/ghi-status` has no skill under `.agents/skills/`: Copilot picks it up from `.claude/commands/ghi-status.md`, which it reads as a single-file command (#757). Verify with `copilot skill list`.
 
 ## Known limitation: delegate-* skill bleed
 

--- a/docs/development/ai/slash-commands.md
+++ b/docs/development/ai/slash-commands.md
@@ -193,12 +193,38 @@ Because skill names are derived from their directory name and **cannot contain c
 }
 ```
 
-**Known limitation — `.claude/commands/` command bleed:** Copilot loads single-file commands from
-`.claude/commands/`, so Claude's own command surface — its self-action and cross-agent files, and
-the `multi-*` orchestrators — appears in a Copilot session too. This is the mirror image of the
-bleed above and of the reason `.github/skills/` was chosen for the bridges: it keeps Copilot's
-skills out of Claude, but nothing keeps Claude's commands out of Copilot. `disabledSkills` does not
-cover them. Whether to address it is open (#753); this note records the behavior.
+**`.claude/commands/` in Copilot — measured, and smaller than it looks.** Copilot loads single-file
+commands from `.claude/commands/`, which raised the question of whether Claude's command surface
+bleeds into a Copilot session the way `delegate-*` bleeds the other way. It does not, and the
+question is closed (#757). Run `copilot skill list` from the repo root to reproduce:
+
+| | |
+| :--- | ---: |
+| project entries Copilot lists | 40 |
+| from `.github/skills/` | 16 |
+| from `.agents/skills/` | 23 |
+| **from `.claude/commands/`** | **1** |
+
+Two reasons the number is one:
+
+- **Discovery is not recursive.** Only top-level `*.md` files in `.claude/commands/` are read, so
+  none of the 16 nested `<target>/<action>.md` bridge files surface in Copilot.
+- **Names collide and dedupe.** `checkpoint`, `ghi-finalize`, `multi-*` and `restore` exist in
+  `.agents/skills/` as well, and Copilot keeps one entry per name.
+
+The one entry is **`ghi-status`**, which has no `.agents/skills/` counterpart — so
+`.claude/commands/` discovery is not a leak here, it is the only thing that makes `/ghi-status`
+available in Copilot at all.
+
+The same dedup shadows eight `.agents/skills/` entries — the `antigravity-*` and `codex-*`
+self-action skills — behind the same-named Copilot bridges in `.github/skills/`. That is the
+desired outcome for a Copilot session, but it depends on precedence rather than on anything the
+repo declares, so check `copilot skill list` after renaming a skill.
+
+**Correction:** an earlier version of this note said `disabledSkills` does not cover commands. It
+does — a command is loaded into the same collection `isSkillDisabled(name)` filters, which is why
+`ghi-status` appears in `copilot skill list` at all. The claim was inferred from the field name
+rather than checked.
 
 ## Adding a new slash command
 


### PR DESCRIPTION
## Description

#757 asked whether Claude's command surface bleeds into a Copilot session the way `delegate-*`
bleeds the other way, and whether `disabledSkills` could silence it. Both questions are answerable
without reading minified JavaScript — `copilot skill list` runs read-only from the repo root and
enumerates exactly what Copilot sees.

**The premise was mostly wrong.** The bleed is one entry, and it is one the repo wants.

## Related Issue

Addresses #757

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

### The measurement

| project entries Copilot lists | 40 |
| :--- | ---: |
| from `.github/skills/` | 16 |
| from `.agents/skills/` | 23 |
| **from `.claude/commands/`** | **1** |

**Q1 — is discovery recursive? No.** Only top-level `*.md` files in `.claude/commands/` are read, so
none of the 16 nested `<target>/<action>.md` bridge files surface in Copilot. Six of the seven
top-level commands are then deduped by name against `.agents/skills/` (`checkpoint`,
`ghi-finalize`, `multi-*`, `restore`), which is how seven files yield one entry.

**Q2 — does `disabledSkills` cover commands? Yes.** A command is loaded into the same collection
`isSkillDisabled(name)` filters — which is *why* `ghi-status` appears in the listing at all.

**The one entry is `ghi-status`, and it is not a leak.** It has no `.agents/skills/` counterpart, so
`.claude/commands/` discovery is the only thing making `/ghi-status` available in Copilot.
`.copilot/README.md` claimed that command came from `.agents/skills/`. It does not; corrected.

### Two corrections to claims I merged earlier

1. **`disabledSkills` does cover commands.** The note added with #753 said it does not. I inferred
   that from the field name instead of checking. The doc now carries the correction explicitly
   rather than quietly dropping the sentence — the claim was public, so the retraction should be.
2. **`ghi-status` does not come from `.agents/skills/`** (`.copilot/README.md`).

### One thing the issue did not ask about

The same dedup **shadows eight `.agents/skills/` entries** — the `antigravity-*` and `codex-*`
self-action skills — behind the same-named Copilot bridges in `.github/skills/`. That is the
desired outcome for a Copilot session, but it depends on precedence rather than on anything the
repo declares, so a rename can silently change which file wins. Recorded with a pointer to re-check
`copilot skill list`.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**No test added, deliberately.** The headline claim requires the Copilot CLI installed and
authenticated, which CI does not have — a test would either be skipped everywhere or assert
something weaker than the claim. The doc names the reproduction command (`copilot skill list`) and
the expected breakdown instead, so the next person can re-measure in one command rather than
re-derive it from the bundle.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests — N/A, see Testing
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**The `.github/skills/` design rationale is unaffected.** It exists to keep Copilot's *skills* from
surfacing twice in Claude; that is unchanged. The reverse direction turns out to be a single command
the repo wants available. So the outcome is **accept and document** — no design change — which #757
listed as a legitimate result, and this PR states it explicitly rather than leaving the question
hanging.

**On method.** #757 was filed off a static read of a minified bundle, and its central claim did not
survive a one-command check against the running CLI. The same shortcut produced the
`disabledSkills` error being corrected here and, earlier in this sequence, #753 and the `python3 -`
misreading in #762. Where a tool is installed, ask it.
