### PR TITLE
docs: describe heredoc handling in the command-blocking reference

### DIFF
--- a/docs/development/ai/command-blocking.md
+++ b/docs/development/ai/command-blocking.md
@@ -120,6 +120,37 @@ EOF
 )"
 ```
 
+#### Heredocs
+
+Quoting is what makes the example above safe: the `$( )` sits inside double quotes, so `shlex`
+collapses the whole thing into one token and nothing inside it is ever a standalone `--force`. An
+**unquoted** heredoc body gets no such protection — it is split into tokens like any other
+argument. Four shapes, and they do not behave alike:
+
+| shape | outcome |
+| :--- | :--- |
+| `doit pr --body="$(cat <<'EOF' … )"` — quoted substitution | allowed; the body is one token |
+| `bash <<EOF` — a shell will execute the body | **blocked** if the body contains a blocked pattern; the body is re-scanned as commands, the way `bash -c` already is |
+| `git commit -F - <<EOF` — prose the receiver consumes as data | **blocked** if the prose names a blocked pattern, because the body is still tokenized |
+| `python3 - <<EOF`, `cat > f.md <<EOF` — a non-shell receiver | body is not re-scanned; the flat token scan still applies to it |
+
+The third row is why **commit messages go in a file**: a message describing `--admin` or
+`gh issue create` is refused as though it invoked one. That block names its alternative rather than
+giving the generic reason:
+
+```
+Reason: A commit message passed by heredoc is scanned as command arguments, so a
+message naming a blocked pattern is refused. Write the message to
+tmp/agents/<agent-type>/ and pass it with `git commit -F <file>`.
+```
+
+See [Commit Guidelines — Passing the Message](../../../.github/CONTRIBUTING.md#commit-guidelines)
+for the convention, and
+[ADR-9019](../../decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md)
+for why the scanner is not taught to recognise prose instead — the short version is that skipping
+bodies for a list of trusted receivers turns a mistake in that list into a bypass, and the flat
+scan is what covers interpreters nobody has listed.
+
 ### Files
 
 | File | Description |


### PR DESCRIPTION
## Description

`command-blocking.md` is the reference a user reads to find out what the hook blocks. Two merges
changed heredoc handling and neither updated it:

- **#762** (`cd4811e`) — the hook now scans heredoc bodies a POSIX shell executes, so
  `bash <<EOF` / `cat ~/.netrc` is blocked where it previously ran.
- **#759** (`5dd08d6`) — a `git commit` heredoc now gets a block-and-redirect naming
  `git commit -F <file>` instead of the generic reason.

Both landed in ADR-9019, the hook's docstrings and `CONTRIBUTING.md`. The reference doc still
described the world before either.

## Related Issue

Addresses #766

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

The `#### Key Feature: Quote-Aware Parsing` section showed exactly one heredoc example — a quoted
`$( )` substitution, labelled allowed. Still true, but as the *only* heredoc case shown it reads as
"heredoc content is safe", which is wrong in both directions.

A new `#### Heredocs` subsection gives the rule — quoting collapses content into one token, an
unquoted body does not, and a body a shell will execute is re-scanned as commands — and the four
shapes that follow from it:

| shape | outcome |
| :--- | :--- |
| `doit pr --body="$(cat <<'EOF' … )"` | allowed; the body is one token |
| `bash <<EOF` | blocked; body re-scanned as commands |
| `git commit -F - <<EOF` | blocked; body still tokenized — hence the redirect |
| `python3 - <<EOF`, `cat > f.md <<EOF` | not re-scanned; the flat token scan still applies |

It points at CONTRIBUTING for the commit-message convention and ADR-9019 for why the scanner is not
taught to recognise prose, rather than restating either.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**Every row was checked against the running hook**, not reasoned about — the same six-case probe in
both directions:

```
ok   ALLOW want ALLOW             quoted substitution
ok   BLOCK want BLOCK             bash <<EOF, shell body
ok   BLOCK want BLOCK (redirect)  git commit -F - <<EOF, prose
ok   BLOCK want BLOCK             python3 - <<EOF, flat scan reaches it
ok   ALLOW want ALLOW             python3 - <<EOF, position-sensitive miss
ok   BLOCK want BLOCK             cat > f.md <<EOF, flat scan reaches it
```

No test added: these are documentation examples, and the behaviours behind them are already pinned
by `test_hook_dangerous_command_matrix.py` (the heredoc contract cases from #762) and
`test_hook_block_dangerous_commands.py` (the redirect cases from #759).

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests — N/A, documentation; the behaviours are already covered
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**Both merges this corrects were mine.** #762's PR verified its facts were carried by the ADR and by
the tests, and did not check the reference doc — the same "verify the destination" step that found
#753, #754 and #757, not applied to my own work. Worth stating plainly, because the method is only
worth anything if it survives being turned inward.

This is **not** part of #749. That audit covers the 2026-08-24 changes; these are from 2026-08-29.
The additions this session *does* make to #749's scope are posted there separately.
