### PR TITLE
docs: stop the workflow samples teaching mutable action tags

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -643,8 +643,7 @@ jobs:
     permissions:
       id-token: write  # Required for trusted publishing
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      # checkout + uv setup, SHA-pinned — see .github/workflows/ci.yml
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
 ```

--- a/docs/development/ci-cd-testing.md
+++ b/docs/development/ci-cd-testing.md
@@ -104,69 +104,23 @@ When a Python version starts failing CI:
 
 ## Pipeline Details (GitHub Actions)
 
-### Recommended Workflow Structure
+### The pipeline that ships
 
-Create `.github/workflows/tests.yml`:
+`ci.yml` is the pipeline. It is not a starting point to copy — it is the workflow this template
+installs, and it already does what a hand-rolled `tests.yml` would:
 
-```yaml
-name: Tests
+| | |
+| :--- | :--- |
+| **Matrix** | derived from `.github/python-versions.json` via `.github/actions/python-versions`, not hardcoded — so a version policy change moves one file |
+| **Platforms** | `ubuntu-latest`, `windows-latest`, `macos-latest` |
+| **Checks** | `doit` tasks (`format_check`, `lint`, `type_check`, `test`), so CI and a local run cannot diverge |
+| **Coverage** | `package_name` **and** `tools/`, gated by `fail_under` in `pyproject.toml` |
+| **Actions** | pinned to commit SHAs with a `# vX.Y.Z` comment (see [Action pinning](#action-pinning-and-workflow-permissions)) |
 
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.14"]  # Bookend strategy: oldest + newest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v1
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          uv sync --dev
-
-      - name: Run format check
-        run: uv run doit format_check
-
-      - name: Run linter
-        run: uv run doit lint
-
-      - name: Run type checker
-        run: uv run doit type_check
-        continue-on-error: true  # Optional: make non-blocking
-
-      - name: Run tests with coverage
-        run: uv run pytest --cov=src --cov-report=xml --cov-report=html
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.12'
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: true
-
-      - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.12'
-        with:
-          name: coverage-report
-          path: htmlcov/
-```
+Read `.github/workflows/ci.yml` for the current definition. This page previously carried a ~60-line
+`tests.yml` sample to copy; it drifted from the real file in every dimension above — hardcoded
+versions, raw `pytest` instead of `doit`, and mutable action tags this project's own tests forbid
+(#772). A second pipeline alongside `ci.yml` was never the intent.
 
 ### Pipeline Jobs
 
@@ -176,9 +130,7 @@ jobs:
 code-quality:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v1
+    # checkout + uv setup, SHA-pinned — see .github/workflows/ci.yml
     - name: Install dependencies
       run: uv sync --dev
     - name: Format check
@@ -196,9 +148,7 @@ code-quality:
 security:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v1
+    # checkout + uv setup, SHA-pinned — see .github/workflows/ci.yml
     - name: Install security tools
       run: uv sync --extra security
     - name: Run security audit
@@ -218,11 +168,8 @@ docs:
   needs: setup
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-      with:
-        python-version: ${{ needs.setup.outputs.newest }}
-    - uses: astral-sh/setup-uv@v7
+    # checkout, setup-python (at needs.setup.outputs.newest) and uv setup —
+    # all SHA-pinned; see .github/workflows/ci.yml for the current pins
     - name: Install dependencies
       run: uv sync --all-extras --dev
     - name: Build documentation
@@ -367,16 +314,18 @@ addopts = [
 
 ### PR Comments
 
-Add coverage comments to PRs using GitHub Actions:
+This template does **not** post coverage comments on PRs, and no workflow here uses a
+coverage-comment action. Coverage is reported by `doit coverage` locally and by the CI job's
+output; the gate is `fail_under` in `pyproject.toml`.
 
-```yaml
-- name: Coverage comment
-  uses: py-cov-action/python-coverage-comment-action@v3
-  with:
-    GITHUB_TOKEN: ${{ github.token }}
-    MINIMUM_GREEN: 80
-    MINIMUM_ORANGE: 70
-```
+If you add one to your own project, pin it to a commit SHA like every other external action — see
+[Action pinning](#action-pinning-and-workflow-permissions). A previous version of this page
+suggested `py-cov-action/python-coverage-comment-action@v3`, which was both unused here and
+unpinned (#772).
+
+Related: PRs no longer receive an automated benchmark regression comment either — that required
+`contents: write` on the pull-request path and was removed with it. The benchmark still runs and
+uploads its JSON.
 
 ## Local Development Workflow
 

--- a/docs/development/release-and-automation.md
+++ b/docs/development/release-and-automation.md
@@ -645,9 +645,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v1
+      # checkout + uv setup, SHA-pinned — see .github/workflows/ci.yml
       - name: Run security audit
         run: uv run doit audit
       - name: Run bandit scan

--- a/tests/test_workflow_action_pinning.py
+++ b/tests/test_workflow_action_pinning.py
@@ -134,3 +134,67 @@ def test_the_pin_check_rejects_a_mutable_ref() -> None:
     assert not SHA.match("release/v1")
     assert not SHA.match("3d3c42e5aac5ba805825da76410c181273ba90b")  # 39 chars
     assert SHA.match("3d3c42e5aac5ba805825da76410c181273ba90b1")
+
+
+# --- Documentation samples are held to the same rule (#772) ----------------
+#
+# The workflows were pinned by #695 and this module has enforced it since. The
+# docs were not covered, and drifted freely: 18 `uses: …@v4`-style tags across
+# three pages, including a ~60-line `tests.yml` sample that told a reader to
+# build a second, unpinned pipeline alongside `ci.yml`. `ci-cd-testing.md`
+# stated the pinning rule correctly at one heading and violated it ninety lines
+# earlier in the same file.
+#
+# A sample is copied more often than it is read, so an unpinned one hands the
+# exposure this rule removes to every project that follows the docs.
+
+DOCS_DIR = REPO_ROOT / "docs"
+YAML_FENCE = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+
+
+def _documented_uses() -> list[tuple[Path, str, str]]:
+    """Return (file, action, ref) for every `uses:` inside a docs yaml fence."""
+    entries: list[tuple[Path, str, str]] = []
+    for path in sorted(DOCS_DIR.rglob("*.md")):
+        for fence in YAML_FENCE.findall(path.read_text(encoding="utf-8")):
+            for line in fence.splitlines():
+                match = USES.match(line)
+                if not match:
+                    continue
+                action = match.group("action").strip("'\"")
+                if action.startswith("./"):
+                    continue
+                entries.append((path, action, match.group("ref")))
+    return entries
+
+
+def test_documented_samples_are_sha_pinned() -> None:
+    """A sample teaching `@v4` teaches the pattern this repo forbids."""
+    unpinned = [
+        f"{path.relative_to(REPO_ROOT)} {action}@{ref}"
+        for path, action, ref in _documented_uses()
+        if not SHA.match(ref) and _base_repo(action) not in PINNING_EXEMPT
+    ]
+    assert not unpinned, (
+        "documentation samples name actions on mutable refs:\n  "
+        + "\n  ".join(unpinned)
+        + "\nPin them, or elide the step and point at .github/workflows/ci.yml — a sample "
+        "that cannot drift beats one guarded against drifting (#772)."
+    )
+
+
+def test_the_docs_scanner_reads_something() -> None:
+    """Guard against the assertion above passing on an empty scan."""
+    entries = _documented_uses()
+    assert entries, (
+        "no `uses:` lines found in any docs yaml fence. If the samples were removed "
+        "entirely that is fine — delete this test rather than leaving it green and blind."
+    )
+
+
+def test_exempt_actions_are_exempt_in_docs_too() -> None:
+    """The docs may show an exempt action on its documented ref, as the workflows do."""
+    documented = {action for _, action, _ in _documented_uses()}
+    for action in documented:
+        if _base_repo(action) in PINNING_EXEMPT:
+            assert PINNING_EXEMPT[_base_repo(action)], "an exemption must carry its reason"


### PR DESCRIPTION
## Description

Three docs shipped GitHub Actions samples on **mutable tags** — 18 of them, including
`astral-sh/setup-uv@v1` while `ci.yml` pins `v10.0.1`. That is the pattern
`tests/test_workflow_action_pinning.py` exists to forbid; it went unnoticed because the test scans
`.github/workflows/` and `.github/actions/` only.

`ci-cd-testing.md` **contradicted itself**: it states the rule correctly under *Action pinning and
workflow permissions*, with a real SHA, and violated it ninety lines earlier in the same file.

A sample is copied more often than it is read, so an unpinned one hands the exposure #695 removed
from this repo to every project that follows the docs.

## Related Issue

Addresses #772

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Changes Made

### Direction 2: stop shipping a parallel pipeline

The issue offered pin-and-guard or stop-shipping. **Stop-shipping**, because samples that cannot
drift beat samples guarded against drifting.

`### Recommended Workflow Structure` told the reader to create `.github/workflows/tests.yml` — a
file this repo does not have and does not need. Its ~60 lines duplicated `ci.yml` while diverging
from it in every dimension:

| the sample | `ci.yml` |
| :--- | :--- |
| `python-version: ["3.12", "3.14"]` hardcoded | derived from `.github/python-versions.json` |
| `uv run pytest --cov=src` | `doit` tasks, so CI and a local run cannot diverge |
| `actions/checkout@v4`, `setup-uv@v1` | SHA-pinned with `# vX.Y.Z` comments |

Replaced with a table of what `ci.yml` actually does and a pointer to it.

### Remaining samples

Repeated checkout/setup boilerplate becomes one comment naming the real workflow. That removes the
rest of the mutable tags and stops those samples going stale on the parts nobody was reading.

### Two things found while editing, neither in the issue

1. **`### PR Comments` recommended `py-cov-action/python-coverage-comment-action@v3`** — unpinned,
   and used by no workflow here. **Removed rather than pinned:** pinning would have preserved a
   different wrong thing, a capability the template advertises and does not have. The section now
   says so, and records that benchmark regression comments went away with `contents: write` too.
2. **My first elision orphaned a `with:` block**, producing invalid YAML. Caught by parsing every
   fenced `yaml` block in `docs/`, which nothing else does. Two fences elsewhere
   (`TABLE_OF_CONTENTS.md`, `AI_SETUP.md`) also fail to parse — both predate this change and are
   untouched.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

The guard extends `test_workflow_action_pinning.py` to docs yaml fences, **reusing the same `SHA`
matcher and `PINNING_EXEMPT` table** — so `pypa/gh-action-pypi-publish@release/v1` stays legal in a
sample exactly as it is in the workflows, since PyPA documents that ref for trusted publishing. One
rule, one exemption list, two scan targets.

| test | fails when |
| :--- | :--- |
| `test_documented_samples_are_sha_pinned` | a sample names an action on a mutable ref |
| `test_the_docs_scanner_reads_something` | the scan finds no `uses:` at all, so the assertion cannot pass blind |
| `test_exempt_actions_are_exempt_in_docs_too` | an exemption appears without its recorded reason |

Verified by mutation: re-adding a single `- uses: actions/checkout@v4` to a sample turns
`test_documented_samples_are_sha_pinned` red.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**One judgment worth a reviewer's eye:** removing the coverage-comment suggestion outright rather
than pinning it. It advertised something the template does not do, so the pinned version would still
have been wrong — just harder to notice.

**Not done here, though the issue mentions it:** the pinning rule is still explained only in
`ci-cd-testing.md` and in the test's docstring. Now that the samples cannot violate it, that is a
smaller gap than it was; say the word if you want it surfaced somewhere a workflow author is more
likely to land.

**Still open from the same review:** #773 (four stale references) and #774 (the hole in the
matrix-count guard).
