### PR TITLE
docs: give consumer-facing changes a home in the sync path

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -114,6 +114,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [CI/CD Testing Guide](development/ci-cd-testing.md) - GitHub Actions pipelines for testing, linting, and coverage
 - [Claude Code Statusline](development/ai/statusline.md) - Custom statusline showing git branch, Python version, and project info
 - [CLI Guide](usage/cli.md) - The application's user-facing command-line interface and how to extend it
+- [Consumer Notes](template/consumer-notes.md) - Breaking changes and behaviour changes that arrive when a project syncs from the template.
 - [Cross-Agent Delegation Matrix](development/ai/cross-agent-delegation.md)
 - [Dependabot Auto-merge](development/dependabot-automerge.md) - How the dependabot auto-merge workflow evaluates, enables, and skips PRs
 - [Development Deployment Guide](deployment/development.md) - Guide for setting up and running the application in development environments

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -30,6 +30,8 @@ This checklist guides an AI agent through synchronizing a downstream project wit
     --body="## Description\nSynchronize project with latest pyproject-template improvements."
   ```
 - [ ] Create branch linked to the issue (e.g., `chore/<issue#>-sync-pyproject-template`)
+- [ ] Read [Consumer Notes](consumer-notes.md) — the breaking and behaviour changes that
+      arrive through this sync. Note which apply to this project before adopting any drift.
 
 ---
 
@@ -157,6 +159,15 @@ For each workflow file flagged as **Modified** or **Missing**:
 
 ## Phase 5: Doit Tasks (`tools/doit/`)
 
+### 5.0 Breaking change: `install_tools` digests
+
+- [ ] Does this project call `install_tool()` or `create_install_task()` with `url_template`
+      for a **non-GitHub** host? If so, adopting `tools/doit/install_tools.py` aborts that
+      install with `IntegrityError` until you pass `sha256=`.
+- [ ] Take the digest from the publisher's checksums file, not from a download you have not
+      verified. Per-platform digests use a dict keyed like `asset_patterns`.
+- [ ] See [Consumer Notes](consumer-notes.md#install_tools-requires-sha256-for-untrusted-hosts).
+
 ### 5.1 Core Task Infrastructure
 
 - [ ] Compare `tools/doit/__init__.py` for discovery mechanism updates
@@ -188,6 +199,11 @@ For each workflow file flagged as **Modified** or **Missing**:
 ---
 
 ## Phase 7: Pre-commit & Other Config
+
+- [ ] After adopting `.pre-commit-config.yaml`, run `doit pre_commit_install` **again** —
+      the config declares four hook types and `commit-msg` is newly among them. An earlier
+      install leaves it absent, and conventional-commit enforcement silently does not run.
+      Verify with `ls .git/hooks/`.
 
 - [ ] Compare `.pre-commit-config.yaml` - hook versions, new hooks
 - [ ] Compare `.github/CONTRIBUTING.md` for updated processes

--- a/docs/template/consumer-notes.md
+++ b/docs/template/consumer-notes.md
@@ -1,0 +1,118 @@
+---
+title: Consumer Notes
+description: Breaking changes and behaviour changes that arrive when a project syncs from the template.
+---
+
+# Consumer Notes
+
+Changes that **reach a downstream project through the sync path** and need action, or need
+explaining when someone notices them. Newest first.
+
+This page exists because the alternative failed. The `sha256` change below was documented in
+ADR-9015 and in the install-tools reference, and neither is read during a sync — so a project
+syncing `tools/doit/install_tools.py` got a runtime abort with no prior warning. Per-topic docs are
+the right home for *how a thing works*; this is the home for *what will change under you*.
+
+Read it after `bootstrap.py --sync` and before adopting drift. It is also linked from
+[Files to Review Carefully](updates.md#files-to-review-carefully) and the
+[AI Sync Checklist](ai-sync-checklist.md).
+
+## Breaking
+
+### `install_tools` requires `sha256` for untrusted hosts
+
+**What changed.** A download from any host outside `IMPLICITLY_TRUSTED_HOSTS` — `github.com`,
+`objects.githubusercontent.com`, `raw.githubusercontent.com`, `api.github.com` — must now be
+accompanied by an expected digest. Without one the install aborts with `IntegrityError` before the
+file is made executable.
+
+**Who breaks.** Any caller passing `url_template` for a non-GitHub host. That is precisely the case
+`url_template` was introduced for (ADR-9015 names `releases.hashicorp.com`, terraform and opentofu),
+so the projects most likely to hit this are the ones the feature was built for.
+
+**What it looks like.**
+
+```
+IntegrityError: https://releases.hashicorp.com/... is outside ['api.github.com',
+'github.com', 'objects.githubusercontent.com', 'raw.githubusercontent.com'] and no
+sha256 was given. Pass sha256= to install_tool()/create_install_task() naming the
+digest you expect
+```
+
+**The fix.** Pass the digest you expect. `sha256` accepts a single string, or a dict keyed the same
+way as `asset_patterns` when the digest differs per platform:
+
+```python
+create_install_task(
+    name="terraform",
+    url_template="https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip",
+    sha256={"linux-x86_64": "…", "darwin-arm64": "…"},
+)
+```
+
+Publishers of this kind ship a checksums file alongside the release; take the digest from there
+rather than computing it from a download you have not yet verified.
+
+**Why it is not optional.** `url_template` fetches from arbitrary third parties, which is exactly
+where an implicit trust assumption should not be extended. See
+[install-tools framework](../development/install-tools-framework.md) and ADR-9015.
+
+## Needs a one-off action
+
+### Re-run `doit pre_commit_install`
+
+**Who.** Every project that ran it *before* adopting the `.pre-commit-config.yaml` that declares
+`default_install_hook_types`.
+
+**Why.** The config now declares four hook types, and `commit-msg` is newly among them. A project
+that installed hooks earlier has no `commit-msg` hook on disk, so **neither conventional-commit
+enforcement nor the branch/issue check runs for it** — silently, because nothing fails when a hook
+that was never installed does not fire.
+
+```bash
+doit pre_commit_install
+```
+
+Verify with `ls .git/hooks/` — `commit-msg`, `pre-commit`, `post-merge` and `post-checkout` should
+all be present.
+
+## Behaviour you will notice
+
+### Conventional-commit enforcement is live
+
+It was configured but dormant while `commit-msg` was never installed. Commit messages that
+previously succeeded are now rejected unless they match `<type>: <subject>`. See
+[Commit Guidelines](../../.github/CONTRIBUTING.md#commit-guidelines).
+
+### The dangerous-command hook blocks more
+
+`tools/hooks/ai/block-dangerous-commands.py` now scans heredoc bodies that a POSIX shell executes,
+so `bash <<EOF` carrying a blocked pattern aborts where it previously ran. It fails safe — the newly
+blocked shapes are ones the hook already intended to catch — but a command that worked before may
+stop. See [AI Command Blocking](../development/ai/command-blocking.md#heredocs).
+
+### Long commit messages go in a file
+
+A commit message passed by heredoc is scanned as command arguments, so a message that merely *names*
+a blocked pattern is refused. Write it to `tmp/agents/<agent-type>/` and pass `git commit -F <file>`;
+the block now says so rather than giving a generic reason. See
+[Passing the Message](../../.github/CONTRIBUTING.md#commit-guidelines).
+
+### PRs get no benchmark regression comment
+
+The benchmark still runs and uploads its JSON. The comment required `contents: write` on the pull
+request path and was removed with it; read the workflow artifact instead.
+
+### Dependabot proposes exact-version action bumps
+
+GitHub Actions are SHA-pinned, so dependabot now proposes `from 6.3.0 to 7.0.0` rather than
+major-to-major `from 6 to 7`. The pin is the point — review the SHA, not only the version.
+
+## Adding to this page
+
+An entry belongs here when a downstream project would be **surprised** by the change: it breaks a
+call that worked, requires a one-off action, or alters behaviour someone will notice without an
+explanation to hand. Ordinary improvements do not need an entry.
+
+Put the *reasoning* in the ADR or the per-topic doc and link it. This page answers "what changes
+under me, and what do I do about it" — nothing else.

--- a/docs/template/migration.md
+++ b/docs/template/migration.md
@@ -73,6 +73,10 @@ See [Template Management](manage.md) for full documentation on the management sc
 ### 10) Verify Locally
 - Install environment: `uv sync --all-extras --dev`
 - Install hooks: `doit pre_commit_install`
+  - Already ran this in an earlier migration? Run it again. The config now declares four hook
+    types and `commit-msg` is newly among them, so an older install has no `commit-msg` hook
+    and neither conventional-commit enforcement nor the branch/issue check fires. Verify with
+    `ls .git/hooks/` — see [Consumer Notes](consumer-notes.md#re-run-doit-pre_commit_install).
 - Run checks: `doit check`
 - Run tests: `doit test`
 

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -120,6 +120,13 @@ These files typically should be kept in sync:
 - `dodo.py` - New tasks or improvements
 - `tools/pyproject_template/*.py` - Template tooling
 
+### Breaking and behaviour changes
+
+Before adopting drift, read **[Consumer Notes](consumer-notes.md)** — changes that arrive through
+the sync path and need action. It currently carries a breaking change to `install_tools`
+(`sha256` is now mandatory for non-GitHub hosts), a hook re-install that must be run once, and the
+behaviour changes a project will notice without explanation.
+
 ### Files to Review Carefully
 
 These may have project-specific customizations:
@@ -128,6 +135,8 @@ These may have project-specific customizations:
 - `mkdocs.yml` - Your navigation differs
 - `README.md` - Your content differs
 - `.github/CONTRIBUTING.md` - May have project-specific rules
+- `tools/doit/install_tools.py` - Adopting this requires `sha256=` for any non-GitHub
+  download; see [Consumer Notes](consumer-notes.md#install_tools-requires-sha256-for-untrusted-hosts)
 
 ### Files to Usually Skip
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,7 @@ nav:
       - Migration Guide: template/migration.md
       - Keeping Up to Date: template/updates.md
       - AI Sync Checklist: template/ai-sync-checklist.md
+      - Consumer Notes: template/consumer-notes.md
       - Tools Reference: template/tools-reference.md
   - Decisions:
       - Overview: decisions/README.md


### PR DESCRIPTION
## Description

First of four PRs against #749, taking its own priority order: **C1 first — the only item that
breaks a downstream project rather than merely misleading one.** Also lands C2, the new C3, and
all of section E, because they share a destination that did not exist.

Making `sha256` mandatory for hosts outside `IMPLICITLY_TRUSTED_HOSTS` breaks any caller passing
`url_template` for a non-GitHub host — which is exactly the case ADR-9015 introduced `url_template`
for, naming `releases.hashicorp.com`, terraform and opentofu. **The projects most likely to break
are the ones the feature was built for.**

It was documented in ADR-9015 and the install-tools reference. Neither is read during a sync, and
nothing in the sync path mentioned it, so a project adopting `tools/doit/install_tools.py` got a
runtime abort with no warning. I checked: **no doc anywhere carried consumer-facing breaking
changes**, which is why this one had nowhere to go.

## Related Issue

Addresses #749

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

### New: `docs/template/consumer-notes.md`

What changes under a downstream project, and what to do about it. Per-topic docs keep explaining
*how things work*; this page answers *what will change under me*, and links the reasoning rather
than restating it.

| section | contents |
| :--- | :--- |
| **Breaking** | **C1** — the four trusted hosts, the real `IntegrityError` text, who breaks and why, and the dict-keyed `sha256=` fix |
| **Needs a one-off action** | **C2** — re-run `doit pre_commit_install`, why it fails silently, `ls .git/hooks/` to verify |
| **Behaviour you will notice** | **E1–E3**, plus **C3** (the hook blocks more) and the commit-message convention from #759 |
| **Adding to this page** | the admission test, so it does not decay into a changelog |

### Wired into the paths a syncing reader actually opens

That was the whole failure, so the links are the substance of this PR:

- **`updates.md`** — a *Breaking and behaviour changes* section placed **ahead of** "Files to Review
  Carefully"; `tools/doit/install_tools.py` added to that list with the digest caveat
- **`migration.md`** — C2 inline at step 10, where "Install hooks" already appears
- **`ai-sync-checklist.md`** — three steps: read the notes at pre-flight, a **5.0 breaking change**
  block opening the `tools/doit/` phase, and the hook re-run in Phase 7
- **`mkdocs.yml`** nav

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**All seven new cross-document anchors were checked to resolve**, not assumed — including the
awkward ones (`#install_tools-requires-sha256-for-untrusted-hosts`,
`#re-run-doit-pre_commit_install`), since backticks and underscores in headings are where anchor
links usually break.

No test added: `test_markdown_links.py` and `test_instruction_pointers.py` already cover link and
anchor resolution for these files, and both pass with the new page in scope.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests — N/A, documentation; links covered by existing tests
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**One deliberate duplication, flagged rather than left implicit.** The C1 and C2 entries appear on
the page *and* inline at each point of use. A reader partway through a sync should not have to
follow a link to learn their install will abort. ADR-9018 asks that duplication be justified rather
than happen quietly — this is the justification, and the inline copies are one or two lines each
that point at the page for the detail.

**Remaining on #749**, in the issue's priority order:

- **PR 2** — A1–A3: `fail_under` is documented as 54 and is 70; the coverage table is stale in both
  rows. Per the agreed approach, that table gets the gate value and the reason the two rows
  converged rather than statement counts — the audit's own figures (2,932 / 73.27%) drifted to
  2,982 / 73.62% within five days, and nothing checks them.
- **PR 3** — B1–B4: ref pinning in `updates.md`, the nine-file drift list, the
  `TEMPLATE_OWNED_TEST_FILES` description that still describes the pre-ADR-9017 rule.
- **PR 4** — D1: `tools/doit/git.py` enumerates a hook set that is no longer the set. Code, so it
  travels separately from the docs.
