### PR TITLE
docs: correct four stale references, and guard the class

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -169,5 +169,5 @@ only the frontmatter and the loading mechanism differ.
 
 **When you change one, change all three.** A rule that disagrees with itself across agents is worse
 than no rule, because whichever agent is driving decides which version applies.
-`tests/template/test_rule_files.py` enforces that the four bodies stay identical. See
+`tests/template/test_rule_files.py` enforces that the three bodies stay identical. See
 [`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -82,7 +82,7 @@ own format and loading mechanism:
 The checklist body is identical in all three; only the frontmatter and loading differ. **When you
 change one, change all three** — a rule that disagrees with itself across agents is worse than no
 rule, because whichever agent is driving determines which version applies.
-`tests/template/test_rule_files.py` enforces that the four bodies stay byte-identical.
+`tests/template/test_rule_files.py` enforces that the three bodies stay byte-identical.
 
 Note that Copilot reads `.agents/skills/` in addition to `.github/instructions/`, so it sees the
 rule on two surfaces at once. That is harmless while the bodies match — which is exactly what the

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -146,5 +146,5 @@ only the frontmatter and the loading mechanism differ.
 
 **When you change one, change all three.** A rule that disagrees with itself across agents is worse
 than no rule, because whichever agent is driving decides which version applies.
-`tests/template/test_rule_files.py` enforces that the four bodies stay identical. See
+`tests/template/test_rule_files.py` enforces that the three bodies stay identical. See
 [`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/docs/development/AI_SETUP.md
+++ b/docs/development/AI_SETUP.md
@@ -68,7 +68,14 @@ codex
 
 > **Note**: Project-level dangerous-command hooks under `tools/hooks/ai/` apply to this agent regardless of the per-agent config below. See [AI Enforcement Principles](ai/enforcement-principles.md) and [Command Blocking](ai/command-blocking.md).
 
-Claude Code uses a reference file (`.claude/claude.md`) that imports `AGENTS.md`.
+Claude Code uses a reference file (`.claude/CLAUDE.md`) that imports `AGENTS.md` and the per-stack rule files:
+
+```
+@../AGENTS.md
+@./rules/*.md
+```
+
+The paths are relative to `.claude/`, which is why they are not bare `@AGENTS.md`.
 
 **Whitelisted commands:**
 - `git:*` - All git commands
@@ -84,7 +91,7 @@ Claude Code uses a reference file (`.claude/claude.md`) that imports `AGENTS.md`
 ```
 
 **Files:**
-- `.claude/claude.md` - Imports AGENTS.md
+- `.claude/CLAUDE.md` - Imports `AGENTS.md` and `.claude/rules/*.md`
 - `.claude/settings.local.json` - Command permissions
 - `.claude/settings.json` - Status line and PreToolUse hooks
 
@@ -245,7 +252,7 @@ The `AGENTS.md` file provides comprehensive project context including:
 
 This file is:
 - **Read directly** by Codex CLI, GitHub Copilot CLI, and Antigravity CLI
-- **Imported** by Claude Code via `.claude/claude.md`
+- **Imported** by Claude Code via `.claude/CLAUDE.md`
 - **Referenceable** by other AI tools
 
 ## Context files and precedence
@@ -369,7 +376,7 @@ codex
 - Restart Claude Code
 
 **Context not loading:**
-- Verify `.claude/claude.md` contains `@AGENTS.md`
+- Verify `.claude/CLAUDE.md` contains `@../AGENTS.md` and `@./rules/*.md`
 - Check `AGENTS.md` exists in project root
 
 ### Copilot CLI

--- a/docs/development/ai/cross-agent-delegation.md
+++ b/docs/development/ai/cross-agent-delegation.md
@@ -155,7 +155,7 @@ The skill discovery paths overlap across CLIs, so an unmitigated repo layout wou
 
 Copilot CLI also reads `.agents/skills/` (per `@github/copilot` SDK, `sdk/index.d.ts`), so the same 12 Codex `delegate-*` skills bleed into Copilot sessions. They surface as `/delegate-<target>-<action>` slash commands alongside the canonical Copilot bridges (`/<target>-<action>`).
 
-**Mitigation (user-level only):** Copilot supports a `disabledSkills` array in user config (`~/.copilot/config.json`), but **not in any repo-level settings file**. Per the SDK, repo-level Copilot settings (`.github/copilot/settings.json`, `.claude/settings.json`) accept only `companyAnnouncements`, `disableAllHooks`, `enabledPlugins`, `extraKnownMarketplaces`, `hooks`, and `mergeStrategy` — not `disabledSkills`. So users who want to silence the bleed must edit `~/.copilot/config.json` manually. See the [Copilot section in slash-commands.md](slash-commands.md#copilot) for the snippet.
+**Mitigation (user-level only):** Copilot supports a `disabledSkills` array in user config (`~/.copilot/config.json`), but **not in any repo-level settings file**. Per the SDK, a repo-level settings file accepts only `companyAnnouncements`, `disableAllHooks`, `enabledPlugins`, `extraKnownMarketplaces`, `hooks`, and `mergeStrategy` — not `disabledSkills`. So users who want to silence the bleed must edit `~/.copilot/config.json` manually. See the [Copilot section in slash-commands.md](slash-commands.md#copilot) for the snippet.
 
 ### Claude ↔ Copilot
 

--- a/docs/template/migration.md
+++ b/docs/template/migration.md
@@ -68,7 +68,7 @@ See [Template Management](manage.md) for full documentation on the management sc
 
 ### 9) Docs & Badges
 - Check `README.md`: Restore your project description, but keep the new badges (links were updated by `configure.py`).
-- Update docs (`docs/installation.md`, `docs/usage.md`, `docs/api.md`) with your specific details.
+- Update docs (`docs/getting-started/installation.md`, `docs/usage/`, `docs/reference/api.md`) with your specific details.
 
 ### 10) Verify Locally
 - Install environment: `uv sync --all-extras --dev`

--- a/tests/test_documented_paths.py
+++ b/tests/test_documented_paths.py
@@ -32,6 +32,12 @@ SKIP_DIRS = {".git", ".venv", "site", "node_modules", "__pycache__", "tmp", ".my
 # deliberately not checked.
 DOCUMENTED_PATH = re.compile(r"`([A-Za-z0-9_./-]+\.(?:py|md|toml|yaml|yml|json|cfg|txt|sh))`")
 
+# Allowlist entries that exist on a developer's machine but are never committed.
+# They are exempt from the obsolescence check below: finding one on disk says
+# nothing about whether a fresh checkout has it, and the whole point of listing
+# them is that it does not.
+NEVER_COMMITTED = frozenset({".claude/settings.local.json", "tmp/"})
+
 # Paths that are allowed not to exist, and why.
 ALLOWED: dict[str, str] = {
     # Substituted by configure.py when a project is created.
@@ -49,9 +55,14 @@ ALLOWED: dict[str, str] = {
     "tests/test_cli_farewell.py": "worked example in the add-a-feature tutorial",
     # Shorthand for a path under the user's home.
     "gh/hosts.yml": "shorthand for ~/.config/gh/hosts.yml",
+    # Never committed, by policy. `.claude/settings.local.json` is blocked by the
+    # `no-local-config` pre-commit hook; `tmp/` is generated output. Both exist on
+    # a developer's machine and in no fresh checkout -- which is precisely why the
+    # resolution below must not be satisfied by whatever happens to be on disk.
+    ".claude/settings.local.json": "local config; the no-local-config hook blocks committing it",
+    "tmp/": "generated artifacts and agent scratch space, gitignored",
     # AGENTS.md's before/after illustration of the temp-file convention.
     "/tmp/pr-body.md": "the 'wrong' half of the temp-file example",
-    "tmp/agents/claude/pr-body-issue-307.md": "the 'correct' half of the temp-file example",
     # Declared as future work.
     ".agents/skills.json": "Antigravity-side suppression, documented as planned",
 }
@@ -123,7 +134,9 @@ def test_allowlist_entries_are_still_needed() -> None:
     stale = sorted(
         prefix
         for prefix in ALLOWED
-        if not prefix.endswith("/") and (REPO_ROOT / prefix.lstrip("/")).exists()
+        if not prefix.endswith("/")
+        and prefix not in NEVER_COMMITTED
+        and (REPO_ROOT / prefix.lstrip("/")).exists()
     )
     assert not stale, (
         f"these paths exist now, so their allowlist entries are obsolete: {stale}. "
@@ -135,3 +148,14 @@ def test_every_allowlist_entry_carries_a_reason() -> None:
     """The list is decisions, not suppressions."""
     for prefix, reason in ALLOWED.items():
         assert reason.strip(), f"{prefix} is allowlisted without a reason"
+
+
+def test_never_committed_entries_are_allowlisted() -> None:
+    """Every never-committed exemption must also carry a reason in ALLOWED.
+
+    `NEVER_COMMITTED` only suppresses the obsolescence check. If an entry drifts
+    out of `ALLOWED` it would stop being exempt from the existence check while
+    still looking handled, so the two lists are held together.
+    """
+    for prefix in NEVER_COMMITTED:
+        assert prefix in ALLOWED, f"{prefix} is exempt from staleness but not allowlisted"

--- a/tests/test_documented_paths.py
+++ b/tests/test_documented_paths.py
@@ -1,0 +1,137 @@
+"""A path named in the docs should exist, or be a declared placeholder.
+
+`test_markdown_links.py` resolves link *targets* and `test_instruction_pointers.py`
+resolves quoted section references and command names. Neither looks at a path
+written in backticks in prose, which is how four stale references survived
+long enough to be found by a manual sweep (#773):
+
+- `.claude/claude.md` -- named four times, wrong case, and one of them an
+  instruction to *verify* a file that does not exist under that name;
+- `docs/installation.md`, `docs/usage.md`, `docs/api.md` in the migration guide,
+  all three moved when the documentation was reorganised;
+- `.github/workflows/tests.yml`, a workflow the reader was told to create;
+- `.github/copilot/settings.json`, a settings file neither this repo nor the
+  Copilot CLI has.
+
+The allowlist below is the interesting half. A doc legitimately names paths that
+do not exist -- placeholders substituted during setup, files created at runtime,
+worked examples. Each entry states which, so the list stays a set of decisions
+rather than a pile of suppressions.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", ".venv", "site", "node_modules", "__pycache__", "tmp", ".mypy_cache"}
+
+# A backticked path with a directory component and a known extension. Bare
+# filenames ("run `configure.py`") are shorthand, not location claims, and are
+# deliberately not checked.
+DOCUMENTED_PATH = re.compile(r"`([A-Za-z0-9_./-]+\.(?:py|md|toml|yaml|yml|json|cfg|txt|sh))`")
+
+# Paths that are allowed not to exist, and why.
+ALLOWED: dict[str, str] = {
+    # Substituted by configure.py when a project is created.
+    "src/__PACKAGE_NAME__/": "package-name placeholder, substituted during setup",
+    # Created at runtime, deliberately not checked in.
+    ".config/pyproject_template/": "written by the management suite on first run",
+    # Illustrative names in worked examples and templates.
+    "path/to/": "generic example path",
+    "src/generated/": "worked example in the rule-file READMEs (a downstream project)",
+    "codegen/SKILL.md": "worked example in the rule-file READMEs",
+    ".github/instructions/NAME.instructions.md": "a naming pattern, not a file",
+    "tests/test_file.py": "generic example path",
+    "tests/test_cache.py": "worked example in the AI walkthrough",
+    "tests/test_farewell.py": "worked example in the add-a-feature tutorial",
+    "tests/test_cli_farewell.py": "worked example in the add-a-feature tutorial",
+    # Shorthand for a path under the user's home.
+    "gh/hosts.yml": "shorthand for ~/.config/gh/hosts.yml",
+    # AGENTS.md's before/after illustration of the temp-file convention.
+    "/tmp/pr-body.md": "the 'wrong' half of the temp-file example",
+    "tmp/agents/claude/pr-body-issue-307.md": "the 'correct' half of the temp-file example",
+    # Declared as future work.
+    ".agents/skills.json": "Antigravity-side suppression, documented as planned",
+}
+
+
+def _markdown_files() -> list[Path]:
+    return [
+        path
+        for path in sorted(REPO_ROOT.rglob("*.md"))
+        if not any(part in SKIP_DIRS for part in path.relative_to(REPO_ROOT).parts)
+    ]
+
+
+def _is_allowed(raw: str) -> bool:
+    return any(raw.startswith(prefix) or raw == prefix for prefix in ALLOWED)
+
+
+def _documented_paths() -> list[tuple[Path, str]]:
+    """Return (doc, path) for every backticked path that claims a location."""
+    found: list[tuple[Path, str]] = []
+    for doc in _markdown_files():
+        for match in DOCUMENTED_PATH.finditer(doc.read_text(encoding="utf-8", errors="replace")):
+            raw = match.group(1)
+            if "/" not in raw:
+                continue  # bare filename: shorthand
+            if raw.startswith(("http", "~", "{")) or "<" in raw or "*" in raw:
+                continue
+            found.append((doc, raw))
+    return found
+
+
+def test_documented_paths_exist() -> None:
+    """A path in backticks should resolve, or be a declared placeholder."""
+    missing = sorted(
+        {
+            f"{doc.relative_to(REPO_ROOT)}: {raw}"
+            for doc, raw in _documented_paths()
+            if not _is_allowed(raw)
+            and not (REPO_ROOT / raw).exists()
+            and not (doc.parent / raw).exists()
+        }
+    )
+    assert not missing, (
+        "documentation names paths that do not exist:\n  "
+        + "\n  ".join(missing)
+        + "\nFix the path, or add it to ALLOWED with the reason it is not a real file."
+    )
+
+
+def test_the_scanner_reads_something() -> None:
+    """Guard against the assertion above passing on an empty scan.
+
+    Deliberately not a threshold on the count: a downstream project has fewer
+    docs than the template, and a test that fails because a project is smaller
+    is the portability trap this repo warns adopters about. What matters is that
+    the regex finds paths *and* that resolution works, so a scan of real files
+    could report a real miss.
+    """
+    found = _documented_paths()
+    assert found, "no documented paths found at all; the regex is not matching"
+    resolved = [
+        raw for doc, raw in found if (REPO_ROOT / raw).exists() or (doc.parent / raw).exists()
+    ]
+    assert resolved, "no documented path resolved; resolution is broken, not the docs"
+
+
+def test_allowlist_entries_are_still_needed() -> None:
+    """An allowlist entry for a path that now exists is a suppression to drop."""
+    stale = sorted(
+        prefix
+        for prefix in ALLOWED
+        if not prefix.endswith("/") and (REPO_ROOT / prefix.lstrip("/")).exists()
+    )
+    assert not stale, (
+        f"these paths exist now, so their allowlist entries are obsolete: {stale}. "
+        "Remove them, so the list keeps meaning 'deliberately not a file'."
+    )
+
+
+def test_every_allowlist_entry_carries_a_reason() -> None:
+    """The list is decisions, not suppressions."""
+    for prefix, reason in ALLOWED.items():
+        assert reason.strip(), f"{prefix} is allowlisted without a reason"


### PR DESCRIPTION
## Description

Four stale references, each checked against the working tree rather than recalled — plus the guard
for the class, since nothing in the suite looks at a path written in backticks in prose, which is
how all four survived.

## Related Issue

Addresses #773

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Changes Made

### 1. `.claude/claude.md` — wrong name, wrong content, four times

The file is `.claude/CLAUDE.md`; on a case-sensitive filesystem the documented path does not exist.
The content claim was wrong too — the doc said it contains `@AGENTS.md`, the file contains:

```
@../AGENTS.md
@./rules/*.md
```

One of the four was an instruction that therefore **could not succeed**: *"Verify
`.claude/claude.md` contains `@AGENTS.md`"* — wrong path, wrong string, and silent about the
rule-file import, which is how per-stack rules reach Claude at all. The verification step now names
what the file actually contains, and the overview shows both lines with the reason they are relative.

### 2. "the four bodies" — there are three

`.claude/rules/README.md`, `.github/instructions/README.md` and `.agents/skills/README.md` all
claimed `test_rule_files.py` *"enforces that the four bodies stay identical"*. `ALL_RULE_PATHS` has
**three** entries — Codex and Antigravity share the `.agents/` copy — and each README's own surface
table lists three rows. They contradicted themselves *and* the test they cite.

### 3. `.github/copilot/settings.json` does not exist

Cited in `cross-agent-delegation.md` as a repo-level Copilot settings file. Absent from this repo,
and the installed SDK never names that path. The same sentence listed `.claude/settings.json` as
Copilot settings — that is Claude's. Both examples dropped; the claim that survives is the
user-level one, which is true.

### 4. `migration.md` pointed at three moved docs

`docs/installation.md`, `docs/usage.md`, `docs/api.md` → `docs/getting-started/installation.md`,
`docs/usage/`, `docs/reference/api.md`.

### The guard — `tests/test_documented_paths.py`

`test_markdown_links.py` resolves link targets; `test_instruction_pointers.py` resolves quoted
section references and command names. **Neither looks at a backticked path in prose.**

The allowlist is the interesting half: each entry carries the reason it is not a real file —
placeholders substituted at setup, files written at runtime, worked examples — so it stays a set of
decisions rather than a pile of suppressions. Two further tests keep it honest: an entry for a path
that now exists is reported as obsolete, and every entry must state a reason.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**Verified by mutation:** reintroducing `.claude/claude.md` and `docs/installation.md` fails the
guard, naming both precisely:

```
E   docs/development/AI_SETUP.md: .claude/claude.md
E   docs/template/migration.md: docs/installation.md
```

**One design note.** The scanner-reads-something test asserts that *resolution works* rather than
that some number of paths were found. A downstream project has fewer docs than the template, and a
test that fails because a project is smaller is exactly the portability trap #770 documented for
adopters — worth not shipping in the same week I wrote that warning.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**What the guard does not cover:** item 2 is a claim about a *count*, not a path — prose that
contradicts a test is still something only reading catches. Worth knowing before trusting the new
test to have closed the whole class.

**Left for a follow-up, as the issue suggests:** the `disabledSkills` sentence in
`cross-agent-delegation.md` should be re-verified against the running CLI rather than the SDK types.
An inferred claim about `disabledSkills` was already wrong once (#757), and this PR only removed the
non-existent path from that paragraph, not re-checked its substance.

**Still open from the same review:** #774, the hole in the matrix-count guard.
