### PR TITLE
fix: widen the matrix-count guard past the shape it missed

### DIFF
--- a/.copilot/README.md
+++ b/.copilot/README.md
@@ -55,7 +55,7 @@ file structure, and a worked example.
 
 ## See Also
 
-- `.github/skills/<target>-<action>/SKILL.md` — Copilot-host workflow skills (16 files). `.github/skills/` is used (instead of `.claude/skills/`) because it's the only Copilot project skill path that Claude does not also read — avoids surfacing duplicate slash commands in Claude.
+- `.github/skills/<target>-<action>/SKILL.md` — Copilot-host workflow skills: one self-action skill per action, plus one bridge per (target, action) pair. `.github/skills/` is used (instead of `.claude/skills/`) because it's the only Copilot project skill path that Claude does not also read — avoids surfacing duplicate slash commands in Claude.
 - `.agents/skills/` — interoperable Codex skill path, also read by Copilot
 - `.claude/agents/implement-worker.md` — implement-worker subagent definition
 - `.github/hooks/copilot-hooks.json` — dangerous command hook wiring

--- a/tests/test_delegation_matrix.py
+++ b/tests/test_delegation_matrix.py
@@ -145,8 +145,14 @@ _PROSE_ONLY_DOCS = (
     "AGENTS.md",
 )
 
+# Nouns a matrix count is written with. `distinct files` alone was too narrow:
+# `.copilot/README.md` carried "(16 files)" in a file this test already scanned,
+# and the guard was trusted to cover it (#774). Widened to the bare nouns, which
+# hits that line and nothing else in _PROSE_ONLY_DOCS -- verified before landing,
+# because a pattern that matches ordinary prose would make the guard noise.
 _COUNT_IN_PROSE = re.compile(
-    r"\b\d+ (?:cells|distinct files|cross-agent bridges|delegation commands|"
+    r"\b\d+ (?:cells|files|entries|skills|bridges|commands|"
+    r"distinct files|cross-agent bridges|delegation commands|"
     r"self-action skills|delegate-\S+ skills)\b"
 )
 
@@ -217,3 +223,17 @@ def test_the_count_checks_detect_a_planted_error() -> None:
     assert _COUNT_IN_PROSE.search("plus 12 cross-agent bridges under .github/skills/"), (
         "the prose scan did not notice a written-out count"
     )
+    # The shape the pattern used to miss: a bare noun after the number. This
+    # exact string sat in .copilot/README.md, inside a file the scan covers,
+    # while the guard was believed to be holding it (#774).
+    assert _COUNT_IN_PROSE.search("Copilot-host workflow skills (16 files)"), (
+        "the prose scan still misses a bare '<n> files'"
+    )
+    # ...and the pattern must not fire on ordinary prose that happens to count
+    # something else, or the guard becomes noise rather than a signal.
+    for benign in (
+        "takes 1 to 3 minutes",
+        "Python 3.14 support",
+        "the 4 sources are listed above",
+    ):
+        assert not _COUNT_IN_PROSE.search(benign), f"false positive on {benign!r}"


### PR DESCRIPTION
## Description

#754 added `test_only_the_matrix_doc_states_counts` so a matrix count could not be written into
prose where nothing checks it. Its pattern required a qualifying noun — `\d+ distinct files`
matched, a bare `\d+ files` did not — so this line in `.copilot/README.md`, **inside a file the test
explicitly scans**, passed:

```
- `.github/skills/<target>-<action>/SKILL.md` — Copilot-host workflow skills (16 files).
```

The number was right. That is the point: it is the same state the five wrong counts were in before
#754 — accurate, in prose, and unguarded *while believed to be guarded*. A guard trusted more than
it deserves is worse than no guard, because it stops anyone looking.

## Related Issue

Addresses #774

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test improvement

## Changes Made

**Both halves, as the issue set out.**

1. **The line is now structural** — "one self-action skill per action, plus one bridge per (target,
   action) pair" — which is what #754 did everywhere else. The count belongs to
   `cross-agent-delegation.md`'s Matrix section and nowhere else.
2. **The pattern gains the bare nouns**: `files`, `entries`, `skills`, `bridges`, `commands`.

### The risk in widening, and what was done about it

The issue warned that widening has an opposite failure mode: a pattern matching ordinary prose makes
the guard noise rather than signal. So the noun set was **checked against all four scanned documents
before landing** — it hits the one known line and nothing else.

Three benign strings are pinned as cases so a later widening cannot quietly start matching prose:

```python
for benign in ("takes 1 to 3 minutes", "Python 3.14 support", "the 4 sources are listed above"):
    assert not _COUNT_IN_PROSE.search(benign)
```

…alongside the shape that was missed:

```python
assert _COUNT_IN_PROSE.search("Copilot-host workflow skills (16 files)")
```

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass; 56 matrix tests green.

**Verified by mutation in both directions:**

| mutation | result |
| :--- | :--- |
| narrow the pattern back to `cells` only | `test_the_count_checks_detect_a_planted_error` fails |
| restore `(16 files)` in `.copilot/README.md` | `test_only_the_matrix_doc_states_counts[.copilot/README.md]` fails |

The second is the one that matters — it is the check that should have caught this the first time,
and now does.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [ ] I have updated the documentation accordingly — N/A beyond the one line made structural
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**This closes the review that produced #772, #773 and #774.** All three are now merged or ready, and
the only remaining open issue is #93 (monorepo support), which predates the review.

Worth recording that two of the three findings were defects in guards I had written earlier the same
day — this one, and the portability trap in #773's guard that passed locally and failed all six CI
jobs. The pattern is consistent: a guard is easy to write so that it passes, and the work is in
proving it fails for the right reason. Every guard added since is mutation-tested for exactly that.
