### PR TITLE
refactor: make a template version a commit SHA

### DIFF
--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -100,6 +100,7 @@ Complete index of all documentation, organized by audience and as a full alphabe
 - [ADR-9017: Template tooling and its tests are template-owned](decisions/9017-template-tooling-and-its-tests-are-template-owned.md)
 - [ADR-9018: AGENTS.md carries only shared, always-on instructions](decisions/9018-agentsmd-carries-only-shared-always-on-instructions.md)
 - [ADR-9019: The dangerous-command hook is a guardrail, not a security boundary](decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md)
+- [ADR-9020: A template version is a commit SHA](decisions/9020-a-template-version-is-a-commit-sha.md)
 - [ADR-NNNN: Title](decisions/adr-template.md)
 - [AI Agent Setup Guide](development/AI_SETUP.md) - Configure Claude, Copilot, Codex, and Antigravity for this project
 - [AI Agent Sync Checklist](template/ai-sync-checklist.md) - Step-by-step checklist for AI agents synchronizing downstream projects with pyproject-template

--- a/docs/decisions/9020-a-template-version-is-a-commit-sha.md
+++ b/docs/decisions/9020-a-template-version-is-a-commit-sha.md
@@ -1,0 +1,85 @@
+# ADR-9020: A template version is a commit SHA
+
+## Status
+Accepted
+
+## Decision
+**A template version is a commit SHA.** Not a release tag, and not a branch name.
+
+Both halves of the update path resolve to one:
+
+| mechanism | accepts | resolves to |
+| :--- | :--- | :--- |
+| `bootstrap.py --sync` | `PYPROJECT_TEMPLATE_REF` — tag, branch or SHA; defaults to `main` | a commit SHA, fetched once for every file |
+| `manage.py check --template-version` | a tag, a branch or a SHA; defaults to `main` | a commit SHA, one archive URL |
+
+Consequences of that single definition:
+
+1. **`main` is the default, stated rather than fallen into.** The template publishes no releases, so
+   `releases/latest` 404s. The drift checker used to reach `main` only by *failing* that lookup
+   first; now it names `main` as the default and says so.
+2. **`get_latest_release()` is removed.** With releases out of the model it is a dead path that
+   invites reintroducing the assumption.
+3. **One archive URL shape**: `/archive/{sha}.zip`, for every ref kind.
+4. **Resolution failure warns and continues** against the unresolved ref, matching
+   `bootstrap.resolve_ref`. Refusing to run a drift check because `api.github.com` is unreachable
+   trades a small consistency gain for a hard outage.
+5. **The flag keeps its name.** `--template-version` was exposed hours before this decision (#779);
+   renaming it to `--template-ref` twice in a day is churn for a cosmetic gain, and "version" is
+   what a consumer calls the thing regardless of its form.
+
+## Rationale
+Releases were assumed by half the machinery and have never existed. `git tag` shows one entry,
+`v0.0.0`, from the initial commit; `gh release list` is empty. So every drift check any downstream
+project has ever run compared against `main` — whatever was merged most recently, including
+half-finished sequences.
+
+The two mechanisms also disagreed. `ai-sync-checklist.md` runs `bootstrap --sync` as Phase 1 and the
+drift check as Phase 2; the first pinned a SHA and the second fetched the moving `main`, so **the
+tooling a project synced and the template it then diffed against could be different commits.** Any
+merge in the window landed in the gap, and fifteen PRs merged on the day this was found.
+
+**Why SHA rather than cutting releases.** Both were viable:
+
+- *Cut releases* would give consumers stable checkpoints and make staged upgrades possible
+  ("adopt v2.2.0, then v2.3.0"). It costs an ongoing cadence and a judgement each time about what
+  "ready" means for a template nobody installs as a package.
+- *SHA-based* costs nothing ongoing, matches what `bootstrap.py` already does after #694/#740, and
+  what the project already records: `TemplateState.commit` has stored a template commit SHA all
+  along. The identity was already half-adopted; this finishes it.
+
+The deciding factor is that `TemplateState.commit` exists. The repo had already chosen commits as
+the thing it remembers about the template; only the drift checker's *fetch* disagreed.
+
+Releases are not foreclosed. A tag is a ref, so `--template-version v2.2.0` keeps working if this
+project starts cutting them — the difference is that nothing *depends* on their existence.
+
+## Consequences
+- **Staged upgrades remain unavailable** until releases exist. A project long behind still gets one
+  large diff. This is the real cost of the decision and it is accepted: nothing in the template
+  offered staged upgrades before either, because there were no tags to stage between.
+- **Every drift check pins its own run.** Two runs against the same ref minutes apart can still
+  resolve to different commits if `main` moves; each run is internally consistent, which is what
+  `bootstrap.py` guarantees and no more.
+- **Phase 1 and Phase 2 still resolve independently**, so the window is narrowed rather than closed.
+  Closing it means Phase 1 handing Phase 2 its SHA — worth doing, deliberately not done here to keep
+  this change to the decision it records.
+- **`get_latest_release` disappears from the public surface** of `tools/pyproject_template`. It was
+  exported from `__init__.py`; a downstream that imported it directly breaks. Judged acceptable —
+  it returns `None` for this template in every case.
+- A downstream can now answer "which template version am I on" with the SHA `bootstrap.py` prints
+  and pass that same SHA to `manage.py check`. One identifier across the whole path.
+
+## Related Issues
+- Issue #781: the template has never cut a release, and half the update path assumed it had
+- Issue #779: `--template-version` was documented in three places and reachable from none — the flag
+  this decision gives a coherent meaning
+- Issue #694 / PR #740: `bootstrap.py` ref pinning, the half of the model that was already right
+- Issue #770: documented that pinning, and told users to record the SHA
+
+## Related Documentation
+- [Keeping Up to Date](../template/updates.md) — the consumer-facing description of what a run pins
+- [AI Sync Checklist](../template/ai-sync-checklist.md) — the two phases this decision aligns
+- [Template Tooling](../template/tools-reference.md) — `manage.py check` and its flags
+- [ADR-9018](9018-agentsmd-carries-only-shared-always-on-instructions.md) — the precedent for
+  recording an allocation rule rather than re-deciding it per issue

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -99,6 +99,7 @@ The Issue contains the full discussion; the ADR summarizes the outcome.
 | [9017](9017-template-tooling-and-its-tests-are-template-owned.md) | Template tooling and its tests are template-owned | Accepted |
 | [9018](9018-agentsmd-carries-only-shared-always-on-instructions.md) | AGENTS.md carries only shared, always-on instructions | Accepted |
 | [9019](9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md) | The dangerous-command hook is a guardrail, not a security boundary | Accepted |
+| [9020](9020-a-template-version-is-a-commit-sha.md) | A template version is a commit SHA | Accepted |
 
 ### Project-level ADRs (0001+)
 

--- a/docs/template/ai-sync-checklist.md
+++ b/docs/template/ai-sync-checklist.md
@@ -102,7 +102,7 @@ python tools/pyproject_template/manage.py --yes check
 
 This will (per [Tools Reference](tools-reference.md)):
 
-1. Fetch the latest template release — or a specific one via `manage.py check --template-version <tag>`, or `main` when no release has been cut
+1. Fetch the template at `main` — or at a specific tag, branch or commit SHA via `manage.py check --template-version <ref>` (ADR-9020)
 2. Compare all files - categorized as **Modified**, **Missing** (new in template), or **Extra** (project-specific)
 3. Keep the template at `tmp/extracted/pyproject-template-main/` for diff commands
 4. Show GitHub compare URL for commit history since last sync

--- a/docs/template/tools-reference.md
+++ b/docs/template/tools-reference.md
@@ -231,7 +231,7 @@ See [Migration Guide](migration.md) for detailed steps.
 
 ## check_template_updates.py
 
-Compare your project against the latest template version.
+Compare your project against a template commit — `main` by default (ADR-9020).
 
 ### Usage
 
@@ -254,10 +254,10 @@ Fetches the latest template release (or specified version), compares it against 
 ### Examples
 
 ```bash
-# Compare against the latest release (or `main`, if none has been cut)
+# Compare against `main` (the default)
 python tools/pyproject_template/manage.py check
 
-# Compare against a specific release
+# Compare against a specific tag, branch or commit SHA
 python tools/pyproject_template/manage.py check --template-version v2.2.0
 ```
 

--- a/docs/template/updates.md
+++ b/docs/template/updates.md
@@ -93,17 +93,18 @@ python tools/pyproject_template/check_template_updates.py
 python tools/pyproject_template/manage.py check --template-version v2.2.0
 ```
 
-Without `--template-version`, the latest **release** is resolved from the GitHub API. If the
-template has cut no releases — or the API call fails — the comparison falls back to the `main`
-branch, and the run says so:
+`--template-version` accepts a **tag, a branch, or a commit SHA**; the default is `main`. Whatever
+you give it is resolved to a commit before anything is downloaded, so a check runs against one
+fixed snapshot rather than a branch that can move underneath it:
 
 ```
-⚠ Could not fetch latest release: HTTP Error 404: Not Found
-i Comparing against template main branch
+i Comparing against template ref: main
+i Downloading from https://github.com/endavis/pyproject-template/archive/5853ced….zip...
 ```
 
-Pin a tag when you want a staged upgrade (one release at a time rather than one large diff), or a
-comparison two people can reproduce.
+That is the same identity `bootstrap.py` pins, so the SHA it prints can be passed straight to
+`manage.py check --template-version <sha>` to diff against exactly what you synced. See
+[ADR-9020](../decisions/9020-a-template-version-is-a-commit-sha.md).
 
 `--skip-changelog` and `--keep-template` are not exposed: `manage.py` already sets both, keeping the
 downloaded template so you can run your own diffs and not opening an editor mid-run.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
       - ADR-9017 Template ownership: decisions/9017-template-tooling-and-its-tests-are-template-owned.md
       - ADR-9018 Instruction allocation: decisions/9018-agentsmd-carries-only-shared-always-on-instructions.md
       - ADR-9019 Hook scope: decisions/9019-the-dangerous-command-hook-is-a-guardrail-not-a-security-boundary.md
+      - ADR-9020 Template version: decisions/9020-a-template-version-is-a-commit-sha.md
   - Reference:
       - API Reference: reference/api.md
   - Examples:

--- a/tests/template/test_check_template_updates.py
+++ b/tests/template/test_check_template_updates.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 import pytest
 
+from tools.pyproject_template import check_template_updates as ctu
 from tools.pyproject_template.check_template_updates import (
     _emit_coupling_warnings,
     compare_files,
@@ -360,3 +361,77 @@ class TestTemplateVersionFlag:
         ):
             manage.action_check_updates(mock.MagicMock(), dry_run=True, template_version="v2.2.0")
         assert seen.get("template_version") == "v2.2.0"
+
+
+class TestRefResolution:
+    """A template version is a commit, and every ref kind resolves to one (#781).
+
+    `bootstrap.py` pins a commit SHA; the drift checker used to fetch a release
+    tag and fall through to the moving `main` branch when no release existed --
+    which is always, since this template has cut none. Two halves of one sync
+    disagreeing about what a version is.
+
+    These cover the resolution and the URL it produces. The gap they close is
+    real: the first version of this change left a stale `version` reference in
+    `run_check_updates` and every existing test passed, because they mock that
+    function. It was caught by running the tool.
+    """
+
+    def test_a_sha_is_used_as_is(self) -> None:
+        """No API call for something already a commit."""
+        sha = "0a64c7e7c916a9bb0b4041f20acce8653e01acfa"
+        with mock.patch.object(ctu.urllib.request, "urlopen") as opener:
+            assert ctu.resolve_template_ref(sha) == sha
+        opener.assert_not_called()
+
+    @pytest.mark.parametrize("ref", ["main", "v0.0.0", "some-branch"])
+    def test_a_tag_or_branch_resolves_to_a_sha(self, ref: str) -> None:
+        sha = "1" * 40
+        response = mock.MagicMock()
+        response.read.return_value = f"{sha}\n".encode()
+        response.__enter__.return_value = response
+        with mock.patch.object(ctu.urllib.request, "urlopen", return_value=response):
+            assert ctu.resolve_template_ref(ref) == sha
+
+    def test_an_unresolvable_ref_warns_and_passes_through(self) -> None:
+        """Offline or rate-limited must not stop a drift check outright."""
+        with mock.patch.object(ctu.urllib.request, "urlopen", side_effect=OSError("offline")):
+            assert ctu.resolve_template_ref("main") == "main"
+
+    def test_a_non_sha_response_is_not_trusted(self) -> None:
+        """A proxy returning HTML must not become the archive path."""
+        response = mock.MagicMock()
+        response.read.return_value = b"<html>rate limited</html>"
+        response.__enter__.return_value = response
+        with mock.patch.object(ctu.urllib.request, "urlopen", return_value=response):
+            assert ctu.resolve_template_ref("main") == "main"
+
+    def test_the_archive_url_names_the_resolved_commit(self, tmp_path: Path) -> None:
+        """One URL shape for tag, branch and SHA -- the resolved commit."""
+        sha = "2" * 40
+        seen: dict[str, str] = {}
+
+        def _capture(url: str, target: Path) -> Path:
+            seen["url"] = url
+            return target
+
+        with (
+            mock.patch.object(ctu, "resolve_template_ref", return_value=sha),
+            mock.patch.object(ctu, "download_and_extract_archive", _capture),
+        ):
+            ctu.download_template(tmp_path, "v0.0.0")
+
+        assert seen["url"].endswith(f"/archive/{sha}.zip"), seen["url"]
+        assert "refs/tags" not in seen["url"], "the release-tag URL shape is gone"
+        assert "refs/heads" not in seen["url"], "the moving-branch URL shape is gone"
+
+    def test_the_default_ref_is_main(self, tmp_path: Path) -> None:
+        """Stated, rather than reached by failing a releases/latest lookup."""
+        assert ctu.DEFAULT_TEMPLATE_REF == "main"
+        seen: dict[str, str] = {}
+        with (
+            mock.patch.object(ctu, "resolve_template_ref", lambda ref: seen.setdefault("ref", ref)),
+            mock.patch.object(ctu, "download_and_extract_archive", lambda url, target: target),
+        ):
+            ctu.download_template(tmp_path, None)
+        assert seen["ref"] == "main"

--- a/tools/pyproject_template/__init__.py
+++ b/tools/pyproject_template/__init__.py
@@ -7,7 +7,7 @@ Provides utilities for managing Python projects based on pyproject-template.
 from .check_template_updates import (
     compare_files,
     download_template,
-    get_latest_release,
+    resolve_template_ref,
     run_check_updates,
 )
 from .configure import (
@@ -52,7 +52,7 @@ __all__ = [
     # Check updates
     "compare_files",
     "download_template",
-    "get_latest_release",
+    "resolve_template_ref",
     "run_check_updates",
     # Migrate
     "run_migrate",

--- a/tools/pyproject_template/check_template_updates.py
+++ b/tools/pyproject_template/check_template_updates.py
@@ -7,7 +7,7 @@ differ from the template. User can then manually review and merge changes.
 
 Usage:
     python tools/pyproject_template/check_template_updates.py
-    python tools/pyproject_template/check_template_updates.py --template-version v2.2.0
+    python tools/pyproject_template/manage.py check --template-version v2.2.0
     python tools/pyproject_template/check_template_updates.py --skip-changelog
 
 Requirements:
@@ -24,7 +24,6 @@ from __future__ import annotations
 import argparse
 import filecmp
 import fnmatch
-import json
 import os
 import re
 import shutil
@@ -57,7 +56,8 @@ from utils import (  # noqa: E402
 _TEMPLATE_OWNED_TEST_SET: frozenset[str] = frozenset(TEMPLATE_OWNED_TEST_FILES)
 
 # Default archive URL derived from template constants
-DEFAULT_ARCHIVE_URL = f"{TEMPLATE_URL}/archive/refs/heads/main.zip"
+# The template is a rolling `main`; a tag or SHA can be named explicitly.
+DEFAULT_TEMPLATE_REF = "main"
 
 # Project-managed exclude file: paths or globs of upstream files the downstream
 # project intentionally does not adopt. See docs/template/manage.md.
@@ -98,26 +98,51 @@ def load_sync_excludes(project_root: Path) -> list[str]:
     return [str(item) for item in excludes if isinstance(item, str)]
 
 
-def get_latest_release() -> str | None:
-    """Get the latest release tag from GitHub API."""
-    api_url = f"https://api.github.com/repos/{TEMPLATE_REPO}/releases/latest"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def resolve_template_ref(ref: str) -> str:
+    """Resolve *ref* -- a tag, branch or commit SHA -- to a commit SHA.
+
+    One identity for a template version, matching what `bootstrap.py` pins
+    (ADR-9020). A tag, a branch and a SHA all resolve here, so a comparison can
+    be reproduced later and both halves of a sync can name the same commit.
+
+    On failure -- offline, rate-limited, an unknown ref -- returns *ref*
+    unchanged and warns. Refusing to run a drift check because api.github.com is
+    unreachable would trade a small gain for a hard outage, which is the same
+    call `bootstrap.resolve_ref` makes.
+    """
+    if SHA_RE.match(ref):
+        return ref
+
+    api_url = f"https://api.github.com/repos/{TEMPLATE_REPO}/commits/{ref}"
+    request = urllib.request.Request(api_url, headers={"Accept": "application/vnd.github.sha"})
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"token {token}")
     try:
-        with urllib.request.urlopen(api_url) as response:  # nosec B310
-            data = json.loads(response.read())
-            tag_name: str | None = data.get("tag_name")
-            return tag_name
+        with urllib.request.urlopen(request, timeout=15) as response:  # nosec B310
+            sha: str = response.read().decode("utf-8").strip()
     except Exception as e:
-        Logger.warning(f"Could not fetch latest release: {e}")
-        return None
+        Logger.warning(f"Could not resolve '{ref}' to a commit ({e}).")
+        Logger.info(f"Continuing against the moving ref '{ref}'.")
+        return ref
+
+    if not SHA_RE.match(sha):
+        Logger.warning(f"Unexpected response resolving '{ref}'; using it as-is.")
+        return ref
+    return sha
 
 
-def download_template(target_dir: Path, version: str | None = None) -> Path:
-    """Download and extract template to target directory."""
-    # Determine download URL
-    if version:
-        archive_url = f"{TEMPLATE_URL}/archive/refs/tags/{version}.zip"
-    else:
-        archive_url = DEFAULT_ARCHIVE_URL
+def download_template(target_dir: Path, ref: str | None = None) -> Path:
+    """Download and extract the template at *ref* (a tag, branch or SHA).
+
+    `ref` is resolved to a commit first, so one URL shape serves all three and
+    the archive is a fixed commit rather than a moving branch.
+    """
+    commit = resolve_template_ref(ref or DEFAULT_TEMPLATE_REF)
+    archive_url = f"{TEMPLATE_URL}/archive/{commit}.zip"
 
     template_root = Path(download_and_extract_archive(archive_url, target_dir))
     Logger.success(f"Template extracted to {template_root}")
@@ -309,8 +334,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=str,
         default=None,
         help=(
-            "Compare against specific template version tag (e.g., v2.2.0). "
-            "Defaults to latest release."
+            "Compare against a specific template ref -- a tag, a branch, or a commit "
+            "SHA. Defaults to 'main'."
         ),
     )
     parser.add_argument(
@@ -346,7 +371,7 @@ def run_check_updates(
     """Check for template updates.
 
     Args:
-        template_version: Specific template version to compare against.
+        template_version: Template ref to compare against -- a tag, branch or SHA.
         skip_changelog: Skip opening CHANGELOG.md in editor.
         keep_template: Keep downloaded template after comparison.
         dry_run: Show what would be done without making changes.
@@ -359,24 +384,18 @@ def run_check_updates(
     tmp_dir = project_root / "tmp"
     tmp_dir.mkdir(exist_ok=True)
 
-    # Get template version
-    version: str | None = None
-    if template_version:
-        version = template_version
-        Logger.info(f"Comparing against template version: {version}")
-    else:
-        version = get_latest_release()
-        if version:
-            Logger.info(f"Latest template release: {version}")
-        else:
-            Logger.info("Comparing against template main branch")
+    # Which template snapshot to compare against. `main` by default -- this
+    # template publishes no releases, and the previous code only reached `main`
+    # by failing a releases/latest lookup first (#781).
+    ref = template_version or DEFAULT_TEMPLATE_REF
+    Logger.info(f"Comparing against template ref: {ref}")
 
     if dry_run:
         Logger.info("Dry run mode - would download and compare template files")
         return 0
 
     # Download template
-    template_dir = download_template(tmp_dir, version)
+    template_dir = download_template(tmp_dir, ref)
 
     # Open CHANGELOG.md for review
     if not skip_changelog:


### PR DESCRIPTION
## Description

This template has cut **no releases** — `gh release list` is empty, and the only tag is `v0.0.0`
from the initial commit — while half the update path assumed otherwise. `get_latest_release()`
called `releases/latest`, got a 404, returned `None`, and every drift check fell through to the
moving `main` branch. It reached the right place by *failing a lookup first*.

The two halves also disagreed about what a version is:

| phase | pinned by |
| :--- | :--- |
| Phase 1 — `bootstrap.py --sync` | a **commit SHA**, resolved once (#694/#740) |
| Phase 2 — drift check | a **release tag**, falling back to moving `main` |

`ai-sync-checklist.md` runs them in that order, so **the tooling a project synced and the template
it then diffed against could be different commits.**

## Related Issue

Addresses #781

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (`get_latest_release` removed from the package surface)
- [x] Documentation update
- [x] Code refactoring
- [x] Test improvement

## Changes Made

### ADR-9020 — a template version is a commit SHA

`--template-version` accepts a **tag, a branch, or a SHA**; all three resolve through
`commits/{ref}` to one commit, and one URL shape serves everything: `/archive/{sha}.zip`. `main` is
the *stated* default rather than a fallback. Resolution failure warns and continues against the
unresolved ref — the same call `bootstrap.resolve_ref` makes, for the same reason: refusing to run a
drift check because `api.github.com` is unreachable trades a small consistency gain for a hard
outage.

### The deciding evidence, found during implementation

**`TemplateState.commit` already exists** and persists a template commit SHA. The repo had already
chosen commits as the thing it remembers about the template; only the drift checker's *fetch*
disagreed. This finishes an identity that was half-adopted rather than introducing one — which is
why the ADR lands on SHA rather than on cutting releases.

Releases are not foreclosed. A tag is a ref, so `--template-version v2.2.0` keeps working if this
project starts tagging; the difference is that nothing *depends* on their existence.

### Removed

`get_latest_release()` and its export from `__init__.py`. With releases out of the model it is a
dead path that invites reintroducing the assumption. **This is the breaking part:** a downstream
importing it directly breaks. Judged acceptable — it returns `None` for this template in every case.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**Verified end to end, for every ref kind:**

```console
$ manage.py check --template-version v0.0.0
i Comparing against template ref: v0.0.0
i Downloading from …/archive/0a64c7e7c916a9bb0b4041f20acce8653e01acfa.zip...
```

Also checked: `main` (default), an explicit branch, a full SHA, and an unresolvable ref — which
warns and fails loudly on download rather than crashing.

### A bug I shipped, and the gap it exposed

The first patch left a stale `version` reference in `run_check_updates`. **Every existing test
passed**, because they mock that function — it was caught by running the tool.

`TestRefResolution` closes that gap: it covers resolution and the URL that comes out of it, rather
than mocking the function under test. Mutation-verified against both realistic regressions —
restoring the `refs/tags` URL shape, and dropping resolution entirely — each of which turns it red.

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [x] ADR created (ADR-9020), indexed, and linked from the consumer docs
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**What this deliberately does not fix**, all recorded in the ADR's Consequences rather than left for
a reader to discover:

- **Staged upgrades remain unavailable** until tags exist. A project long behind still gets one
  large diff. Accepted: nothing offered staged upgrades before either, because there were no tags to
  stage between.
- **Phase 1 and Phase 2 still resolve independently**, so the divergence window is *narrowed, not
  closed*. Closing it means Phase 1 handing Phase 2 its SHA — worth doing, and left out to keep this
  change to the decision it records.
- Two runs against the same ref minutes apart can still resolve to different commits if `main`
  moves. Each run is internally consistent, which is what `bootstrap.py` guarantees and no more.

**Flag name kept.** `--template-version` was exposed hours earlier in #780; renaming to
`--template-ref` twice in a day is churn for a cosmetic gain, and "version" is what a consumer calls
the thing regardless of its form. The ADR records that reasoning so it is not re-litigated.

**Still open:** #778 (14 documented invocations that refuse to run) — now unblocked, since this
decides what those docs should say about versions.
