### PR TITLE
docs: correct stale facts about the coverage gate and hook install

### DIFF
--- a/docs/development/ai/enforcement-principles.md
+++ b/docs/development/ai/enforcement-principles.md
@@ -218,7 +218,7 @@ These patterns are blocked across all AI agents. Claude and Copilot both use the
 | All CI checks must pass | `ci.yml` | Required status check for merge |
 | `ready-to-merge` label required | `merge-gate.yml` | Blocks merge without label |
 | Full test matrix on merge | `ci.yml` | Runs all Python versions when labeled |
-| Minimum 80% test coverage | `ci.yml` + `pyproject.toml` | `fail_under = 80` fails CI if coverage drops |
+| Minimum test coverage | `ci.yml` + `pyproject.toml` | `fail_under` fails CI when coverage drops below the gate; `pyproject.toml` holds the current value |
 
 ### By Settings (Agent-Specific)
 

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -294,7 +294,7 @@ both properties.
 
 ### Coverage Requirements
 
-- **Enforced threshold**: `fail_under = 54` in `pyproject.toml`
+- **Enforced threshold**: `fail_under = 70` in `pyproject.toml`
 - **Measured scope**: `package_name` **and** `tools/`
 - **Artifacts**: Upload HTML coverage reports for review
 - **Integration**: Use Codecov or similar service for tracking
@@ -310,20 +310,28 @@ The threshold is deliberately set to what the codebase actually achieves rather 
 aspirational number pointed at the wrong target. **Ratchet it upward** as tooling coverage
 improves; treat lowering it as a change that needs justification in the PR.
 
-Nothing is omitted from the measured scope.
+One directory is omitted: `tools/pyproject_template/`. It is the template's own management
+suite, deleted by both spawn routes, so leaving it in scope measured code downstream that is
+never tested there — which put a spawned project 19 points under the gate (#731). Its tests
+still run in template CI. Nothing else is omitted.
 
 #### Template vs downstream
 
-`cleanup --setup` / `--all` deletes `tools/pyproject_template/`, so a downstream project measures
-a smaller set than this repository does:
+`cleanup --setup` / `--all` deletes `tools/pyproject_template/`, so the two shapes once measured
+different code and reported different numbers.
 
-| Shape | Statements | Coverage | Gate at 54 |
-| :--- | ---: | ---: | :--- |
-| Template (this repo) | 5,102 | 58.29% | passes |
-| Downstream, after `cleanup` | 2,748 | 62.98% | passes |
+**They no longer do.** #731 omitted that directory from the gate precisely so both shapes measure
+the same statements with the same tests: a spawned project now sees the number this repository
+sees, rather than one 19 points lower that it had no way to raise. There is one figure to track,
+not two.
 
-<!-- The downstream row is measured by excluding `tools/pyproject_template/` from the report,
-     which yields the same denominator `cleanup` produces by deleting it. -->
+Run `doit coverage` for the current value. The gate is `fail_under` in `pyproject.toml` — 70 at the
+time of writing — and CI fails below it.
+
+Statement counts and percentages are deliberately **not** quoted here. They move with every merge:
+the figures this section used to carry were stale within days, and a number in prose that no test
+reads is a number that will be wrong (#754). `pyproject.toml` holds the threshold, `doit coverage`
+reports the measurement, and both are checked.
 
 #### Keep coverage hermetic
 

--- a/docs/development/doit-tasks-reference.md
+++ b/docs/development/doit-tasks-reference.md
@@ -953,12 +953,18 @@ doit pre_commit_install
 ```
 
 **What it does:**
-- Installs pre-commit hooks to `.git/hooks/`
-- Hooks run automatically on `git commit`
+- Installs every hook type declared by `default_install_hook_types` in `.pre-commit-config.yaml`:
+  `pre-commit`, `commit-msg`, `post-merge` and `post-checkout`
+- Hooks run automatically on the matching git action
+
+**Why `commit-msg` matters:** it carries conventional-commit validation and the check that a
+commit's issue reference matches its branch (#741). A project that installed hooks *before* that
+type was declared does not have it, and neither check runs — silently, because a hook that was
+never installed cannot fail. Run this task again to pick it up, then confirm with `ls .git/hooks/`.
 
 **Equivalent command:**
 ```bash
-uv run pre-commit install
+uv run pre-commit install   # installs all declared hook types
 ```
 
 ### `pre_commit_run`


### PR DESCRIPTION
## Description

PR 2 of 4 against #749: section A — documentation that is factually wrong about a **live gate**.

Sweeping for the same class of error turned up two more the audit had not found, one of them in the
table that is supposed to be authoritative about what this project enforces.

## Related Issue

Addresses #749

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

| | claim | actual |
| :--- | :--- | :--- |
| **A1** `ci-cd-testing.md:297` | `fail_under = 54` | **70** |
| **A2** the shape table | 5,102 stmts / 58.29%, 2,748 / 62.98%, "Gate at 54" | all four stale; the rows have converged |
| **A3** `doit-tasks-reference.md` | installs hooks, equivalent to `uv run pre-commit install` | four hook types, `commit-msg` newly load-bearing |
| **new** `ci-cd-testing.md` | "Nothing is omitted from the measured scope." | `tools/pyproject_template/*` is omitted |
| **new** `enforcement-principles.md:221` | "Minimum 80% test coverage", `fail_under = 80` | the gate is **70** |

### A2 — the table is replaced with a fact, not with fresher numbers

The two rows stopped being meaningfully different when #731 omitted `tools/pyproject_template/` from
the gate, precisely so both shapes measure the same statements with the same tests. There is one
figure to track, not two, and the section now says that.

**Why no new numbers.** Statement counts move with every merge — the audit's own re-measurement,
taken five days before this PR, had already drifted from 2,932 / 73.27% to 2,982 / 73.62%. A number
in prose that no test reads is a number that will be wrong (#754). `pyproject.toml` holds the
threshold and `doit coverage` reports the measurement; both are checked, so the doc names them
rather than copying them.

### The two the audit missed

- **"Nothing is omitted from the measured scope"** contradicted the change it sits beside: #731's
  `omit = ["tools/pyproject_template/*"]` is the entire mechanism by which the two shapes converged.
- **`enforcement-principles.md`** claimed an 80% minimum in its *Currently Enforced Processes*
  table. A wrong number there is worse than elsewhere — that table is what a reader consults to
  learn what is actually enforced. It now names `fail_under` and points at `pyproject.toml` instead
  of quoting a value that can drift.

### Left alone deliberately

The `40.73%` and `8.27%` figures at `ci-cd-testing.md:257` are a measurement of a past experiment
(#731's shed-the-tests trial), not a live gate value. Quoting them is correct and they should stay.

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass. The threshold was read from `pyproject.toml` and the
coverage measured with `doit coverage` rather than taken from the issue, which is how the drift
since the audit was noticed.

After the edits, a repo-wide sweep for the stale values (`fail_under = 5x`, `58.29`, `62.98`,
`5,102`, `2,748`, `Gate at 54`) returns nothing.

No test added: the numbers are gone rather than corrected, which is the durable fix. The two that
remain — `fail_under` in `pyproject.toml`, and the coverage `doit coverage` reports — are both
already enforced by CI.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests — N/A, documentation; both surviving figures are CI-enforced
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**Remaining on #749:**

- **PR 3** — B1–B4: ref pinning in `updates.md`, the nine-file drift list, and the
  `TEMPLATE_OWNED_TEST_FILES` description that still describes the pre-ADR-9017 membership rule.
- **PR 4** — D1: `tools/doit/git.py` enumerates a hook set that is no longer the set. Code, so it
  travels separately.
