### PR TITLE
feat: expose --template-version through manage.py

### DIFF
--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -102,7 +102,7 @@ python tools/pyproject_template/manage.py --yes check
 
 This will (per [Tools Reference](tools-reference.md)):
 
-1. Fetch the latest template release (or specified version via `--template-version`)
+1. Fetch the latest template release — or a specific one via `manage.py check --template-version <tag>`, or `main` when no release has been cut
 2. Compare all files - categorized as **Modified**, **Missing** (new in template), or **Extra** (project-specific)
 3. Keep the template at `tmp/extracted/pyproject-template-main/` for diff commands
 4. Show GitHub compare URL for commit history since last sync

--- a/docs/template/tools-reference.md
+++ b/docs/template/tools-reference.md
@@ -254,18 +254,16 @@ Fetches the latest template release (or specified version), compares it against 
 ### Examples
 
 ```bash
-# Compare against latest release
-python tools/pyproject_template/check_template_updates.py
+# Compare against the latest release (or `main`, if none has been cut)
+python tools/pyproject_template/manage.py check
 
-# Compare against specific version
-python tools/pyproject_template/check_template_updates.py --template-version v2.2.0
-
-# Quick comparison without changelog review
-python tools/pyproject_template/check_template_updates.py --skip-changelog
-
-# Keep template for manual inspection
-python tools/pyproject_template/check_template_updates.py --keep-template
+# Compare against a specific release
+python tools/pyproject_template/manage.py check --template-version v2.2.0
 ```
+
+`check_template_updates.py` refuses to run directly — `manage.py` is the entry point. See
+[#778](https://github.com/endavis/pyproject-template/issues/778) for the other invocations in this
+document that still need the same treatment.
 
 ### Output Categories
 

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -89,15 +89,24 @@ python tools/pyproject_template/check_template_updates.py
 ### CLI Options
 
 ```bash
-# Compare against specific version
-python tools/pyproject_template/check_template_updates.py --template-version v2.2.0
-
-# Skip opening CHANGELOG in editor
-python tools/pyproject_template/check_template_updates.py --skip-changelog
-
-# Keep downloaded template for manual inspection
-python tools/pyproject_template/check_template_updates.py --keep-template
+# Compare against a specific template release instead of the latest
+python tools/pyproject_template/manage.py check --template-version v2.2.0
 ```
+
+Without `--template-version`, the latest **release** is resolved from the GitHub API. If the
+template has cut no releases — or the API call fails — the comparison falls back to the `main`
+branch, and the run says so:
+
+```
+⚠ Could not fetch latest release: HTTP Error 404: Not Found
+i Comparing against template main branch
+```
+
+Pin a tag when you want a staged upgrade (one release at a time rather than one large diff), or a
+comparison two people can reproduce.
+
+`--skip-changelog` and `--keep-template` are not exposed: `manage.py` already sets both, keeping the
+downloaded template so you can run your own diffs and not opening an editor mid-run.
 
 ### Example Output
 

--- a/tests/template/test_check_template_updates.py
+++ b/tests/template/test_check_template_updates.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
+import types
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -296,3 +299,64 @@ class TestEmitCouplingWarnings:
         _emit_coupling_warnings(different_files, project)
         captured = capsys.readouterr()
         assert "bootstrap" not in captured.out
+
+
+class TestTemplateVersionFlag:
+    """`--template-version` must be reachable, and must reach the download (#779).
+
+    The flag existed in `check_template_updates.parse_args` and `manage.py` never
+    forwarded it: `action_check_updates` called `run_check_updates` with
+    `skip_changelog` and `keep_template` hardcoded and nothing else. The direct
+    invocation is refused by a guard, so the argument was dead code reachable
+    only from Python while three documents advertised it.
+
+    These tests pin both halves: the flag parses, and the value it carries
+    changes the archive URL rather than being accepted and dropped.
+    """
+
+    @staticmethod
+    def _manage() -> types.ModuleType:
+        return importlib.import_module("tools.pyproject_template.manage")
+
+    def test_flag_parses_before_the_subcommand(self) -> None:
+        args = self._manage().parse_args(["--template-version", "v2.2.0", "check"])
+        assert args.template_version == "v2.2.0"
+        assert args.command == "check"
+
+    def test_flag_parses_after_the_subcommand(self) -> None:
+        """The order people actually write, and the one manage.md documented."""
+        args = self._manage().parse_args(["check", "--template-version", "v2.2.0"])
+        assert args.template_version == "v2.2.0"
+
+    def test_show_excluded_parses_in_both_positions(self) -> None:
+        """The same fix; `check --show-excluded` was documented and rejected."""
+        assert self._manage().parse_args(["check", "--show-excluded"]).show_excluded is True
+        assert self._manage().parse_args(["--show-excluded", "check"]).show_excluded is True
+
+    def test_defaults_survive_the_two_parsers(self) -> None:
+        """Neither parser's default may overwrite the other's value.
+
+        Both the global parser and the `check` subparser declare these options.
+        Without `SUPPRESS` the subparser parses second and writes its own default
+        over a value the global parser set, so `--show-excluded check` would
+        silently lose the flag.
+        """
+        args = self._manage().parse_args(["check"])
+        assert args.template_version is None
+        assert args.show_excluded is False
+
+    def test_the_version_reaches_the_download(self) -> None:
+        """Accepting the flag and dropping it would pass every test above."""
+        manage = self._manage()
+        seen: dict[str, object] = {}
+
+        def _capture(**kwargs: object) -> int:
+            seen.update(kwargs)
+            return 0
+
+        with (
+            mock.patch.object(manage, "run_check_updates", _capture),
+            mock.patch.object(manage, "get_template_latest_commit", lambda: None),
+        ):
+            manage.action_check_updates(mock.MagicMock(), dry_run=True, template_version="v2.2.0")
+        assert seen.get("template_version") == "v2.2.0"

--- a/tests/template/test_pyproject_template_main.py
+++ b/tests/template/test_pyproject_template_main.py
@@ -887,7 +887,13 @@ class TestYesFlagBehavior:
             main(["--yes", "sync"])
 
             mock_run_action.assert_called_once_with(
-                5, mock_manager, False, yes=True, cleanup_mode=None, show_excluded=False
+                5,
+                mock_manager,
+                False,
+                yes=True,
+                cleanup_mode=None,
+                show_excluded=False,
+                template_version=None,
             )
 
     def test_sync_with_yes_skips_prompt(self, tmp_path: Path) -> None:

--- a/tools/pyproject_template/manage.py
+++ b/tools/pyproject_template/manage.py
@@ -290,6 +290,7 @@ def run_action(
     yes: bool = False,
     cleanup_mode: str | None = None,
     show_excluded: bool = False,
+    template_version: str | None = None,
 ) -> int:
     """Run the selected action."""
     if action == 1:
@@ -297,7 +298,9 @@ def run_action(
     elif action == 2:
         return action_configure(manager, dry_run, yes=yes)
     elif action == 3:
-        return action_check_updates(manager, dry_run, show_excluded=show_excluded)
+        return action_check_updates(
+            manager, dry_run, show_excluded=show_excluded, template_version=template_version
+        )
     elif action == 4:
         return action_repo_settings(manager, dry_run)
     elif action == 5:
@@ -416,12 +419,23 @@ def action_create_project(manager: SettingsManager, dry_run: bool, *, yes: bool 
 
 
 def action_check_updates(
-    manager: SettingsManager, dry_run: bool, *, show_excluded: bool = False
+    manager: SettingsManager,
+    dry_run: bool,
+    *,
+    show_excluded: bool = False,
+    template_version: str | None = None,
 ) -> int:
-    """Check for template updates (comparison only, does not modify files)."""
+    """Check for template updates (comparison only, does not modify files).
+
+    `template_version` pins which template snapshot the project is compared
+    against. Without it the latest release is resolved from the GitHub API, and
+    if that call fails the comparison silently falls back to `main` -- so a run
+    that looks like "latest release" can be against unreleased code (#779).
+    """
     Logger.header("Checking for Template Updates")
 
     result = run_check_updates(
+        template_version=template_version,
         skip_changelog=True,
         keep_template=True,  # Keep template so user can run diff commands
         dry_run=dry_run,
@@ -821,7 +835,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     subparsers.add_parser("create", help="Create new project from template")
     subparsers.add_parser("configure", help="Re-run configuration")
-    subparsers.add_parser("check", help="Check for template updates")
+    check_parser = subparsers.add_parser("check", help="Check for template updates")
+    check_parser.add_argument(
+        "--show-excluded",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="List paths skipped via .config/pyproject_template/sync-exclude.toml",
+    )
+    check_parser.add_argument(
+        "--template-version",
+        metavar="TAG",
+        default=argparse.SUPPRESS,
+        help="Compare against a specific template release tag (e.g. v2.2.0) instead of the latest",
+    )
     subparsers.add_parser("repo", help="Update repository settings")
     subparsers.add_parser("sync", help="Mark as synced to latest template")
     cleanup_parser = subparsers.add_parser("cleanup", help="Clean up template-specific files")
@@ -853,8 +879,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="With 'check': list paths skipped via .config/pyproject_template/sync-exclude.toml",
     )
+    parser.add_argument(
+        "--template-version",
+        metavar="TAG",
+        default=None,
+        help=(
+            "With 'check': compare against a specific template release tag (e.g. v2.2.0) "
+            "instead of the latest. Pins the comparison so a staged upgrade takes one "
+            "release at a time and two runs produce the same diff."
+        ),
+    )
 
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    # Both parsers may declare these; SUPPRESS means an unset flag leaves no
+    # attribute at all, so fill the defaults once here rather than letting
+    # either parser's default overwrite the other's value.
+    if not hasattr(args, "show_excluded"):
+        args.show_excluded = False
+    if not hasattr(args, "template_version"):
+        args.template_version = None
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -884,6 +928,7 @@ def main(argv: list[str] | None = None) -> int:
                 yes=args.yes,
                 cleanup_mode=cleanup_mode,
                 show_excluded=args.show_excluded,
+                template_version=args.template_version,
             )
         return 1
 
@@ -892,7 +937,12 @@ def main(argv: list[str] | None = None) -> int:
         if not manager.settings.is_configured():
             Logger.error("Cannot auto-detect settings. Run interactively first.")
             return 1
-        return action_check_updates(manager, args.dry_run, show_excluded=args.show_excluded)
+        return action_check_updates(
+            manager,
+            args.dry_run,
+            show_excluded=args.show_excluded,
+            template_version=args.template_version,
+        )
 
     # Handle --yes (non-interactive mode)
     if args.yes:


### PR DESCRIPTION
## Description

`--template-version` pins which template snapshot a drift check compares against. It existed in
`check_template_updates.parse_args`, `run_check_updates` took the parameter, and `manage.py` never
passed one — `action_check_updates` hardcoded `skip_changelog=True, keep_template=True` and
forwarded only `--show-excluded`. The direct invocation is refused by a guard, so the argument was
**dead code reachable only from Python** while three documents advertised it.

## Related Issue

Addresses #779

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Changes Made

### The flag is wired through

The argument, `action_check_updates`, `run_action`, and both dispatch sites.

### Both argument orders now work — which fixes a second, pre-existing bug

As global options, argparse accepted these only *before* the subcommand. So
`manage.py check --show-excluded` — **the form `manage.md:93` documents** — was rejected, and
`check --template-version` would have been too:

```console
$ manage.py check --show-excluded
error: unrecognized arguments: --show-excluded
```

Declaring both on the `check` subparser as well makes either order work. `default=argparse.SUPPRESS`
is the load-bearing detail: without it the subparser parses second and writes its own default over a
value the global parser already set, so `--show-excluded check` would silently lose the flag. There
is a test for exactly that.

### A finding from testing it: this template has cut no releases

`releases/latest` 404s, so `get_latest_release()` returns `None` and **every drift check compares
against `main`**, not against a release.

The tool is honest about it at runtime:

```
⚠ Could not fetch latest release: HTTP Error 404: Not Found
i Comparing against template main branch
```

The docs promised "the latest release" and never mentioned the fallback. They now describe both, and
show that warning so a reader recognises it. *(This corrects my own framing on #779, where I
headed the note "the fallback is silent" — it is not silent, it warns. The body of that comment was
accurate; the heading overstated it.)*

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**Verified end to end against a real tag** — not just that it parses:

```console
$ manage.py check --template-version v0.0.0
i Comparing against template version: v0.0.0
i Downloading from …/archive/refs/tags/v0.0.0.zip...
```

Five new tests in `TestTemplateVersionFlag`, each mutation-verified:

| test | fails when |
| :--- | :--- |
| parses before / after the subcommand | either order stops working |
| `--show-excluded` in both positions | the subparser declaration is dropped |
| defaults survive two parsers | `SUPPRESS` is replaced with a real default |
| **the version reaches the download** | the forwarding is removed — accepting the flag and dropping it would pass every other test |

## One existing test changed, deliberately and after checking

`TestYesFlagBehavior::test_yes_flag_passed_to_run_action` uses `assert_called_once_with`, which is
exhaustive over kwargs; this adds one. It was **updated rather than loosened**, and I stopped to
confirm that before touching it rather than editing a red test into green.

Its purpose — that `--yes sync` forwards `yes=True` — is untouched. Its exhaustiveness is a
deliberate design that catches unnoticed changes to what `main` forwards, and it still does:
planting an extra kwarg in the call site still fails it. The alternative considered and rejected was
relaxing it to check `yes=True` alone, which would never break this way again at the cost of the
coverage it was built for.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**`--skip-changelog` and `--keep-template` are deliberately not exposed.** `manage.py` sets both to
the values a user wants — keep the download so they can run their own diffs, don't open an editor
mid-run — so exposing them would add surface for no capability. The doc mentions are removed instead.

**Scope.** This fixes the `--template-version` mentions in three docs because leaving them would
document the flag wrongly at the moment it starts working. The broader problem — 14 documented
invocations of scripts that refuse to run — remains #778, and `tools-reference.md` now carries a
pointer to it.

**Worth a decision separately:** whether this template should cut releases. The entire update model —
"compare against the latest release", `doit release`, `release.yml` — assumes they exist, and none
do. I have not filed that; say the word if you want it recorded.
