### PR TITLE
docs: document ref pinning and what the next sync will offer

### DIFF
--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -57,9 +57,31 @@ template version it was fetched with. If your local tooling is older than the te
 comparing against, the checker may miss or misreport differences. Always run `bootstrap --sync` before running
 the drift check.
 
-**Template-owned tests:** The files listed in `TEMPLATE_OWNED_TEST_FILES` (e.g. `tests/template/test_check_template_updates.py`)
-are tooling tests that run only in the template's own CI. They are silently excluded from the drift report and
-will be shed from your project by `cleanup --setup`. You do not need to adopt or maintain them.
+**Template-owned tests:** The files listed in `TEMPLATE_OWNED_TEST_FILES` are excluded from the drift
+report and shed by `cleanup --setup`; you do not need to adopt or maintain them. A test is
+template-owned when **its target does not survive configuration** (ADR-9017) — which is broader than
+"tooling tests". The list covers the management suite, and also `test_configure_paths.py`,
+`test_readme_split.py` and `test_downstream_test_retention.py`, whose targets `configure.py`
+consumes or destroys during setup. Everything else under `tests/` is yours to adopt, including the
+`tools/doit/` and `tools/hooks/` tests, which cover code that ships to and runs in your project
+(#731).
+
+**New files you will see in this sync.** These are recent additions, all downstream-owned, so the
+drift checker will offer them:
+
+| File | Adopt? |
+| :--- | :--- |
+| `tests/agent_roster.py` | Yes — a helper, not a test. Required by the roster-aware tests below. |
+| `tests/test_cross_agent_contract.py` | Yes if you wire more than one AI agent; it derives its scope from the roster and checks nothing for agents you dropped. |
+| `tests/test_instruction_pointers.py` | Yes — catches instruction files pointing at sections and commands that do not exist. |
+| `tests/test_workflow_action_pinning.py` | Yes if you keep `.github/workflows/`. |
+| `tests/test_hermetic_suite.py` | Yes — keeps the unit suite off real external binaries. |
+| `tests/test_hypothesis_profiles.py` | Yes if you kept the Hypothesis profiles in `conftest.py`. |
+| `tools/hooks/check_commit_issue_ref.py` + `tests/test_hook_commit_issue_ref.py` | Yes, together, and re-run `doit pre_commit_install` after — the hook needs the `commit-msg` type. |
+| `tests/test_agents_md_allocation.py` | Yes, **then trim `RELOCATION_TARGETS`**. It names template paths including `docs/development/dependabot-automerge.md`; a project without that doc adopts a test that cannot pass. |
+
+The last row is the general hazard: a test can be downstream-owned and still name structure your
+project does not have. Read the constants at the top of a test before adopting it.
 
 After running bootstrap:
 

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -29,6 +29,33 @@ Stay in sync with improvements to the pyproject-template.
 > can use `manage.py`, `check_template_updates.py`, and the rest of the
 > sync tooling described below.
 
+## Which template version you get
+
+`bootstrap.py` resolves the ref once, up front, and fetches every file from that single commit.
+A run is therefore internally consistent: `main` moving mid-run cannot give you half of one commit
+and half of another.
+
+It prints the commit it pinned to:
+
+```
+  Pinned to commit 4ef5b9c1a2b3 (from 'main')
+```
+
+**Record that SHA.** It is the answer to "which template version is this project synced against",
+and it is what makes a sync reproducible.
+
+To pin deliberately — reviewing an update before taking it, or reproducing an earlier sync — set
+`PYPROJECT_TEMPLATE_REF` to a branch, tag or full SHA:
+
+```bash
+PYPROJECT_TEMPLATE_REF=4ef5b9c... curl -sSL https://raw.githubusercontent.com/endavis/pyproject-template/main/bootstrap.py | python3 - --sync
+```
+
+If `api.github.com` is unreachable or rate-limited, the run **warns and continues** against the
+moving ref rather than failing. Pinning is a consistency improvement; refusing to bootstrap because
+an API call failed would trade a small gain for a hard outage. Set `GITHUB_TOKEN` if you are being
+rate-limited.
+
 ## When to Update
 
 Consider checking for template updates when:


### PR DESCRIPTION
## Description

PR 3 of 4 against #749: section B — the update mechanism. Two things a syncing project needs and
could not get from the docs, and one description that stopped matching the rule it describes.

## Related Issue

Addresses #749

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

### B1 — ref pinning was entirely undocumented

`bootstrap.py` resolves the ref to a commit SHA once and fetches every file from that commit, so a
run cannot get half of one commit and half of another. It honours `PYPROJECT_TEMPLATE_REF`, and
falls back to the moving ref with a warning when `api.github.com` is unreachable. `updates.md` still
showed the plain `curl` invocation with none of that.

New **Which template version you get** section covering the pinned-commit line bootstrap actually
prints, why that SHA is worth recording (it answers "which template version is this synced
against"), pinning deliberately for review or reproduction, and `GITHUB_TOKEN` for rate limits.

### B2 / B4 — nine files will surface as drift with no guidance

The drift checker walks every file in the template, so recent additions arrive as "please adopt"
suggestions. The checklist now lists them with what each depends on.

The row that matters is the last: **`tests/test_agents_md_allocation.py` is downstream-owned and
adoptable, but its `RELOCATION_TARGETS` names template paths** including
`docs/development/dependabot-automerge.md`. A project without that doc adopts a test that cannot
pass. That is the general hazard — downstream-owned is not the same as portable — and the table says
so explicitly, with "read the constants at the top of a test before adopting it".

### B3 — the ownership rule had moved on

The checklist described `TEMPLATE_OWNED_TEST_FILES` as tooling tests, naming
`test_check_template_updates.py`. Since #691/#733 the rule is **the test's target does not survive
configuration** (ADR-9017), and the list grew from 8 to 11 — adding `test_configure_paths.py`,
`test_readme_split.py` and `test_downstream_test_retention.py`, none of which are tooling tests in
the old sense.

It also now states the converse, which is the half that costs a project real coverage if missed: the
`tools/doit/` and `tools/hooks/` tests **are** yours to adopt, because that code ships to and runs
in your project (#731).

## Testing

- [x] All existing tests pass
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**Every claim was checked against the source, not against the issue:**

| claim | verified against |
| :--- | :--- |
| the printed pin line and its 12-char SHA | `bootstrap.py:89` |
| `PYPROJECT_TEMPLATE_REF`, `GITHUB_TOKEN` | their `os.environ` reads at `bootstrap.py:46,65` |
| 11 template-owned entries, 3 of them non-tooling | `tools/pyproject_template/utils.py` |
| all nine drift files exist | the working tree |

No test added: these describe an external mechanism (`bootstrap.py` running against GitHub) and a
future sync's contents, neither of which CI can assert.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [ ] I have added tests — N/A, documentation of an external mechanism
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**Remaining on #749: PR 4 — D1**, the last item. `tools/doit/git.py` enumerates three
`pre-commit install` actions, and `commit-msg` is not among them; it works only because #741 added
`default_install_hook_types`, which makes the first line install all four. The other two lines are
now redundant *and* misleading about what the hook set is. It is code rather than docs, so it
travels separately.
