### PR TITLE
docs: add the verified-claims rule, and cover every rule not just the first

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -169,5 +169,5 @@ only the frontmatter and the loading mechanism differ.
 
 **When you change one, change all three.** A rule that disagrees with itself across agents is worse
 than no rule, because whichever agent is driving decides which version applies.
-`tests/template/test_rule_files.py` enforces that the three bodies stay identical. See
+`tests/template/test_rule_files.py` enforces that each rule's three bodies stay identical. See
 [`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/.agents/skills/verified-claims/SKILL.md
+++ b/.agents/skills/verified-claims/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: verified-claims
+description: Use when writing a factual claim about this repository or a third-party tool into a GitHub issue, a commit message, a pull request body, or documentation — especially a claim about an exit code, a count, or how an installed tool behaves.
+---
+
+Skill: verified-claims
+
+Self-check before writing a factual claim into an issue, commit, PR or doc:
+
+1. Can I paste the exact command and its output? If not, this is inference —
+   say so, or go measure it. Every claim that survived review in the session
+   that produced this rule had pasted output; every one that did not, failed.
+2. Did an exit code come through a pipe? `$?` is the last command's, not the
+   script's. Use `out=$(cmd); code=$?`. This error recurred twice in one
+   session, the second time reaching a filed issue and a merged PR (#778).
+3. Is the claim about a third-party tool? Ask the installed tool, not its type
+   definitions, its docs, or a minified bundle (#753, #757, #762).
+4. Am I repeating a claim from an issue or an existing doc? Re-measure before
+   restating it as fact — an audit's own figures went stale within five days
+   (#749).
+5. Is it a count, a size or a percentage? It belongs in a file something
+   checks, not in prose (#754).
+6. If a claim published earlier turns out wrong, correct it where it was
+   published, not only in conversation (#757, #778).
+
+Observed failures: endavis/pyproject-template#778, endavis/pyproject-template#757, endavis/pyproject-template#762

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -59,8 +59,10 @@ Target: **30 lines or fewer** per rule file. If a file grows past 30 lines, spli
 
 **This loader is enabled in the template.** It was previously commented out, on the reasoning that
 a template ships no rule files and downstream consumers would opt in after authoring their first.
-That reasoning expired when the template authored its own: `typing-branch-narrowing.md` documents
-a trap that produced defects in two consecutive PRs **in this repository's code**. A rule file that
+That reasoning expired when the template authored its own. `typing-branch-narrowing.md` documents
+a trap that produced defects in two consecutive PRs **in this repository's code**;
+`verified-claims.md` documents four claims written into issues and merged commits without being
+measured (#785). A rule file that
 ships but never loads is a mechanism built and not used, so the loader is on and downstream
 projects inherit it.
 
@@ -70,8 +72,8 @@ tolerates a glob matching nothing, but leaving it invites a future file to load 
 ## Mirroring across agent surfaces
 
 Every agent in the delegation matrix edits this codebase, so a rule that only Claude loads is a
-half-installed control. `typing-branch-narrowing` is mirrored to all three surfaces, each with its
-own format and loading mechanism:
+half-installed control. Every rule here is mirrored to all three surfaces — currently
+`typing-branch-narrowing` and `verified-claims` — each with its own format and loading mechanism:
 
 | Surface | Path | Loading |
 | :--- | :--- | :--- |
@@ -82,7 +84,7 @@ own format and loading mechanism:
 The checklist body is identical in all three; only the frontmatter and loading differ. **When you
 change one, change all three** — a rule that disagrees with itself across agents is worse than no
 rule, because whichever agent is driving determines which version applies.
-`tests/template/test_rule_files.py` enforces that the three bodies stay byte-identical.
+`tests/template/test_rule_files.py` enforces that each rule's three bodies stay byte-identical.
 
 Note that Copilot reads `.agents/skills/` in addition to `.github/instructions/`, so it sees the
 rule on two surfaces at once. That is harmless while the bodies match — which is exactly what the

--- a/.claude/rules/verified-claims.md
+++ b/.claude/rules/verified-claims.md
@@ -1,0 +1,21 @@
+Skill: verified-claims
+
+Self-check before writing a factual claim into an issue, commit, PR or doc:
+
+1. Can I paste the exact command and its output? If not, this is inference —
+   say so, or go measure it. Every claim that survived review in the session
+   that produced this rule had pasted output; every one that did not, failed.
+2. Did an exit code come through a pipe? `$?` is the last command's, not the
+   script's. Use `out=$(cmd); code=$?`. This error recurred twice in one
+   session, the second time reaching a filed issue and a merged PR (#778).
+3. Is the claim about a third-party tool? Ask the installed tool, not its type
+   definitions, its docs, or a minified bundle (#753, #757, #762).
+4. Am I repeating a claim from an issue or an existing doc? Re-measure before
+   restating it as fact — an audit's own figures went stale within five days
+   (#749).
+5. Is it a count, a size or a percentage? It belongs in a file something
+   checks, not in prose (#754).
+6. If a claim published earlier turns out wrong, correct it where it was
+   published, not only in conversation (#757, #778).
+
+Observed failures: endavis/pyproject-template#778, endavis/pyproject-template#757, endavis/pyproject-template#762

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -146,5 +146,5 @@ only the frontmatter and the loading mechanism differ.
 
 **When you change one, change all three.** A rule that disagrees with itself across agents is worse
 than no rule, because whichever agent is driving decides which version applies.
-`tests/template/test_rule_files.py` enforces that the three bodies stay identical. See
+`tests/template/test_rule_files.py` enforces that each rule's three bodies stay identical. See
 [`.claude/rules/README.md`](../../.claude/rules/README.md) for the authoring discipline.

--- a/.github/instructions/verified-claims.instructions.md
+++ b/.github/instructions/verified-claims.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: '**'
+---
+
+Skill: verified-claims
+
+Self-check before writing a factual claim into an issue, commit, PR or doc:
+
+1. Can I paste the exact command and its output? If not, this is inference —
+   say so, or go measure it. Every claim that survived review in the session
+   that produced this rule had pasted output; every one that did not, failed.
+2. Did an exit code come through a pipe? `$?` is the last command's, not the
+   script's. Use `out=$(cmd); code=$?`. This error recurred twice in one
+   session, the second time reaching a filed issue and a merged PR (#778).
+3. Is the claim about a third-party tool? Ask the installed tool, not its type
+   definitions, its docs, or a minified bundle (#753, #757, #762).
+4. Am I repeating a claim from an issue or an existing doc? Re-measure before
+   restating it as fact — an audit's own figures went stale within five days
+   (#749).
+5. Is it a count, a size or a percentage? It belongs in a file something
+   checks, not in prose (#754).
+6. If a claim published earlier turns out wrong, correct it where it was
+   published, not only in conversation (#757, #778).
+
+Observed failures: endavis/pyproject-template#778, endavis/pyproject-template#757, endavis/pyproject-template#762

--- a/tests/template/test_rule_files.py
+++ b/tests/template/test_rule_files.py
@@ -21,14 +21,28 @@ from agent_roster import agent_is_present
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-RULE_NAME = "typing-branch-narrowing"
+# Rules are discovered, not listed. Pinning one name meant the second rule
+# authored (`verified-claims`, #785) inherited none of the guarantees below --
+# it was mirrored to three surfaces with nothing holding the bodies together,
+# which is the state this module exists to prevent.
+RULE_DIR = REPO_ROOT / ".claude" / "rules"
 
-# Every surface the template mirrors the rule to, and how each one is loaded.
-ALL_RULE_PATHS = {
-    "claude": REPO_ROOT / ".claude" / "rules" / f"{RULE_NAME}.md",
-    "copilot": REPO_ROOT / ".github" / "instructions" / f"{RULE_NAME}.instructions.md",
-    "agents": REPO_ROOT / ".agents" / "skills" / RULE_NAME / "SKILL.md",
-}
+
+def _rule_names() -> list[str]:
+    """Every rule authored on the Claude surface, which is the canonical list."""
+    return sorted(path.stem for path in RULE_DIR.glob("*.md") if path.name not in {"README.md"})
+
+
+def _all_rule_paths(rule: str) -> dict[str, Path]:
+    """Every surface a rule is mirrored to, and how each one is loaded."""
+    return {
+        "claude": REPO_ROOT / ".claude" / "rules" / f"{rule}.md",
+        "copilot": REPO_ROOT / ".github" / "instructions" / f"{rule}.instructions.md",
+        "agents": REPO_ROOT / ".agents" / "skills" / rule / "SKILL.md",
+    }
+
+
+RULE_NAMES = _rule_names()
 
 # Which agents each surface serves. `.agents/` is read by both Codex and
 # Antigravity, so that surface is live if either agent is.
@@ -38,13 +52,24 @@ SURFACE_AGENTS = {
     "agents": ("codex", "antigravity"),
 }
 
+
 # The surfaces this project actually loads. A project that drops an agent drops
 # its rule surface with it, and must not be told the mirror is broken (#690).
-RULE_PATHS = {
-    surface: path
-    for surface, path in ALL_RULE_PATHS.items()
-    if any(agent_is_present(agent) for agent in SURFACE_AGENTS[surface])
-}
+def _rule_paths(rule: str) -> dict[str, Path]:
+    """The surfaces this project actually loads, for one rule.
+
+    A project that drops an agent drops its rule surface with it, and must not
+    be told the mirror is broken (#690).
+    """
+    return {
+        surface: path
+        for surface, path in _all_rule_paths(rule).items()
+        if any(agent_is_present(agent) for agent in SURFACE_AGENTS[surface])
+    }
+
+
+# Every (rule, surface) pair this project loads, for parametrisation.
+RULE_SURFACES = [(rule, surface) for rule in RULE_NAMES for surface in sorted(_rule_paths(rule))]
 
 MAX_LINES = 30
 
@@ -63,65 +88,72 @@ def _body(path: Path) -> str:
     return text.strip()
 
 
-@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
-def test_rule_exists_on_every_surface(surface: str) -> None:
-    """The rule is present for every agent family this project wires."""
-    assert RULE_PATHS[surface].exists(), f"missing {surface} copy: {RULE_PATHS[surface]}"
+@pytest.mark.parametrize(("rule", "surface"), RULE_SURFACES)
+def test_rule_exists_on_every_surface(rule: str, surface: str) -> None:
+    """Each rule is present for every agent family this project wires."""
+    path = _rule_paths(rule)[surface]
+    assert path.exists(), f"{rule}: missing {surface} copy: {path}"
 
 
-def test_rule_bodies_are_identical_across_surfaces() -> None:
+@pytest.mark.parametrize("rule", RULE_NAMES)
+def test_rule_bodies_are_identical_across_surfaces(rule: str) -> None:
     """The checklist must not drift between agents."""
-    if len(RULE_PATHS) < 2:
+    paths = _rule_paths(rule)
+    if len(paths) < 2:
         pytest.skip("only one rule surface is live; there is nothing to drift against")
 
-    bodies = {name: _body(path) for name, path in RULE_PATHS.items()}
+    bodies = {name: _body(path) for name, path in paths.items()}
     reference_surface = next(iter(sorted(bodies)))
     reference = bodies[reference_surface]
     mismatched = [name for name, body in bodies.items() if body != reference]
     assert not mismatched, (
-        f"rule body differs on {mismatched} (compared against {reference_surface}); "
+        f"{rule}: body differs on {mismatched} (compared against {reference_surface}); "
         "update every live surface together"
     )
 
 
-@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
-def test_rule_declares_observed_failures(surface: str) -> None:
+@pytest.mark.parametrize(("rule", "surface"), RULE_SURFACES)
+def test_rule_declares_observed_failures(rule: str, surface: str) -> None:
     """A rule with no observed-failure link is a guess, not a discipline."""
-    body = _body(RULE_PATHS[surface])
+    body = _body(_rule_paths(rule)[surface])
     match = re.search(r"^Observed failures:\s*(.+)$", body, re.MULTILINE)
-    assert match, f"{surface} copy is missing the 'Observed failures:' footer"
+    assert match, f"{rule}: {surface} copy is missing the 'Observed failures:' footer"
     assert re.search(r"#\d+", match.group(1)), (
-        f"{surface} footer must cite at least one real issue or PR"
+        f"{rule}: {surface} footer must cite at least one real issue or PR"
     )
 
 
-@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
-def test_rule_names_a_skill_gate(surface: str) -> None:
+@pytest.mark.parametrize(("rule", "surface"), RULE_SURFACES)
+def test_rule_names_a_skill_gate(rule: str, surface: str) -> None:
     """``Skill:`` is the first body line — it names the capability gate."""
-    assert _body(RULE_PATHS[surface]).splitlines()[0].startswith("Skill: ")
+    assert _body(_rule_paths(rule)[surface]).splitlines()[0].startswith("Skill: ")
 
 
-@pytest.mark.parametrize("surface", sorted(RULE_PATHS))
-def test_rule_stays_within_the_line_budget(surface: str) -> None:
+@pytest.mark.parametrize(("rule", "surface"), RULE_SURFACES)
+def test_rule_stays_within_the_line_budget(rule: str, surface: str) -> None:
     """Past 30 lines a rule stops surviving a long context window; split it."""
-    count = len(RULE_PATHS[surface].read_text(encoding="utf-8").splitlines())
-    assert count <= MAX_LINES, f"{surface} copy is {count} lines (max {MAX_LINES})"
+    count = len(_rule_paths(rule)[surface].read_text(encoding="utf-8").splitlines())
+    assert count <= MAX_LINES, f"{rule}: {surface} copy is {count} lines (max {MAX_LINES})"
 
 
-def test_copilot_copy_declares_a_path_scope() -> None:
+@pytest.mark.parametrize("rule", RULE_NAMES)
+def test_copilot_copy_declares_a_path_scope(rule: str) -> None:
     """Copilot's loader requires ``applyTo:`` frontmatter to gate the file."""
-    if "copilot" not in RULE_PATHS:
+    paths = _rule_paths(rule)
+    if "copilot" not in paths:
         pytest.skip("copilot is not wired in this project")
-    text = RULE_PATHS["copilot"].read_text(encoding="utf-8")
+    text = paths["copilot"].read_text(encoding="utf-8")
     assert text.startswith("---"), "Copilot instructions need YAML frontmatter"
     assert re.search(r"^applyTo:\s*\S+", text, re.MULTILINE)
 
 
-def test_agents_copy_declares_a_skill_gate_description() -> None:
+@pytest.mark.parametrize("rule", RULE_NAMES)
+def test_agents_copy_declares_a_skill_gate_description(rule: str) -> None:
     """``description:`` is the skill-gate trigger for Codex and Antigravity."""
-    if "agents" not in RULE_PATHS:
+    paths = _rule_paths(rule)
+    if "agents" not in paths:
         pytest.skip("neither codex nor antigravity is wired in this project")
-    text = RULE_PATHS["agents"].read_text(encoding="utf-8")
+    text = paths["agents"].read_text(encoding="utf-8")
     assert re.search(r"^name:\s*\S+", text, re.MULTILINE)
     assert re.search(r"^description:\s*\S+", text, re.MULTILINE)
 
@@ -131,7 +163,7 @@ def test_claude_loads_rule_files() -> None:
 
     A rule file that ships but never loads is a mechanism built and not used.
     """
-    if "claude" not in RULE_PATHS:
+    if not any("claude" in _rule_paths(rule) for rule in RULE_NAMES):
         pytest.skip("claude is not wired in this project")
     text = (REPO_ROOT / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
     assert re.search(r"^@\./rules/\*\.md\s*$", text, re.MULTILINE), (


### PR DESCRIPTION
## Description

Four factual claims about this repository were written into issues, commit messages and PR bodies in
one session **without being measured**. Each was inference stated as observation.

| claim | how it was "verified" | reality |
| :--- | :--- | :--- |
| two guarded scripts exit 0 (#778) | read `$?` after a pipe — it was `head`'s status | all three `sys.exit(1)` |
| `disabledSkills` doesn't cover commands (#753) | inferred from the field name | it does |
| `python3 - <<EOF` executes shell (#762) | assumed "interpreter reads stdin" | the body is Python |
| Copilot reads no `commands/` directory (#753) | counted repo docs, 3 votes to 1 | it reads `.claude/commands/` |

**The first is the sharpest.** That pipe mistake had already happened earlier in the same session,
been noticed, and been corrected — then recurred about forty tool calls later and reached a filed
issue and a merged PR before anyone caught it. Being told once did not hold, which is precisely the
argument `enforcement-principles.md` makes for not relying on instructions.

## Related Issue

Addresses #785

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Changes Made

### The rule, mirrored to all three surfaces

Written against the **general shape** rather than the pipe: *inference presented as measurement*.
Its first check is the diagnostic that separates good claims from bad ones without judgement —

> Can I paste the exact command and its output? If not, this is inference — say so, or go measure it.

Every claim that survived review in that session had a pasted command and its output (the
`copilot skill list` breakdown, the heredoc matrix, `--template-version` resolving to a SHA, every
mutation test). Every claim that did not, failed. Five further checks cover exit codes through
pipes, third-party tools, restating others' claims, counts in prose, and correcting a published
claim where it was published.

### `test_rule_files.py` only ever covered the first rule

```python
RULE_NAME = "typing-branch-narrowing"
```

So `verified-claims` would have shipped to three surfaces **with nothing holding the bodies
together** — exactly the state that module exists to prevent, and the same "guard that doesn't guard
what you think" pattern as #774.

Rules are now **discovered** from `.claude/rules/`, and every check is parametrised over
`(rule, surface)`. **16 tests become 31.**

The three surface READMEs said "the three bodies", which read as though one rule existed. Now
per-rule, and `.claude/rules/README.md` names both.

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [x] Manually tested the changes

`doit check` and `mkdocs build --strict` pass.

**Mutation-verified against the new rule specifically**, not just the old one:

| mutation | result |
| :--- | :--- |
| drift one copy of `verified-claims` | `test_rule_bodies_are_identical_across_surfaces[verified-claims]` fails |
| drop its `Observed failures:` footer | `test_rule_declares_observed_failures[verified-claims-copilot]` fails |

## Checklist

- [x] My code follows the code style of this project (ran `doit format`)
- [x] I have run linting checks (`doit lint`)
- [x] I have run type checking (`doit type_check`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`doit test`)
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md — N/A, generated on release (`update_changelog_on_bump`)
- [x] My changes generate no new warnings

## Additional Notes

**A hook is deliberately not proposed.** Under ADR-9019 this is a category-3 tripwire: piping to
`head` is legitimate constantly and was used correctly dozens of times in the same session, so a
matcher would be noise rather than signal. Rule 3 of that ADR says fix this class by convention, not
by making a scanner smarter — this is the case where a rule file is the right instrument.

**Two things worth noting about how this PR was built**, since they are the rule working before it
merged:

1. The dangerous-command hook **blocked my first attempt to write the rule body**, because the
   heredoc contained the words "merge commit". I used the Write tool instead — the convention
   established in #759 — rather than reaching for a bypass.
2. `doit issue` **rejected my first draft** of #785 for missing the `Documentation Type` section. I
   had not read the template first, which AGENTS.md's Pre-Action Checks requires. The validator
   caught what I skipped.

**This is the second rule file**, after `typing-branch-narrowing` (#704). That one was authored
because a trap produced defects in two consecutive PRs; this one has four observed instances in a
single session, and the discovery change means a third will be covered automatically.
